### PR TITLE
fix: Synchronize sources startup (to pre-populate `RecordReader`)

### DIFF
--- a/dozer-core/src/dag/executor.rs
+++ b/dozer-core/src/dag/executor.rs
@@ -245,7 +245,7 @@ impl<'a> DagExecutor<'a> {
         senders: HashMap<PortHandle, Vec<Sender<ExecutorOperation>>>,
         schemas: &NodeSchemas,
         epoch_manager: Arc<EpochManager>,
-        start_barrier: Arc<Barrier>
+        start_barrier: Arc<Barrier>,
     ) -> Result<JoinHandle<()>, ExecutionError> {
         let (sender, receiver) = bounded(self.options.channel_buffer_sz);
         let start_seq = *self
@@ -423,7 +423,7 @@ impl<'a> DagExecutor<'a> {
                     .get(&handle)
                     .ok_or_else(|| ExecutionError::InvalidNodeHandle(handle.clone()))?,
                 epoch_manager.clone(),
-                start_barrier.clone()
+                start_barrier.clone(),
             )?;
             self.join_handles.insert(handle.clone(), join_handle);
         }


### PR DESCRIPTION
the startup of sources is not synchronized. As a result, all `RecordReader` are not populated upon startup. A join processor needs to have access to all input ports' RecordReader when receiving an Operation. Adding a barrier to synchronize the startup solves the problem