### PR TITLE
refactor: Remove references to lmdb::Database

### DIFF
--- a/dozer-cache/src/cache/lmdb/cache.rs
+++ b/dozer-cache/src/cache/lmdb/cache.rs
@@ -69,7 +69,7 @@ impl LmdbCache {
 
         txn.put::<Vec<u8>, Vec<u8>>(self.db, &key, &encoded, WriteFlags::default())?;
 
-        let indexer = Indexer::new(&self.indexer_db);
+        let indexer = Indexer::new(self.indexer_db);
 
         indexer.build_indexes(txn, rec, schema, key)?;
 
@@ -184,7 +184,7 @@ impl Cache for LmdbCache {
 
     fn get(&self, key: &[u8]) -> anyhow::Result<Record> {
         let txn: RoTransaction = self.env.begin_ro_txn()?;
-        let rec: Record = helper::get(&txn, &self.db, key)?;
+        let rec: Record = helper::get(&txn, self.db, key)?;
         Ok(rec)
     }
 
@@ -192,7 +192,7 @@ impl Cache for LmdbCache {
         let txn: RoTransaction = self.env.begin_ro_txn()?;
         let schema = self._get_schema_from_reverse_key(name, &txn)?;
 
-        let handler = LmdbQueryHandler::new(&self.db, &self.indexer_db, &txn);
+        let handler = LmdbQueryHandler::new(self.db, self.indexer_db, &txn);
         let records = handler.query(&schema, query)?;
         Ok(records)
     }

--- a/dozer-cache/src/cache/lmdb/indexer.rs
+++ b/dozer-cache/src/cache/lmdb/indexer.rs
@@ -4,17 +4,17 @@ use lmdb::{Database, RwTransaction, Transaction, WriteFlags};
 
 use crate::cache::index;
 
-pub struct Indexer<'a> {
-    db: &'a Database,
+pub struct Indexer {
+    db: Database,
 }
-impl<'a> Indexer<'a> {
-    pub fn new(db: &'a Database) -> Self {
+impl Indexer {
+    pub fn new(db: Database) -> Self {
         Self { db }
     }
 
     pub fn build_indexes(
         &self,
-        parent_txn: &'a mut RwTransaction,
+        parent_txn: &mut RwTransaction,
         rec: &Record,
         schema: &Schema,
         pkey: Vec<u8>,
@@ -28,7 +28,7 @@ impl<'a> Indexer<'a> {
         for index in schema.secondary_indexes.iter() {
             let secondary_key = self._build_index(index, rec, identifier)?;
 
-            txn.put::<Vec<u8>, Vec<u8>>(*self.db, &secondary_key, &pkey, WriteFlags::default())?;
+            txn.put::<Vec<u8>, Vec<u8>>(self.db, &secondary_key, &pkey, WriteFlags::default())?;
         }
         txn.commit()?;
         Ok(())

--- a/dozer-cache/src/cache/lmdb/query/handler.rs
+++ b/dozer-cache/src/cache/lmdb/query/handler.rs
@@ -11,12 +11,12 @@ use crate::cache::{
 use dozer_types::types::{Record, Schema, SchemaIdentifier};
 
 pub struct LmdbQueryHandler<'a> {
-    db: &'a Database,
-    indexer_db: &'a Database,
+    db: Database,
+    indexer_db: Database,
     txn: &'a RoTransaction<'a>,
 }
 impl<'a> LmdbQueryHandler<'a> {
-    pub fn new(db: &'a Database, indexer_db: &'a Database, txn: &'a RoTransaction) -> Self {
+    pub fn new(db: Database, indexer_db: Database, txn: &'a RoTransaction) -> Self {
         Self {
             db,
             indexer_db,
@@ -47,7 +47,7 @@ impl<'a> LmdbQueryHandler<'a> {
         limit: usize,
         skip: usize,
     ) -> anyhow::Result<Vec<Record>> {
-        let cursor = self.txn.open_ro_cursor(*self.db)?;
+        let cursor = self.txn.open_ro_cursor(self.db)?;
         let mut cache_iterator = CacheIterator::new(&cursor, None, true);
         // cache_iterator.skip(skip);
 
@@ -88,7 +88,7 @@ impl<'a> LmdbQueryHandler<'a> {
 
         let starting_key =
             index::get_secondary_index(schema_identifier.id, &index_scan.index_def.fields, &fields);
-        let cursor = self.txn.open_ro_cursor(*self.indexer_db)?;
+        let cursor = self.txn.open_ro_cursor(self.indexer_db)?;
 
         let mut cache_iterator = CacheIterator::new(&cursor, Some(&starting_key), true);
         let mut pkeys = vec![];

--- a/dozer-cache/src/cache/lmdb/query/helper.rs
+++ b/dozer-cache/src/cache/lmdb/query/helper.rs
@@ -1,10 +1,10 @@
 use dozer_types::serde;
 use lmdb::{Database, RoTransaction, Transaction};
-pub fn get<T>(txn: &RoTransaction, db: &Database, key: &[u8]) -> anyhow::Result<T>
+pub fn get<T>(txn: &RoTransaction, db: Database, key: &[u8]) -> anyhow::Result<T>
 where
     T: for<'a> serde::de::Deserialize<'a>,
 {
-    let rec = txn.get(*db, &key)?;
+    let rec = txn.get(db, &key)?;
     let rec: T = bincode::deserialize(rec)?;
     Ok(rec)
 }


### PR DESCRIPTION
This type is just a `newtype` around `libc::c_uint`, and it implements `Copy` so can be freely copied around and owned by anyone.

We don't need to create references to it in any circumustance.