### PR TITLE
chore: Run test that depends on mongodb behind a feature flag

### DIFF
--- a/.github/workflows/dozer.yaml
+++ b/.github/workflows/dozer.yaml
@@ -85,4 +85,4 @@ jobs:
           cargo fmt -- --check
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --features mongodb

--- a/dozer-tests/Cargo.toml
+++ b/dozer-tests/Cargo.toml
@@ -19,3 +19,6 @@ tokio = { version = "1.23.0", features = ["full"] }
 bson = "2.4.0"
 mongodb = "2.3.1"
 futures = "0.3.25"
+
+[features]
+mongodb = []

--- a/dozer-tests/src/lib.rs
+++ b/dozer-tests/src/lib.rs
@@ -3,6 +3,7 @@ mod sql_tests;
 #[cfg(test)]
 pub use sql_tests::TestFramework;
 
+#[cfg(feature = "mongodb")]
 #[cfg(test)]
 mod cache_tests;
 

--- a/dozer-tests/src/tests/mod.rs
+++ b/dozer-tests/src/tests/mod.rs
@@ -2,4 +2,5 @@ mod mapper;
 
 mod sql;
 
+#[cfg(feature = "mongodb")]
 mod cache;


### PR DESCRIPTION
Unfortunately we still have to compile mongodb because it's a dev dependency.