### PR TITLE
chore: enable building pre-release on main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [release, release-dev, release-test]
+    branches: [release, release-dev, main]
     tags:
       - "v*.*.*"
 env:


### PR DESCRIPTION
Releasing is taking about 8 mins. We can start building pre-releases on every main push. So we have the latest container. 