### PR TITLE
chore: Remove `secondary_indexes` from `Schema`

### DIFF
--- a/dozer-api/src/api_helper.rs
+++ b/dozer-api/src/api_helper.rs
@@ -51,13 +51,14 @@ impl ApiHelper {
 
     pub fn generate_oapi3(&self) -> Result<OpenAPI, ApiError> {
         let schema_name = self.details.schema_name.clone();
-        let schema = self
+        let (schema, secondary_indexes) = self
             .reader
-            .get_schema_by_name(&schema_name)
+            .get_schema_and_indexes_by_name(&schema_name)
             .map_err(ApiError::SchemaNotFound)?;
 
         let oapi_generator = OpenApiGenerator::new(
             schema,
+            secondary_indexes,
             schema_name,
             self.details.cache_endpoint.endpoint.clone(),
             vec![format!("http://localhost:{}", "8080")],
@@ -69,7 +70,10 @@ impl ApiHelper {
     }
     /// Get a single record
     pub fn get_record(&self, key: String) -> Result<IndexMap<String, String>, CacheError> {
-        let schema = self.reader.get_schema_by_name(&self.details.schema_name)?;
+        let schema = self
+            .reader
+            .get_schema_and_indexes_by_name(&self.details.schema_name)?
+            .0;
 
         let field_types: Vec<FieldType> = schema
             .primary_index
@@ -102,7 +106,10 @@ impl ApiHelper {
         &self,
         mut exp: QueryExpression,
     ) -> Result<(Schema, Vec<Record>), CacheError> {
-        let schema = self.reader.get_schema_by_name(&self.details.schema_name)?;
+        let schema = self
+            .reader
+            .get_schema_and_indexes_by_name(&self.details.schema_name)?
+            .0;
         let records = self.reader.query(&self.details.schema_name, &mut exp)?;
 
         Ok((schema, records))
@@ -110,7 +117,10 @@ impl ApiHelper {
 
     /// Get schema
     pub fn get_schema(&self) -> Result<Schema, CacheError> {
-        let schema = self.reader.get_schema_by_name(&self.details.schema_name)?;
+        let schema = self
+            .reader
+            .get_schema_and_indexes_by_name(&self.details.schema_name)?
+            .0;
         Ok(schema)
     }
 }

--- a/dozer-api/src/generator/oapi/generator.rs
+++ b/dozer-api/src/generator/oapi/generator.rs
@@ -10,6 +10,7 @@ use tempdir::TempDir;
 
 pub struct OpenApiGenerator {
     schema: dozer_types::types::Schema,
+    secondary_indexes: Vec<IndexDefinition>,
     schema_name: String,
     endpoint: ApiEndpoint,
     server_host: Vec<String>,
@@ -24,8 +25,8 @@ impl OpenApiGenerator {
 
     // Generate first secondary_index as an example
     fn generate_query_example(&self) -> Value {
-        if !self.schema.secondary_indexes.is_empty() {
-            if let IndexDefinition::SortedInverted(fields) = &self.schema.secondary_indexes[0] {
+        if !self.secondary_indexes.is_empty() {
+            if let IndexDefinition::SortedInverted(fields) = &self.secondary_indexes[0] {
                 let field_def = &self.schema.fields[fields[0].0];
                 let name = field_def.name.clone();
                 let val = match field_def.typ {
@@ -239,12 +240,14 @@ impl OpenApiGenerator {
 
     pub fn new(
         schema: dozer_types::types::Schema,
+        secondary_indexes: Vec<IndexDefinition>,
         schema_name: String,
         endpoint: ApiEndpoint,
         server_host: Vec<String>,
     ) -> Self {
         Self {
             schema,
+            secondary_indexes,
             endpoint,
             server_host,
             schema_name,

--- a/dozer-api/src/generator/protoc/generator.rs
+++ b/dozer-api/src/generator/protoc/generator.rs
@@ -35,7 +35,10 @@ impl ProtoGenerator<'_> {
                 let cache = x.to_owned().cache_endpoint.cache;
                 let endpoint = x.to_owned().cache_endpoint.endpoint;
                 let schema_name = endpoint.name.to_owned();
-                let schema = cache.get_schema_by_name(&schema_name).unwrap();
+                let schema = cache
+                    .get_schema_and_indexes_by_name(&schema_name)
+                    .unwrap()
+                    .0;
                 ProtoService::new(schema, schema_name, endpoint)
             })
             .collect();

--- a/dozer-api/src/grpc/dynamic/by_id.rs
+++ b/dozer-api/src/grpc/dynamic/by_id.rs
@@ -26,8 +26,9 @@ async fn grpc_get_by_id(
     let dynamic_message = request.into_inner();
     let cache = pipeline_details.cache_endpoint.cache.to_owned();
     let schema = cache
-        .get_schema_by_name(&pipeline_details.schema_name)
-        .map_err(from_cache_error)?;
+        .get_schema_and_indexes_by_name(&pipeline_details.schema_name)
+        .map_err(from_cache_error)?
+        .0;
     let primary_idx = schema.primary_index.first().ok_or_else(|| {
         GRPCError::MissingPrimaryKeyToQueryById(pipeline_details.schema_name.to_owned())
     })?;

--- a/dozer-api/src/grpc/dynamic/tests/utils.rs
+++ b/dozer-api/src/grpc/dynamic/tests/utils.rs
@@ -1,4 +1,5 @@
 use crossbeam::channel;
+use dozer_types::types::IndexDefinition;
 use tokio::time;
 
 use crate::{
@@ -16,7 +17,7 @@ use std::{collections::HashMap, io, thread};
 pub fn generate_proto(
     dir_path: String,
     schema_name: String,
-    schema: Option<dozer_types::types::Schema>,
+    schema: Option<(dozer_types::types::Schema, Vec<IndexDefinition>)>,
 ) -> Result<(std::string::String, HashMap<std::string::String, GrpcType>), GenerationError> {
     let endpoint = test_utils::get_endpoint();
     let mut map = HashMap::new();

--- a/dozer-api/src/rest/tests/routes.rs
+++ b/dozer-api/src/rest/tests/routes.rs
@@ -6,11 +6,12 @@ use dozer_types::serde_json::{json, Value};
 
 #[test]
 fn test_generate_oapi() {
-    let schema: dozer_types::types::Schema = test_utils::get_schema();
+    let (schema, secondary_indexes) = test_utils::get_schema();
     let endpoint = test_utils::get_endpoint();
 
     let oapi_generator = OpenApiGenerator::new(
         schema,
+        secondary_indexes,
         endpoint.name.to_owned(),
         endpoint,
         vec![format!("http://localhost:{}", "8080")],

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -39,10 +39,12 @@ fn query(cache: Arc<LmdbCache>, _n: usize) {
 }
 
 fn cache(c: &mut Criterion) {
-    let schema = test_utils::schema_0();
+    let (schema, secondary_indexes) = test_utils::schema_0();
     let cache = Arc::new(LmdbCache::new(CacheOptions::default()).unwrap());
 
-    cache.insert_schema("benches", &schema).unwrap();
+    cache
+        .insert_schema("benches", &schema, &secondary_indexes)
+        .unwrap();
 
     let size: usize = 1000000;
     c.bench_with_input(BenchmarkId::new("cache_insert", size), &size, |b, &s| {

--- a/dozer-cache/src/cache/lmdb/cache.rs
+++ b/dozer-cache/src/cache/lmdb/cache.rs
@@ -89,6 +89,7 @@ impl LmdbCache {
         txn: &mut RwTransaction,
         rec: &Record,
         schema: &Schema,
+        secondary_indexes: &[IndexDefinition],
     ) -> Result<(), CacheError> {
         let p_key = &schema.primary_index;
         let values = &rec.values;
@@ -103,7 +104,7 @@ impl LmdbCache {
             index_metadata: self.index_metadata.clone(),
         };
 
-        indexer.build_indexes(txn, rec, schema, key)?;
+        indexer.build_indexes(txn, rec, schema, secondary_indexes, key)?;
 
         Ok(())
     }
@@ -113,9 +114,10 @@ impl LmdbCache {
         txn: &mut RwTransaction,
         schema: &Schema,
         name: &str,
+        secondary_indexes: &[IndexDefinition],
     ) -> Result<(), CacheError> {
-        let encoded: Vec<u8> =
-            bincode::serialize(&schema).map_err(CacheError::map_serialization_error)?;
+        let encoded: Vec<u8> = bincode::serialize(&(schema, secondary_indexes))
+            .map_err(CacheError::map_serialization_error)?;
         let schema_id = schema.to_owned().identifier.unwrap();
         let key = get_schema_key(&schema_id);
 
@@ -154,7 +156,7 @@ impl LmdbCache {
         &self,
         name: &str,
         txn: &RoTransaction,
-    ) -> Result<Schema, CacheError> {
+    ) -> Result<(Schema, Vec<IndexDefinition>), CacheError> {
         let schema_reverse_key = index::get_schema_reverse_key(name);
         let schema_identifier = txn
             .get(self.schema_db, &schema_reverse_key)
@@ -162,22 +164,21 @@ impl LmdbCache {
         let schema_id: SchemaIdentifier = bincode::deserialize(schema_identifier)
             .map_err(CacheError::map_deserialization_error)?;
 
-        let schema = self._get_schema(txn, &schema_id)?;
+        let schema = self.get_schema_and_indexes(txn, &schema_id)?;
 
         Ok(schema)
     }
 
-    fn _get_schema(
+    fn get_schema_and_indexes<T: Transaction>(
         &self,
-        txn: &RoTransaction,
+        txn: &T,
         schema_identifier: &SchemaIdentifier,
-    ) -> Result<Schema, CacheError> {
+    ) -> Result<(Schema, Vec<IndexDefinition>), CacheError> {
         let key = get_schema_key(schema_identifier);
         let schema = txn
             .get(self.schema_db, &key)
             .map_err(|e| CacheError::QueryError(QueryError::GetValue(e)))?;
-        let schema: Schema =
-            bincode::deserialize(schema).map_err(CacheError::map_deserialization_error)?;
+        let schema = bincode::deserialize(schema).map_err(CacheError::map_deserialization_error)?;
         Ok(schema)
     }
 
@@ -192,12 +193,13 @@ impl LmdbCache {
         key: &[u8],
         rec: &Record,
         schema: &Schema,
+        secondary_indexes: &[IndexDefinition],
         txn: &mut RwTransaction,
     ) -> Result<(), CacheError> {
         txn.del(self.db, &key, None)
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
 
-        self._insert(txn, rec, schema)
+        self._insert(txn, rec, schema, secondary_indexes)
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
         Ok(())
     }
@@ -213,9 +215,9 @@ impl Cache for LmdbCache {
             .schema_id
             .to_owned()
             .map_or(Err(CacheError::SchemaIdentifierNotFound), Ok)?;
-        let schema = self.get_schema(&schema_identifier)?;
+        let (schema, secondary_indexes) = self.get_schema_and_indexes(&txn, &schema_identifier)?;
 
-        self._insert(&mut txn, rec, &schema)?;
+        self._insert(&mut txn, rec, &schema, &secondary_indexes)?;
         txn.commit()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
         Ok(())
@@ -248,26 +250,40 @@ impl Cache for LmdbCache {
             .env
             .begin_ro_txn()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
-        let schema = self._get_schema_from_reverse_key(name, &txn)?;
+        let (schema, secondary_indexes) = self._get_schema_from_reverse_key(name, &txn)?;
 
-        let handler =
-            LmdbQueryHandler::new(&self.db, self.index_metadata.clone(), &txn, &schema, query);
+        let handler = LmdbQueryHandler::new(
+            &self.db,
+            self.index_metadata.clone(),
+            &txn,
+            &schema,
+            &secondary_indexes,
+            query,
+        );
         let records = handler.query()?;
         Ok(records)
     }
 
-    fn update(&self, key: &[u8], rec: &Record, schema: &Schema) -> Result<(), CacheError> {
+    fn update(&self, key: &[u8], rec: &Record, _schema: &Schema) -> Result<(), CacheError> {
+        let schema_identifier = rec
+            .schema_id
+            .to_owned()
+            .map_or(Err(CacheError::SchemaIdentifierNotFound), Ok)?;
         let mut txn: RwTransaction = self
             .env
             .begin_rw_txn()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
-        self._update(key, rec, schema, &mut txn)?;
+        let (schema, secondary_indexes) = self.get_schema_and_indexes(&txn, &schema_identifier)?;
+        self._update(key, rec, &schema, &secondary_indexes, &mut txn)?;
         txn.commit()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
         Ok(())
     }
 
-    fn get_schema_by_name(&self, name: &str) -> Result<Schema, CacheError> {
+    fn get_schema_and_indexes_by_name(
+        &self,
+        name: &str,
+    ) -> Result<(Schema, Vec<IndexDefinition>), CacheError> {
         let txn: RoTransaction = self
             .env
             .begin_ro_txn()
@@ -281,11 +297,17 @@ impl Cache for LmdbCache {
             .env
             .begin_ro_txn()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
-        self._get_schema(&txn, schema_identifier)
+        self.get_schema_and_indexes(&txn, schema_identifier)
+            .map(|(schema, _)| schema)
     }
-    fn insert_schema(&self, name: &str, schema: &Schema) -> Result<(), CacheError> {
+    fn insert_schema(
+        &self,
+        name: &str,
+        schema: &Schema,
+        secondary_indexes: &[IndexDefinition],
+    ) -> Result<(), CacheError> {
         // Create a db for each index
-        for (idx, index) in schema.secondary_indexes.iter().enumerate() {
+        for (idx, index) in secondary_indexes.iter().enumerate() {
             let key = IndexMetaData::get_key(schema, idx);
             let name = format!("index_#{}", key);
             let db = utils::init_db(&self.env, Some(&name), &self.cache_options)?;
@@ -302,7 +324,7 @@ impl Cache for LmdbCache {
             .env
             .begin_rw_txn()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
-        self._insert_schema(&mut txn, schema, name)?;
+        self._insert_schema(&mut txn, schema, name, secondary_indexes)?;
         txn.commit()
             .map_err(|e| CacheError::InternalError(Box::new(e)))?;
         Ok(())

--- a/dozer-cache/src/cache/lmdb/query/tests.rs
+++ b/dozer-cache/src/cache/lmdb/query/tests.rs
@@ -11,7 +11,7 @@ use dozer_types::{
 #[test]
 fn query_secondary() {
     let cache = LmdbCache::new(CacheOptions::default()).unwrap();
-    let schema = test_utils::schema_1();
+    let (schema, seconary_indexes) = test_utils::schema_1();
     let record = Record::new(
         schema.identifier.clone(),
         vec![
@@ -21,7 +21,9 @@ fn query_secondary() {
         ],
     );
 
-    cache.insert_schema("sample", &schema).unwrap();
+    cache
+        .insert_schema("sample", &schema, &seconary_indexes)
+        .unwrap();
     cache.insert(&record).unwrap();
 
     let filter = FilterExpression::And(vec![
@@ -45,13 +47,15 @@ fn query_secondary() {
     assert_eq!(records[0], record, "must be equal");
 
     // Full text query.
-    let schema = test_utils::schema_full_text_single();
+    let (schema, secondary_indexes) = test_utils::schema_full_text_single();
     let record = Record::new(
         schema.identifier.clone(),
         vec![Field::String("today is a good day".into())],
     );
 
-    cache.insert_schema("full_text_sample", &schema).unwrap();
+    cache
+        .insert_schema("full_text_sample", &schema, &secondary_indexes)
+        .unwrap();
     cache.insert(&record).unwrap();
 
     let filter = FilterExpression::Simple(
@@ -70,9 +74,11 @@ fn query_secondary() {
 #[test]
 fn query_secondary_vars() {
     let cache = LmdbCache::new(CacheOptions::default()).unwrap();
-    let schema = test_utils::schema_1();
+    let (schema, seconary_indexes) = test_utils::schema_1();
 
-    cache.insert_schema("sample", &schema).unwrap();
+    cache
+        .insert_schema("sample", &schema, &seconary_indexes)
+        .unwrap();
 
     let items: Vec<(i64, String, i64)> = vec![
         (1, "yuri".to_string(), 521),

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -17,9 +17,11 @@ fn read_and_write() {
     }))
     .unwrap();
 
-    let schema = test_utils::schema_1();
+    let (schema, secondary_indexes) = test_utils::schema_1();
 
-    cache_writer.insert_schema("sample", &schema).unwrap();
+    cache_writer
+        .insert_schema("sample", &schema, &secondary_indexes)
+        .unwrap();
     let items: Vec<(i64, String, i64)> = vec![
         (1, "a".to_string(), 521),
         (2, "a".to_string(), 521),

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -6,16 +6,24 @@ pub use self::lmdb::{
     CacheOptions, CacheReadOptions, CacheWriteOptions,
 };
 use crate::errors::CacheError;
-use dozer_types::types::{Record, Schema, SchemaIdentifier};
+use dozer_types::types::{IndexDefinition, Record, Schema, SchemaIdentifier};
 pub mod expression;
 pub mod index;
 mod plan;
 pub mod test_utils;
 pub trait Cache {
     // Schema Operations
-    fn insert_schema(&self, name: &str, schema: &Schema) -> Result<(), CacheError>;
+    fn insert_schema(
+        &self,
+        name: &str,
+        schema: &Schema,
+        secondary_indexes: &[IndexDefinition],
+    ) -> Result<(), CacheError>;
     fn get_schema(&self, schema_identifier: &SchemaIdentifier) -> Result<Schema, CacheError>;
-    fn get_schema_by_name(&self, name: &str) -> Result<Schema, CacheError>;
+    fn get_schema_and_indexes_by_name(
+        &self,
+        name: &str,
+    ) -> Result<(Schema, Vec<IndexDefinition>), CacheError>;
 
     // Record Operations
     fn insert(&self, rec: &Record) -> Result<(), CacheError>;

--- a/dozer-cache/src/cache/plan/tests.rs
+++ b/dozer-cache/src/cache/plan/tests.rs
@@ -12,7 +12,7 @@ use dozer_types::{
 
 #[test]
 fn test_generate_plan_simple() {
-    let schema = test_utils::schema_0();
+    let (schema, secondary_indexes) = test_utils::schema_0();
 
     let query = QueryExpression::new(
         Some(FilterExpression::Simple(
@@ -24,7 +24,7 @@ fn test_generate_plan_simple() {
         10,
         0,
     );
-    let planner = QueryPlanner::new(&schema, &query);
+    let planner = QueryPlanner::new(&schema, &secondary_indexes, &query);
     if let Plan::IndexScans(index_scans) = planner.plan().unwrap() {
         assert_eq!(index_scans.len(), 1);
         assert_eq!(index_scans[0].index_id, 0);
@@ -53,7 +53,7 @@ fn test_generate_plan_simple() {
 
 #[test]
 fn test_generate_plan_and() {
-    let schema = test_utils::schema_1();
+    let (schema, secondary_indexes) = test_utils::schema_1();
 
     let filter = FilterExpression::And(vec![
         FilterExpression::Simple("a".to_string(), expression::Operator::EQ, Value::from(1)),
@@ -64,7 +64,7 @@ fn test_generate_plan_and() {
         ),
     ]);
     let query = QueryExpression::new(Some(filter), vec![], 10, 0);
-    let planner = QueryPlanner::new(&schema, &query);
+    let planner = QueryPlanner::new(&schema, &secondary_indexes, &query);
     // Pick the 3rd index
     if let Plan::IndexScans(index_scans) = planner.plan().unwrap() {
         assert_eq!(index_scans.len(), 1);
@@ -95,7 +95,7 @@ fn test_generate_plan_and() {
 
 #[test]
 fn test_generate_plan_range_query_and_order_by() {
-    let schema = test_utils::schema_1();
+    let (schema, secondary_indexes) = test_utils::schema_1();
     let filter = FilterExpression::Simple("c".into(), expression::Operator::GT, 1.into());
     let query = QueryExpression::new(
         Some(filter),
@@ -106,7 +106,7 @@ fn test_generate_plan_range_query_and_order_by() {
         10,
         0,
     );
-    let planner = QueryPlanner::new(&schema, &query);
+    let planner = QueryPlanner::new(&schema, &secondary_indexes, &query);
     if let Plan::IndexScans(index_scans) = planner.plan().unwrap() {
         assert_eq!(index_scans.len(), 1);
         assert_eq!(index_scans[0].index_id, 4);

--- a/dozer-cache/src/cache/test_utils.rs
+++ b/dozer-cache/src/cache/test_utils.rs
@@ -3,43 +3,47 @@ use dozer_types::types::{
     SortDirection::{Ascending, Descending},
 };
 
-pub fn schema_0() -> Schema {
-    Schema {
-        identifier: Some(SchemaIdentifier { id: 0, version: 1 }),
-        fields: vec![FieldDefinition {
-            name: "foo".to_string(),
-            typ: dozer_types::types::FieldType::String,
-            nullable: true,
-        }],
-        values: vec![0],
-        primary_index: vec![0],
-        secondary_indexes: vec![IndexDefinition::SortedInverted(vec![(0, Ascending)])],
-    }
-}
-
-pub fn schema_1() -> Schema {
-    Schema {
-        identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
-        fields: vec![
-            FieldDefinition {
-                name: "a".to_string(),
-                typ: dozer_types::types::FieldType::Int,
-                nullable: true,
-            },
-            FieldDefinition {
-                name: "b".to_string(),
+pub fn schema_0() -> (Schema, Vec<IndexDefinition>) {
+    (
+        Schema {
+            identifier: Some(SchemaIdentifier { id: 0, version: 1 }),
+            fields: vec![FieldDefinition {
+                name: "foo".to_string(),
                 typ: dozer_types::types::FieldType::String,
                 nullable: true,
-            },
-            FieldDefinition {
-                name: "c".to_string(),
-                typ: dozer_types::types::FieldType::Int,
-                nullable: true,
-            },
-        ],
-        values: vec![0],
-        primary_index: vec![0],
-        secondary_indexes: vec![
+            }],
+            values: vec![0],
+            primary_index: vec![0],
+        },
+        vec![IndexDefinition::SortedInverted(vec![(0, Ascending)])],
+    )
+}
+
+pub fn schema_1() -> (Schema, Vec<IndexDefinition>) {
+    (
+        Schema {
+            identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
+            fields: vec![
+                FieldDefinition {
+                    name: "a".to_string(),
+                    typ: dozer_types::types::FieldType::Int,
+                    nullable: true,
+                },
+                FieldDefinition {
+                    name: "b".to_string(),
+                    typ: dozer_types::types::FieldType::String,
+                    nullable: true,
+                },
+                FieldDefinition {
+                    name: "c".to_string(),
+                    typ: dozer_types::types::FieldType::Int,
+                    nullable: true,
+                },
+            ],
+            values: vec![0],
+            primary_index: vec![0],
+        },
+        vec![
             IndexDefinition::SortedInverted(vec![(0, Ascending)]),
             IndexDefinition::SortedInverted(vec![(1, Ascending)]),
             IndexDefinition::SortedInverted(vec![(2, Ascending)]),
@@ -48,19 +52,21 @@ pub fn schema_1() -> Schema {
             // descending index
             IndexDefinition::SortedInverted(vec![(2, Descending)]),
         ],
-    }
+    )
 }
 
-pub fn schema_full_text_single() -> Schema {
-    Schema {
-        identifier: Some(SchemaIdentifier { id: 2, version: 1 }),
-        fields: vec![FieldDefinition {
-            name: "foo".to_string(),
-            typ: dozer_types::types::FieldType::String,
-            nullable: false,
-        }],
-        values: vec![0],
-        primary_index: vec![0],
-        secondary_indexes: vec![IndexDefinition::FullText(0)],
-    }
+pub fn schema_full_text_single() -> (Schema, Vec<IndexDefinition>) {
+    (
+        Schema {
+            identifier: Some(SchemaIdentifier { id: 2, version: 1 }),
+            fields: vec![FieldDefinition {
+                name: "foo".to_string(),
+                typ: dozer_types::types::FieldType::String,
+                nullable: false,
+            }],
+            values: vec![0],
+            primary_index: vec![0],
+        },
+        vec![IndexDefinition::FullText(0)],
+    )
 }

--- a/dozer-cache/src/reader.rs
+++ b/dozer-cache/src/reader.rs
@@ -6,7 +6,7 @@ use super::cache::expression::FilterExpression;
 use crate::errors::CacheError;
 use dozer_types::{
     serde,
-    types::{Record, Schema},
+    types::{IndexDefinition, Record, Schema},
 };
 use serde::{Deserialize, Serialize};
 
@@ -34,8 +34,11 @@ impl CacheReader {
         Ok(())
     }
 
-    pub fn get_schema_by_name(&self, name: &str) -> Result<Schema, CacheError> {
-        self.cache.get_schema_by_name(name)
+    pub fn get_schema_and_indexes_by_name(
+        &self,
+        name: &str,
+    ) -> Result<(Schema, Vec<IndexDefinition>), CacheError> {
+        self.cache.get_schema_and_indexes_by_name(name)
     }
 
     pub fn get(&self, key: &[u8]) -> Result<Record, CacheError> {

--- a/dozer-ingestion/src/connectors/ethereum/helper.rs
+++ b/dozer-ingestion/src/connectors/ethereum/helper.rs
@@ -133,6 +133,5 @@ pub fn get_eth_schema() -> Schema {
         values: vec![],
         // Log Index
         primary_index: vec![0],
-        secondary_indexes: vec![],
     }
 }

--- a/dozer-ingestion/src/connectors/postgres/helper.rs
+++ b/dozer-ingestion/src/connectors/postgres/helper.rs
@@ -198,7 +198,6 @@ pub fn map_schema(rel_id: &u32, columns: &[Column]) -> Result<Schema, ConnectorE
         fields: field_defs.unwrap(),
         values: vec![],
         primary_index: vec![0],
-        secondary_indexes: vec![],
     })
 }
 

--- a/dozer-ingestion/src/connectors/postgres/schema_helper.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema_helper.rs
@@ -98,7 +98,6 @@ impl SchemaHelper {
                 fields: fields.clone(),
                 values: vec![],
                 primary_index,
-                secondary_indexes: vec![],
             };
             schemas.push((table_name, schema));
         }

--- a/dozer-ingestion/src/connectors/postgres/xlog_mapper.rs
+++ b/dozer-ingestion/src/connectors/postgres/xlog_mapper.rs
@@ -248,7 +248,6 @@ impl XlogMapper {
             fields,
             values: vec![0],
             primary_index: vec![0],
-            secondary_indexes: vec![],
         };
 
         self.relations_map.insert(rel_id, table);

--- a/dozer-ingestion/src/connectors/snowflake/schema_helper.rs
+++ b/dozer-ingestion/src/connectors/snowflake/schema_helper.rs
@@ -53,7 +53,6 @@ impl SchemaHelper {
             fields: defined_fields,
             values: vec![],
             primary_index: vec![0],
-            secondary_indexes: vec![],
         })
     }
 }

--- a/dozer-ingestion/src/ingestion/ingestor.rs
+++ b/dozer-ingestion/src/ingestion/ingestor.rs
@@ -117,7 +117,6 @@ mod tests {
             fields: vec![],
             values: vec![],
             primary_index: vec![],
-            secondary_indexes: vec![],
         };
 
         // Expected seq no - 2

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -92,7 +92,7 @@ pub struct CacheSink {
     cache: Arc<LmdbCache>,
     counter: i32,
     before: Instant,
-    input_schemas: Mutex<HashMap<PortHandle, Schema>>,
+    input_schemas: Mutex<HashMap<PortHandle, (Schema, Vec<IndexDefinition>)>>,
     api_endpoint: ApiEndpoint,
     pb: ProgressBar,
     notifier: Option<crossbeam::channel::Sender<PipelineRequest>>,
@@ -110,15 +110,15 @@ impl Sink for CacheSink {
             let mut map = self.input_schemas.lock();
 
             // Append primary and secondary keys
-            let schema = self.get_output_schema(schema)?;
+            let (schema, secondary_indexes) = self.get_output_schema(schema)?;
 
             self.cache
-                .insert_schema(&self.api_endpoint.name, &schema)
+                .insert_schema(&self.api_endpoint.name, &schema, &secondary_indexes)
                 .map_err(|e| {
                     ExecutionError::SinkError(SinkError::SchemaUpdateFailed(Box::new(e)))
                 })?;
 
-            map.insert(*k, schema.to_owned());
+            map.insert(*k, (schema.clone(), secondary_indexes));
 
             if let Some(notifier) = &self.notifier {
                 let schema = types_helper::map_schema(self.api_endpoint.name.to_owned(), &schema);
@@ -166,7 +166,7 @@ impl Sink for CacheSink {
                 self.before.elapsed(),
             ));
         }
-        let schema = self
+        let (schema, secondary_indexes) = self
             .input_schemas
             .lock()
             .get(&from_port)
@@ -184,7 +184,11 @@ impl Sink for CacheSink {
         }
 
         self.batched_sender
-            .send(BatchedCacheMsg { op, schema })
+            .send(BatchedCacheMsg {
+                op,
+                schema,
+                secondary_indexes,
+            })
             .unwrap();
         Ok(())
     }
@@ -194,7 +198,7 @@ impl CacheSink {
     pub fn new(
         cache: Arc<LmdbCache>,
         api_endpoint: ApiEndpoint,
-        input_schemas: Mutex<HashMap<PortHandle, Schema>>,
+        input_schemas: Mutex<HashMap<PortHandle, (Schema, Vec<IndexDefinition>)>>,
         notifier: Option<crossbeam::channel::Sender<PipelineRequest>>,
         record_cutoff: u32,
         timeout: u64,
@@ -224,7 +228,10 @@ impl CacheSink {
             batched_sender,
         }
     }
-    fn get_output_schema(&self, schema: &Schema) -> Result<Schema, ExecutionError> {
+    fn get_output_schema(
+        &self,
+        schema: &Schema,
+    ) -> Result<(Schema, Vec<IndexDefinition>), ExecutionError> {
         let mut schema = schema.clone();
 
         // Get hash of schema
@@ -251,7 +258,7 @@ impl CacheSink {
         });
 
         // Automatically create secondary indexes
-        schema.secondary_indexes = schema
+        let secondary_indexes = schema
             .fields
             .iter()
             .enumerate()
@@ -274,7 +281,7 @@ impl CacheSink {
                 FieldType::Binary | FieldType::Bson => None,
             })
             .collect();
-        Ok(schema)
+        Ok((schema, secondary_indexes))
     }
 
     fn get_schema_hash(&self) -> u64 {
@@ -316,7 +323,7 @@ mod tests {
 
         let schema = test_utils::get_schema();
 
-        let (cache, mut sink) = test_utils::init_sink(&schema);
+        let (cache, mut sink) = test_utils::init_sink(&schema, vec![]);
 
         let initial_values = vec![Field::Int(1), Field::String("Film name old".to_string())];
 

--- a/dozer-orchestrator/src/simple/tests.rs
+++ b/dozer-orchestrator/src/simple/tests.rs
@@ -65,7 +65,7 @@ fn single_source_sink() {
     let r = running.clone();
     let executor_running = running.clone();
 
-    let schema = test_utils::schema_1();
+    let schema = test_utils::schema_1().0;
     // Initialize a schema.
     ingestor2
         .write()

--- a/dozer-orchestrator/src/test_utils.rs
+++ b/dozer-orchestrator/src/test_utils.rs
@@ -1,10 +1,9 @@
 use crate::pipeline::CacheSink;
 use dozer_cache::cache::{CacheOptions, LmdbCache};
 use dozer_core::dag::executor_local::DEFAULT_PORT_HANDLE;
-use dozer_core::dag::node::PortHandle;
 use dozer_types::models::api_endpoint::{ApiEndpoint, ApiIndex};
 use dozer_types::parking_lot::Mutex;
-use dozer_types::types::{FieldDefinition, FieldType, Schema, SchemaIdentifier};
+use dozer_types::types::{FieldDefinition, FieldType, IndexDefinition, Schema, SchemaIdentifier};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -25,15 +24,17 @@ pub fn get_schema() -> Schema {
         ],
         values: vec![0],
         primary_index: vec![0],
-        secondary_indexes: vec![],
     }
 }
 
-pub fn init_sink(schema: &Schema) -> (Arc<LmdbCache>, CacheSink) {
+pub fn init_sink(
+    schema: &Schema,
+    secondary_indexes: Vec<IndexDefinition>,
+) -> (Arc<LmdbCache>, CacheSink) {
     let cache = Arc::new(LmdbCache::new(CacheOptions::default()).unwrap());
 
-    let mut input_schemas: HashMap<PortHandle, Schema> = HashMap::new();
-    input_schemas.insert(DEFAULT_PORT_HANDLE, schema.clone());
+    let mut input_schemas = HashMap::new();
+    input_schemas.insert(DEFAULT_PORT_HANDLE, (schema.clone(), secondary_indexes));
 
     let sink = CacheSink::new(
         Arc::clone(&cache),

--- a/dozer-tests/src/sql_tests/helper.rs
+++ b/dozer-tests/src/sql_tests/helper.rs
@@ -243,7 +243,6 @@ pub fn get_schema(columns: &[rusqlite::Column]) -> Schema {
             .collect(),
         values: vec![],
         primary_index: vec![0],
-        secondary_indexes: vec![],
     }
 }
 

--- a/dozer-tests/src/tests/mapper.rs
+++ b/dozer-tests/src/tests/mapper.rs
@@ -153,7 +153,6 @@ fn test_null_inserts() {
                 }],
                 values: vec![],
                 primary_index: vec![0],
-                secondary_indexes: vec![]
             }
         )
         .unwrap(),
@@ -194,7 +193,6 @@ fn test_null_inserts() {
                 ],
                 values: vec![],
                 primary_index: vec![0],
-                secondary_indexes: vec![]
             }
         )
         .unwrap(),

--- a/dozer-types/src/types.rs
+++ b/dozer-types/src/types.rs
@@ -112,9 +112,6 @@ pub struct Schema {
     /// only Insert Operation are supported. Updates and Deletes are not supported without a
     /// primary key definition
     pub primary_index: Vec<usize>,
-
-    // Secondary indexes definitions
-    pub secondary_indexes: Vec<IndexDefinition>,
 }
 
 impl Schema {
@@ -124,7 +121,6 @@ impl Schema {
             fields: Vec::new(),
             values: Vec::new(),
             primary_index: Vec::new(),
-            secondary_indexes: Vec::new(),
         }
     }
 


### PR DESCRIPTION
@duonganhthu43 You might want to take a look at this because it affects some code in `dozer-api` and I'm not sure if I made the correct decisions.