### PR TITLE
chore: Ignore `dozer-tests/*` when counting coverage

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,7 +57,7 @@ jobs:
       - id: coverage
         run: |
           cargo install grcov
-          grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" --ignore 'target/*' -o target/coverage.lcov
+          grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" --ignore 'target/*' --ignore 'dozer-tests/*' -o target/coverage.lcov
           echo "::set-output name=report::target/coverage.lcov"
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Now that the integration test changes from a test to a binary, `cargo test` won't run or generate coverage data of it.