### PR TITLE
chore: inject pipeline_details

### DIFF
--- a/dozer-api/src/api_helper.rs
+++ b/dozer-api/src/api_helper.rs
@@ -1,107 +1,131 @@
+use actix_web::web::ReqData;
 use actix_web::{http::header::ContentType, web, HttpResponse, Responder};
 use anyhow::Context;
 use dozer_cache::cache::{expression::QueryExpression, index, Cache, LmdbCache};
 use dozer_types::json_value_to_field;
+use dozer_types::record_to_json;
 use dozer_types::serde_json;
 use dozer_types::serde_json::Value;
 use dozer_types::types::{Field, FieldType};
-use dozer_types::{models::api_endpoint::ApiEndpoint, record_to_json};
 use std::{collections::HashMap, sync::Arc};
 
+use crate::api_server::PipelineDetails;
 use crate::{generator::oapi::generator::OpenApiGenerator, rest_error::RestError};
 
 /// Generated function to return openapi.yaml documentation.
 pub async fn generate_oapi(
-    app_data: web::Data<(Arc<LmdbCache>, Vec<ApiEndpoint>)>,
+    pipeline_details: Option<ReqData<PipelineDetails>>,
+    cache: web::Data<Arc<LmdbCache>>,
 ) -> Result<HttpResponse, RestError> {
-    let cache = app_data.0.to_owned();
-    let endpoints = app_data.1.to_owned();
-    let schema_by_name =
-        cache
-            .get_schema_by_name(&endpoints[0].name)
+    if let Some(details) = pipeline_details {
+        let schema_name = details.schema_name.clone();
+        let schema = cache
+            .get_schema_by_name(&schema_name)
             .map_err(|e| RestError::Validation {
                 message: Some(e.to_string()),
                 details: None,
             })?;
-    let schema_name = endpoints[0].clone().name;
-    let oapi_generator = OpenApiGenerator::new(
-        schema_by_name,
-        schema_name,
-        endpoints[0].clone(),
-        vec![format!("http://localhost:{}", "8080")],
-    );
 
-    match oapi_generator.generate_oas3() {
-        Ok(result) => Ok(HttpResponse::Ok().json(result)),
-        Err(e) => {
-            let error = RestError::Unknown {
-                message: Some(e.to_string()),
-                details: None,
-            };
-            Ok(HttpResponse::UnprocessableEntity().json(error))
+        let oapi_generator = OpenApiGenerator::new(
+            schema,
+            schema_name,
+            details.endpoint.clone(),
+            vec![format!("http://localhost:{}", "8080")],
+        );
+
+        match oapi_generator.generate_oas3() {
+            Ok(result) => Ok(HttpResponse::Ok().json(result)),
+            Err(e) => {
+                let error = RestError::Unknown {
+                    message: Some(e.to_string()),
+                    details: None,
+                };
+                Ok(HttpResponse::UnprocessableEntity().json(error))
+            }
         }
+    } else {
+        Ok(HttpResponse::InternalServerError().body("pipeline_details not initialized"))
     }
 }
 
 // Generated Get function to return a single record in JSON format
 pub async fn get(
+    pipeline_details: Option<ReqData<PipelineDetails>>,
     path: web::Path<String>,
-    app_data: web::Data<(Arc<LmdbCache>, Vec<ApiEndpoint>)>,
+    cache: web::Data<Arc<LmdbCache>>,
 ) -> impl Responder {
-    let cache = app_data.0.to_owned();
     let key = path.into_inner();
-    match get_record(cache, key) {
-        Ok(map) => {
-            let str = serde_json::to_string(&map).unwrap();
-            HttpResponse::Ok().body(str)
+
+    if let Some(details) = pipeline_details {
+        match get_record(&details.schema_name, cache, key) {
+            Ok(map) => {
+                let str = serde_json::to_string(&map).unwrap();
+                HttpResponse::Ok().body(str)
+            }
+            Err(e) => HttpResponse::NotFound().body(e.to_string()),
         }
-        Err(e) => HttpResponse::NotFound().body(e.to_string()),
+    } else {
+        HttpResponse::InternalServerError().body("pipeline_details not initialized")
     }
 }
 
 // Generated list function for multiple records with a default query expression
-pub async fn list(app_data: web::Data<(Arc<LmdbCache>, Vec<ApiEndpoint>)>) -> impl Responder {
-    let cache = app_data.0.to_owned();
-    let exp = QueryExpression::new(None, vec![], 50, 0);
-    let records = get_records(cache, exp);
+pub async fn list(
+    pipeline_details: Option<ReqData<PipelineDetails>>,
+    cache: web::Data<Arc<LmdbCache>>,
+) -> impl Responder {
+    if let Some(details) = pipeline_details {
+        let exp = QueryExpression::new(None, vec![], 50, 0);
+        let records = get_records(&details.schema_name, cache, exp);
 
-    match records {
-        Ok(maps) => HttpResponse::Ok().json(maps),
-        Err(e) => HttpResponse::UnprocessableEntity()
-            .content_type(ContentType::json())
-            .body(e.to_string()),
+        match records {
+            Ok(maps) => HttpResponse::Ok().json(maps),
+            Err(e) => HttpResponse::UnprocessableEntity()
+                .content_type(ContentType::json())
+                .body(e.to_string()),
+        }
+    } else {
+        HttpResponse::InternalServerError().body("pipeline_details not initialized")
     }
 }
 
 // Generated query function for multiple records
 pub async fn query(
+    pipeline_details: Option<ReqData<PipelineDetails>>,
     query_info: web::Json<Value>,
-    app_data: web::Data<(Arc<LmdbCache>, Vec<ApiEndpoint>)>,
+    cache: web::Data<Arc<LmdbCache>>,
 ) -> Result<HttpResponse, RestError> {
-    let cache = app_data.0.to_owned();
-    let query_expression =
-        serde_json::from_value::<QueryExpression>(query_info.0).map_err(|e| {
-            RestError::Validation {
-                message: Some(e.to_string()),
-                details: None,
-            }
-        })?;
-    let records = get_records(cache, query_expression);
+    if let Some(details) = pipeline_details {
+        let query_expression =
+            serde_json::from_value::<QueryExpression>(query_info.0).map_err(|e| {
+                RestError::Validation {
+                    message: Some(e.to_string()),
+                    details: None,
+                }
+            })?;
+        let records = get_records(&details.schema_name, cache, query_expression);
 
-    match records {
-        Ok(maps) => {
-            let str = serde_json::to_string(&maps).unwrap();
-            Ok(HttpResponse::Ok().body(str))
+        match records {
+            Ok(maps) => {
+                let str = serde_json::to_string(&maps).unwrap();
+                Ok(HttpResponse::Ok().body(str))
+            }
+            Err(_) => Ok(HttpResponse::Ok()
+                .content_type(ContentType::json())
+                .body("[]")),
         }
-        Err(_) => Ok(HttpResponse::Ok()
-            .content_type(ContentType::json())
-            .body("[]")),
+    } else {
+        Ok(HttpResponse::InternalServerError().body("pipeline_details not initialized"))
     }
 }
 
 /// Get a single record
-fn get_record(cache: Arc<LmdbCache>, key: String) -> anyhow::Result<HashMap<String, String>> {
-    let schema = cache.get_schema_by_name("films")?;
+fn get_record(
+    schema_name: &str,
+    cache: web::Data<Arc<LmdbCache>>,
+    key: String,
+) -> anyhow::Result<HashMap<String, String>> {
+    let schema = cache.get_schema_by_name(schema_name)?;
 
     let field_types: Vec<FieldType> = schema
         .primary_index
@@ -124,10 +148,11 @@ fn get_record(cache: Arc<LmdbCache>, key: String) -> anyhow::Result<HashMap<Stri
 
 /// Get multiple records
 fn get_records(
-    cache: Arc<LmdbCache>,
+    schema_name: &str,
+    cache: web::Data<Arc<LmdbCache>>,
     exp: QueryExpression,
 ) -> anyhow::Result<Vec<HashMap<String, String>>> {
-    let records = cache.query("films", &exp)?;
+    let records = cache.query(schema_name, &exp)?;
     let schema = cache.get_schema(
         &records[0]
             .schema_id

--- a/dozer-api/src/api_server.rs
+++ b/dozer-api/src/api_server.rs
@@ -1,13 +1,19 @@
 use actix_web::{
     body::MessageBody,
-    dev::{ServiceFactory, ServiceRequest, ServiceResponse},
-    rt, web, App, HttpServer,
+    dev::{Service, ServiceFactory, ServiceRequest, ServiceResponse},
+    rt, web, App, HttpMessage, HttpServer,
 };
 use dozer_cache::cache::LmdbCache;
 use dozer_types::models::api_endpoint::ApiEndpoint;
 use std::sync::Arc;
 
 use crate::api_helper;
+
+#[derive(Clone)]
+pub struct PipelineDetails {
+    pub schema_name: String,
+    pub endpoint: ApiEndpoint,
+}
 
 #[derive(Clone)]
 pub struct ApiServer {
@@ -42,15 +48,27 @@ impl ApiServer {
         >,
     > {
         let app = App::new();
-        let app = app.app_data(web::Data::new((cache, endpoints.clone())));
+        let app = app.app_data(web::Data::new(cache));
+
         let app = endpoints.iter().fold(app, |app, endpoint| {
-            let list_route = &endpoint.path.clone();
-            let get_route = format!("{}/{}", list_route, "{id}");
-            let query_route = format!("{}/query", list_route);
-            app.route(list_route, web::get().to(api_helper::list))
-                .route(&get_route, web::get().to(api_helper::get))
-                .route(&query_route, web::post().to(api_helper::query))
-                .route("oapi", web::post().to(api_helper::generate_oapi))
+            let endpoint = endpoint.clone();
+            let scope = endpoint.path.clone();
+            let schema_name = endpoint.name.clone();
+            app.service(
+                web::scope(&scope)
+                    // Inject pipeline_details for generated functions
+                    .wrap_fn(move |req, srv| {
+                        req.extensions_mut().insert(PipelineDetails {
+                            schema_name: schema_name.to_owned(),
+                            endpoint: endpoint.clone(),
+                        });
+                        srv.call(req)
+                    })
+                    .route("/query", web::post().to(api_helper::query))
+                    .route("oapi", web::post().to(api_helper::generate_oapi))
+                    .route("/{id}", web::get().to(api_helper::get))
+                    .route("", web::get().to(api_helper::list)),
+            )
         });
         app
     }


### PR DESCRIPTION
Inject `PipelineDetails` so we can attach multiple pipelines to one ApiServer. As described in the issue [here](https://github.com/getdozer/dozer/issues/93)
Also refactor to associate a route to a particular schema. 

```
pub struct PipelineDetails {
    pub schema_name: String,
    pub endpoint: ApiEndpoint,
}

```