### PR TITLE
fix: handle error return from thread when intialize grpc + rest

### DIFF
--- a/dozer-api/src/errors.rs
+++ b/dozer-api/src/errors.rs
@@ -66,6 +66,8 @@ pub enum GRPCError {
     ServerReflectionError(#[from] tonic_reflection::server::Error),
     #[error("Unable to decode query expression: {0}")]
     UnableToDecodeQueryExpression(String),
+    #[error("{0}")]
+    TransportErrorDetail(String),
 }
 impl From<GRPCError> for tonic::Status {
     fn from(input: GRPCError) -> Self {

--- a/dozer-api/src/grpc/client_server.rs
+++ b/dozer-api/src/grpc/client_server.rs
@@ -195,7 +195,14 @@ impl ApiServer {
         grpc_router
             .serve_with_shutdown(addr, receiver_shutdown.map(drop))
             .await
-            .map_err(|e| GRPCError::InternalError(Box::new(e)))
+            .map_err(|e| {
+                let inner_error: Box<dyn std::error::Error> = e.into();
+                let detail = inner_error.source();
+                if let Some(detail) = detail {
+                    return GRPCError::TransportErrorDetail(detail.to_string());
+                }
+                GRPCError::TransportErrorDetail(inner_error.to_string())
+            })
     }
 
     pub fn setup_broad_cast_channel(

--- a/dozer-api/src/rest/api_server.rs
+++ b/dozer-api/src/rest/api_server.rs
@@ -166,9 +166,7 @@ impl ApiServer {
             )
         })
         .bind(address.to_owned())
-        .map_err(|e| {
-            ApiError::PortAlreadyInUse(e)
-        })?
+        .map_err(ApiError::PortAlreadyInUse)?
         .shutdown_timeout(self.shutdown_timeout.to_owned())
         .run();
 

--- a/dozer-orchestrator/src/errors.rs
+++ b/dozer-orchestrator/src/errors.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::enum_variant_names)]
 
-use dozer_api::errors::{GRPCError, ApiError};
+use dozer_api::errors::{ApiError, GRPCError};
 use dozer_cache::errors::CacheError;
 use dozer_core::dag::errors::ExecutionError;
 use dozer_ingestion::errors::ConnectorError;

--- a/dozer-orchestrator/src/lib.rs
+++ b/dozer-orchestrator/src/lib.rs
@@ -19,6 +19,7 @@ use std::{
         Arc,
     },
 };
+use tokio::task::JoinHandle;
 #[cfg(test)]
 mod test_utils;
 mod utils;
@@ -51,6 +52,16 @@ use dozer_types::log::info;
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;
 use dozer_types::types::Schema;
+
+async fn flatten_joinhandle(
+    handle: JoinHandle<Result<(), OrchestrationError>>,
+) -> Result<(), OrchestrationError> {
+    match handle.await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(err)) => Err(err),
+        Err(err) => Err(OrchestrationError::InternalError(Box::new(err))),
+    }
+}
 
 pub fn validate(input: Connection, tables: Option<Vec<TableInfo>>) -> Result<(), ConnectorError> {
     let connection_service = get_connector(input.clone())?;

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -4,7 +4,7 @@ use crate::utils::{
     get_api_dir, get_api_security_config, get_cache_dir, get_grpc_config, get_pipeline_config,
     get_pipeline_dir, get_rest_config,
 };
-use crate::Orchestrator;
+use crate::{flatten_joinhandle, Orchestrator};
 use dozer_api::auth::{Access, Authorizer};
 use dozer_api::{
     actix_web::dev::ServerHandle,
@@ -106,7 +106,7 @@ impl Orchestrator for SimpleOrchestrator {
             // Initialize API Server
             let rest_config = get_rest_config(self.config.to_owned());
             let security = get_api_security_config(self.config.to_owned());
-            tokio::spawn(async move {
+            let rest_handle = tokio::spawn(async move {
                 let api_server = rest::ApiServer::new(rest_config, security);
                 api_server
                     .run(cache_endpoints, tx)
@@ -132,13 +132,17 @@ impl Orchestrator for SimpleOrchestrator {
 
             let api_security = get_api_security_config(self.config.to_owned());
             let grpc_server = grpc::ApiServer::new(grpc_config, api_dir, api_security, flags);
-            tokio::spawn(async move {
+            let grpc_handle = tokio::spawn(async move {
                 grpc_server
                     .run(ce2, receiver_shutdown, rx1)
                     .await
                     .map_err(OrchestrationError::GrpcServerFailed)
             });
-        });
+            tokio::try_join!(
+                flatten_joinhandle(rest_handle),
+                flatten_joinhandle(grpc_handle)
+            )
+        })?;
 
         let server_handle = rx
             .recv()


### PR DESCRIPTION
Fix:  Error message when initialize Grpc/Rest should propagate in cli thread instead of silent running. E.g port already allocated