### PR TITLE
chore: Bulid secondary index key only from values.

### DIFF
--- a/dozer-cache/src/cache/index/mod.rs
+++ b/dozer-cache/src/cache/index/mod.rs
@@ -44,14 +44,8 @@ pub fn get_secondary_index(field_val: &[Option<Vec<u8>>]) -> Vec<u8> {
     field_val.join("#".as_bytes())
 }
 
-pub fn get_full_text_secondary_index(schema_id: u32, field_idx: u64, token: &str) -> Vec<u8> {
-    [
-        "index".as_bytes(),
-        &schema_id.to_be_bytes(),
-        &field_idx.to_be_bytes(),
-        token.as_bytes(),
-    ]
-    .join("#".as_bytes())
+pub fn get_full_text_secondary_index(token: &str) -> Vec<u8> {
+    token.as_bytes().to_vec()
 }
 
 pub fn get_schema_reverse_key(name: &str) -> Vec<u8> {
@@ -64,9 +58,6 @@ mod tests {
 
     #[test]
     fn test_get_full_text_secondary_index() {
-        assert_eq!(
-            get_full_text_secondary_index(1, 1, "foo"),
-            b"index#\0\0\0\x01#\0\0\0\0\0\0\0\x01#foo",
-        );
+        assert_eq!(get_full_text_secondary_index("foo"), b"foo",);
     }
 }

--- a/dozer-cache/src/cache/lmdb/indexer.rs
+++ b/dozer-cache/src/cache/lmdb/indexer.rs
@@ -1,7 +1,7 @@
 use crate::errors::{CacheError, IndexError, QueryError};
 use dozer_types::{
     errors::types::TypeError,
-    types::{Field, IndexDefinition, Record, Schema, SchemaIdentifier},
+    types::{Field, IndexDefinition, Record, Schema},
 };
 use lmdb::{RwTransaction, Transaction, WriteFlags};
 use std::sync::Arc;
@@ -26,11 +26,6 @@ impl Indexer {
             .begin_nested_txn()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
 
-        let identifier = &schema
-            .identifier
-            .to_owned()
-            .map_or(Err(CacheError::SchemaIdentifierNotFound), Ok)?;
-
         if schema.secondary_indexes.is_empty() {
             return Err(CacheError::IndexError(IndexError::MissingSecondaryIndexes));
         }
@@ -46,9 +41,7 @@ impl Indexer {
                         .map_err(|e| CacheError::QueryError(QueryError::InsertValue(e)))?;
                 }
                 IndexDefinition::FullText(field_index) => {
-                    for secondary_key in
-                        self._build_indices_full_text(identifier, *field_index, &rec.values)?
-                    {
+                    for secondary_key in self._build_indices_full_text(*field_index, &rec.values)? {
                         txn.put(db, &secondary_key, &pkey, WriteFlags::default())
                             .map_err(|e| CacheError::QueryError(QueryError::InsertValue(e)))?;
                     }
@@ -75,11 +68,10 @@ impl Indexer {
         Ok(index::get_secondary_index(&values))
     }
 
-    fn _build_indices_full_text<'a>(
+    fn _build_indices_full_text(
         &self,
-        identifier: &SchemaIdentifier,
         field_index: usize,
-        values: &'a [Field],
+        values: &[Field],
     ) -> Result<Vec<Vec<u8>>, CacheError> {
         let string = if let Some(field) = values.get(field_index) {
             if let Field::String(string) = field {
@@ -95,18 +87,14 @@ impl Indexer {
 
         Ok(string
             .unicode_words()
-            .map(|token| get_full_text_secondary_index(identifier.id, field_index as _, token))
+            .map(get_full_text_secondary_index)
             .collect())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::cache::{
-        lmdb::test_utils as lmdb_utils,
-        test_utils::{self, schema_0},
-        Cache, LmdbCache,
-    };
+    use crate::cache::{lmdb::test_utils as lmdb_utils, test_utils, Cache, LmdbCache};
 
     use super::*;
 
@@ -141,24 +129,21 @@ mod tests {
         let indexer = Indexer {
             index_metadata: Arc::new(IndexMetaData::new()),
         };
-        let schema = schema_0();
 
-        let identifier = schema.identifier.as_ref().unwrap();
         let field_index = 0;
         assert_eq!(
             indexer
                 ._build_indices_full_text(
-                    identifier,
                     field_index,
                     &[Field::String("today is a good day".into())]
                 )
                 .unwrap(),
             vec![
-                get_full_text_secondary_index(identifier.id, field_index as _, "today"),
-                get_full_text_secondary_index(identifier.id, field_index as _, "is"),
-                get_full_text_secondary_index(identifier.id, field_index as _, "a"),
-                get_full_text_secondary_index(identifier.id, field_index as _, "good"),
-                get_full_text_secondary_index(identifier.id, field_index as _, "day"),
+                get_full_text_secondary_index("today"),
+                get_full_text_secondary_index("is"),
+                get_full_text_secondary_index("a"),
+                get_full_text_secondary_index("good"),
+                get_full_text_secondary_index("day"),
             ]
         );
     }

--- a/dozer-cache/src/cache/lmdb/query/handler.rs
+++ b/dozer-cache/src/cache/lmdb/query/handler.rs
@@ -251,12 +251,6 @@ impl<'a> LmdbQueryHandler<'a> {
     }
 
     fn build_comparision_key(&self, index_scan: &'a IndexScan) -> Result<Vec<u8>, CacheError> {
-        let schema_identifier = self
-            .schema
-            .identifier
-            .clone()
-            .map_or(Err(CacheError::SchemaIdentifierNotFound), Ok)?;
-
         let mut fields = vec![];
 
         for (idx, idf) in index_scan.filters.iter().enumerate() {
@@ -284,13 +278,9 @@ impl<'a> LmdbQueryHandler<'a> {
 
         match &index_scan.index_def {
             IndexDefinition::SortedInverted(_) => Ok(self.build_composite_range_key(fields)?),
-            IndexDefinition::FullText(field_index) => {
+            IndexDefinition::FullText(_) => {
                 if let Some(Field::String(token)) = &fields[0] {
-                    Ok(index::get_full_text_secondary_index(
-                        schema_identifier.id,
-                        *field_index as _,
-                        token,
-                    ))
+                    Ok(index::get_full_text_secondary_index(token))
                 } else {
                     Err(CacheError::IndexError(IndexError::ExpectedStringFullText))
                 }


### PR DESCRIPTION
Now that we've opened a new database for every index, we no longer need to include schema id and field indexes in the secondary index key.