### PR TITLE
perf: Don't use bincode comparator for single field sorted inverted index

### DIFF
--- a/dozer-cache/src/cache/lmdb/comparator.rs
+++ b/dozer-cache/src/cache/lmdb/comparator.rs
@@ -1,0 +1,124 @@
+use dozer_types::{
+    ordered_float::OrderedFloat,
+    types::{Field, FieldType, Schema, SortDirection},
+};
+use lmdb::{Database, Environment, Result, Transaction};
+use lmdb_sys::{mdb_set_compare, MDB_cmp_func, MDB_val, MDB_SUCCESS};
+
+use crate::cache::index::compare_composite_secondary_index;
+
+pub fn compared_without_composite_key(field: &Field) -> bool {
+    matches!(
+        field,
+        Field::UInt(_)
+            | Field::Int(_)
+            | Field::Float(_)
+            | Field::Boolean(_)
+            | Field::String(_)
+            | Field::Text(_)
+            | Field::Binary(_)
+    )
+}
+
+pub fn set_sorted_inverted_comparator(
+    env: &Environment,
+    db: Database,
+    schema: &Schema,
+    fields: &[(usize, SortDirection)],
+) -> Result<()> {
+    let comparator: MDB_cmp_func = if fields.len() == 1 {
+        let (index, direction) = fields[0];
+        if direction == SortDirection::Descending {
+            match schema.fields[index].typ {
+                FieldType::UInt => Some(compare_uint_descending),
+                FieldType::Int => Some(compare_int_descending),
+                FieldType::Float => Some(compare_float_descending),
+                FieldType::Boolean => Some(compare_bool_descending),
+                FieldType::String => Some(compare_string_descending),
+                FieldType::Text => Some(compare_string_descending),
+                FieldType::Binary => Some(compare_binary_descending),
+                _ => Some(compare_composite_key),
+            }
+        } else {
+            None
+        }
+    } else {
+        Some(compare_composite_key)
+    };
+
+    if let Some(comparator) = comparator {
+        let txn = env.begin_rw_txn()?;
+        unsafe {
+            assert_eq!(
+                mdb_set_compare(txn.txn(), db.dbi(), Some(comparator)),
+                MDB_SUCCESS
+            );
+        }
+        txn.commit()
+    } else {
+        Ok(())
+    }
+}
+
+macro_rules! comparator {
+    ($name:ident, $parser:ident) => {
+        unsafe extern "C" fn $name(a: *const MDB_val, b: *const MDB_val) -> std::ffi::c_int {
+            let a = $parser(mdb_val_to_slice(&*a));
+            let b = $parser(mdb_val_to_slice(&*b));
+            a.cmp(&b).reverse() as _
+        }
+    };
+}
+
+fn parse_uint(bytes: &[u8]) -> u64 {
+    u64::from_be_bytes(bytes.try_into().unwrap())
+}
+
+comparator!(compare_uint_descending, parse_uint);
+
+fn parse_int(bytes: &[u8]) -> i64 {
+    i64::from_be_bytes(bytes.try_into().unwrap())
+}
+
+comparator!(compare_int_descending, parse_int);
+
+fn parse_float(bytes: &[u8]) -> OrderedFloat<f64> {
+    OrderedFloat(f64::from_be_bytes(bytes.try_into().unwrap()))
+}
+
+comparator!(compare_float_descending, parse_float);
+
+fn parse_bool(bytes: &[u8]) -> bool {
+    bytes[0] > 0
+}
+
+comparator!(compare_bool_descending, parse_bool);
+
+fn parse_string(bytes: &[u8]) -> &str {
+    std::str::from_utf8(bytes).unwrap()
+}
+
+comparator!(compare_string_descending, parse_string);
+
+fn parse_binary(bytes: &[u8]) -> &[u8] {
+    bytes
+}
+
+comparator!(compare_binary_descending, parse_binary);
+
+unsafe fn mdb_val_to_slice(val: &MDB_val) -> &[u8] {
+    std::slice::from_raw_parts(val.mv_data as *const u8, val.mv_size)
+}
+
+unsafe extern "C" fn compare_composite_key(
+    a: *const MDB_val,
+    b: *const MDB_val,
+) -> std::ffi::c_int {
+    match compare_composite_secondary_index(mdb_val_to_slice(&*a), mdb_val_to_slice(&*b)) {
+        Ok(ordering) => ordering as std::ffi::c_int,
+        Err(e) => {
+            dozer_types::log::error!("Error deserializing secondary index key: {}", e);
+            0
+        }
+    }
+}

--- a/dozer-cache/src/cache/lmdb/indexer.rs
+++ b/dozer-cache/src/cache/lmdb/indexer.rs
@@ -58,7 +58,7 @@ impl Indexer {
             .copied()
             .filter_map(|(index, direction)| (values.get(index).map(|value| (value, direction))))
             .collect::<Vec<_>>();
-        index::get_secondary_index(&values).map_err(CacheError::map_serialization_error)
+        index::get_secondary_index(&values)
     }
 
     fn _build_indices_full_text(

--- a/dozer-cache/src/cache/lmdb/mod.rs
+++ b/dozer-cache/src/cache/lmdb/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 pub mod batched_writer;
 pub mod cache;
+pub mod comparator;
 pub mod indexer;
 pub mod query;
 pub mod utils;

--- a/dozer-cache/src/cache/lmdb/query/handler.rs
+++ b/dozer-cache/src/cache/lmdb/query/handler.rs
@@ -263,7 +263,7 @@ impl<'a> LmdbQueryHandler<'a> {
                         fields.push((val, range_query.sort_direction));
                     }
                 }
-                index::get_secondary_index(&fields).map_err(CacheError::map_serialization_error)
+                index::get_secondary_index(&fields)
             }
             IndexScanKind::FullText { filter } => {
                 if let Field::String(token) = &filter.val {


### PR DESCRIPTION
Performance gain:

```
cache_insert/1000000    time:   [75.001 µs 75.452 µs 76.087 µs]
                        change: [-6.6560% -5.2616% -3.4701%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

cache_get/1000000       time:   [1.0178 µs 1.0203 µs 1.0226 µs]
                        change: [-1.4059% -1.0583% -0.7286%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

cache_query/1000000     time:   [2.9855 µs 3.0503 µs 3.1200 µs]
                        change: [-13.661% -11.851% -10.080%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe
```