### PR TITLE
fix: benches report missing the comparison

### DIFF
--- a/.github/workflows/schedule-test-job.yaml
+++ b/.github/workflows/schedule-test-job.yaml
@@ -37,10 +37,9 @@ jobs:
             ~/.cargo/registry/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-nightly
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-nightly
 
       - run: rustup toolchain update nightly && rustup default nightly
       - name: Run Bench
@@ -96,5 +95,3 @@ jobs:
            ```
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-


### PR DESCRIPTION
Because I used to use the same key/restore-keys with main github action pipeline, it leads to lose old benches report 
My solution: use another   key/restore-keys
Action:

- [x] Change key/restore-keys in step cache 

Result: The newest notification in slack channel release-notifications has a comparison
https://getdozer.s3.ap-southeast-1.amazonaws.com/bench-test-result/2022-11-07/criterion/report/index.html