### PR TITLE
chore: Add `Field::as_*` and `Field::to_*` unit tests

### DIFF
--- a/dozer-tests/src/tests/cache.rs
+++ b/dozer-tests/src/tests/cache.rs
@@ -11,7 +11,6 @@ use crate::cache_tests::{
 };
 
 #[tokio::test]
-#[ignore]
 async fn test_cache_query() {
     let secondary_indexes = vec![
         IndexDefinition::SortedInverted(vec![0]),

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -472,4 +472,346 @@ pub mod tests {
             assert_eq!(bytes.len(), field.data_encoding_len());
         }
     }
+
+    #[test]
+    fn test_as_conversion() {
+        let field = Field::UInt(1);
+        assert!(field.as_uint().is_some());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Int(1);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_some());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Float(OrderedFloat::from(1.0));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_some());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Boolean(true);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_some());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::String("".to_string());
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_some());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Text("".to_string());
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_some());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Binary(vec![]);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_some());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Decimal(Decimal::from(1));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_some());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Timestamp(DateTime::from(Utc.timestamp_millis(0)));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_some());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Date(NaiveDate::from_ymd(1970, 1, 1));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_some());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Bson(vec![]);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_some());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Null;
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_null().is_some());
+    }
+
+    #[test]
+    fn test_to_conversion() {
+        let field = Field::UInt(1);
+        assert!(field.to_uint().is_some());
+        assert!(field.to_int().is_some());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Int(1);
+        assert!(field.to_uint().is_some());
+        assert!(field.to_int().is_some());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Float(OrderedFloat::from(1.0));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Boolean(true);
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::String("".to_string());
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Text("".to_string());
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Binary(vec![]);
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_some());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Decimal(Decimal::from(1));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Timestamp(DateTime::from(Utc.timestamp_millis(0)));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().is_some());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Date(NaiveDate::from_ymd(1970, 1, 1));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_some());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Bson(vec![]);
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_some());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Null;
+        assert!(field.to_uint().is_some());
+        assert!(field.to_int().is_some());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().is_none());
+        assert!(field.to_date().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_null().is_some());
+    }
 }


### PR DESCRIPTION
The `as_*` conversion implementation change was what caused cache tests to fail. I'm adding these tests to ensure it doesn't get changed accidentally.