### PR TITLE
Chore/apply flags config

### DIFF
--- a/dozer-api/src/generator/protoc/generator.rs
+++ b/dozer-api/src/generator/protoc/generator.rs
@@ -208,7 +208,6 @@ impl<'a> ProtoGenerator<'a> {
     ) -> Result<(), GenerationError> {
         let generator = ProtoGenerator::new(details, folder_path, security, flags)?;
         generator._generate_proto()?;
-
         Ok(())
     }
 

--- a/dozer-api/src/generator/protoc/generator.rs
+++ b/dozer-api/src/generator/protoc/generator.rs
@@ -2,6 +2,7 @@ use crate::{errors::GenerationError, PipelineDetails};
 use dozer_cache::cache::Cache;
 use dozer_types::log::error;
 use dozer_types::models::api_security::ApiSecurity;
+use dozer_types::models::app_config::Flags;
 use dozer_types::serde::{self, Deserialize, Serialize};
 use dozer_types::types::FieldType;
 use handlebars::Handlebars;
@@ -22,6 +23,7 @@ pub struct ProtoMetadata {
     plural_pascal_name: String,
     pascal_name: String,
     enable_token: bool,
+    enable_on_event: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,6 +44,7 @@ pub struct ProtoGenerator<'a> {
     schema_name: String,
     folder_path: &'a Path,
     security: &'a Option<ApiSecurity>,
+    flags: &'a Option<Flags>,
 }
 
 fn safe_name(name: &str) -> String {
@@ -55,6 +58,7 @@ impl<'a> ProtoGenerator<'a> {
         pipeline_details: PipelineDetails,
         folder_path: &'a Path,
         security: &'a Option<ApiSecurity>,
+        flags: &'a Option<Flags>,
     ) -> Result<Self, GenerationError> {
         let cache = pipeline_details.cache_endpoint.cache.clone();
         let schema_name = safe_name(&pipeline_details.cache_endpoint.endpoint.name);
@@ -69,6 +73,7 @@ impl<'a> ProtoGenerator<'a> {
             schema_name,
             folder_path,
             security,
+            flags,
         };
         generator.register_template()?;
         Ok(generator)
@@ -146,6 +151,7 @@ impl<'a> ProtoGenerator<'a> {
             plural_pascal_name: self.schema_name.to_pascal_case().to_plural(),
             pascal_name: self.schema_name.to_pascal_case().to_singular(),
             enable_token: self.security.is_some(),
+            enable_on_event: self.flags.to_owned().unwrap_or_default().push_events,
         };
         Ok(metadata)
     }
@@ -198,8 +204,9 @@ impl<'a> ProtoGenerator<'a> {
         folder_path: &Path,
         details: PipelineDetails,
         security: &Option<ApiSecurity>,
+        flags: &Option<Flags>,
     ) -> Result<(), GenerationError> {
-        let generator = ProtoGenerator::new(details, folder_path, security)?;
+        let generator = ProtoGenerator::new(details, folder_path, security, flags)?;
         generator._generate_proto()?;
 
         Ok(())

--- a/dozer-api/src/generator/protoc/generator.rs
+++ b/dozer-api/src/generator/protoc/generator.rs
@@ -2,7 +2,7 @@ use crate::{errors::GenerationError, PipelineDetails};
 use dozer_cache::cache::Cache;
 use dozer_types::log::error;
 use dozer_types::models::api_security::ApiSecurity;
-use dozer_types::models::app_config::Flags;
+use dozer_types::models::flags::Flags;
 use dozer_types::serde::{self, Deserialize, Serialize};
 use dozer_types::types::FieldType;
 use handlebars::Handlebars;

--- a/dozer-api/src/generator/protoc/template/proto.tmpl
+++ b/dozer-api/src/generator/protoc/template/proto.tmpl
@@ -27,12 +27,14 @@ service {{plural_pascal_name}} {
    */
   rpc query(Query{{plural_pascal_name}}Request) returns (Query{{plural_pascal_name}}Response);
 
+  {{#if enable_on_event}}
   /**
    * Subscribes to the Dozer event stream, optionally applies a filter. See [Query](../query) for the filter format.
    *
    * This API is unstable and may change in the future.
    */
   rpc on_event({{pascal_name}}EventRequest) returns (stream {{pascal_name}}Event);
+  {{/if}}
   {{#if enable_token}}
   // Gets the authentication token.
   rpc token(TokenRequest) returns (TokenResponse);
@@ -57,6 +59,7 @@ message Query{{plural_pascal_name}}Response {
   repeated {{pascal_name}} data = 1;
 }
 
+{{#if enable_on_event}}
 // Request for `on_event`.
 message {{pascal_name}}EventRequest {
   // The event type to subscribe to.
@@ -64,7 +67,6 @@ message {{pascal_name}}EventRequest {
   // JSON filter string.
   optional string filter = 2;
 }
-
 // Response for `on_event`.
 message {{pascal_name}}Event {
   // The operation type.
@@ -74,7 +76,7 @@ message {{pascal_name}}Event {
   // New record data.
   optional {{pascal_name}} new = 3;
 }
-
+{{/if}}
 /**
  * {{pascal_name}} record type.
  * 

--- a/dozer-api/src/generator/protoc/tests.rs
+++ b/dozer-api/src/generator/protoc/tests.rs
@@ -1,7 +1,7 @@
 use super::generator::ProtoGenerator;
 use crate::generator::protoc::utils::{create_descriptor_set, get_proto_descriptor};
 use crate::{test_utils, CacheEndpoint, PipelineDetails};
-use dozer_types::models::api_security::ApiSecurity;
+use dozer_types::models::{api_security::ApiSecurity, app_config::Flags};
 use std::collections::HashMap;
 use tempdir::TempDir;
 
@@ -25,8 +25,9 @@ fn test_generate_proto_and_descriptor() {
     let tmp_dir = TempDir::new("proto_generated").unwrap();
     let tmp_dir_path = tmp_dir.path();
     let api_security: Option<ApiSecurity> = None;
+    let flags = Flags::default();
 
-    ProtoGenerator::generate(tmp_dir_path, details, &api_security).unwrap();
+    ProtoGenerator::generate(tmp_dir_path, details, &api_security,  &Some(flags)).unwrap();
 
     let descriptor_path = create_descriptor_set(tmp_dir_path, &[endpoint.name]).unwrap();
     let (_, descriptor) = get_proto_descriptor(&descriptor_path).unwrap();
@@ -67,8 +68,8 @@ fn test_generate_proto_and_descriptor_with_security() {
     let tmp_dir_path = tmp_dir.path();
 
     let api_security = Some(ApiSecurity::Jwt("vDKrSDOrVY".to_owned()));
-
-    ProtoGenerator::generate(tmp_dir_path, details, &api_security).unwrap();
+    let flags = Flags::default();
+    ProtoGenerator::generate(tmp_dir_path, details, &api_security, &Some(flags)).unwrap();
 
     let descriptor_path = create_descriptor_set(tmp_dir_path, &[endpoint.name]).unwrap();
     let (_, descriptor) = get_proto_descriptor(&descriptor_path).unwrap();

--- a/dozer-api/src/generator/protoc/tests.rs
+++ b/dozer-api/src/generator/protoc/tests.rs
@@ -88,7 +88,6 @@ fn test_generate_proto_and_descriptor_with_security() {
     );
 }
 
-
 #[test]
 fn test_generate_proto_and_descriptor_with_push_event_off() {
     let schema_name = "films".to_string();

--- a/dozer-api/src/generator/protoc/tests.rs
+++ b/dozer-api/src/generator/protoc/tests.rs
@@ -1,7 +1,8 @@
 use super::generator::ProtoGenerator;
 use crate::generator::protoc::utils::{create_descriptor_set, get_proto_descriptor};
 use crate::{test_utils, CacheEndpoint, PipelineDetails};
-use dozer_types::models::{api_security::ApiSecurity, app_config::Flags};
+use dozer_types::models::api_security::ApiSecurity;
+use dozer_types::models::flags::Flags;
 use prost_reflect::{MethodDescriptor, ServiceDescriptor};
 use std::collections::HashMap;
 use tempdir::TempDir;

--- a/dozer-api/src/generator/protoc/tests.rs
+++ b/dozer-api/src/generator/protoc/tests.rs
@@ -87,3 +87,51 @@ fn test_generate_proto_and_descriptor_with_security() {
         "Missing Token response generated with security config"
     );
 }
+
+
+#[test]
+fn test_generate_proto_and_descriptor_with_push_event_off() {
+    let schema_name = "films".to_string();
+    let schema = test_utils::get_schema();
+
+    let endpoint = test_utils::get_endpoint();
+
+    let mut map = HashMap::new();
+    let details = PipelineDetails {
+        schema_name: schema_name.clone(),
+        cache_endpoint: CacheEndpoint {
+            cache: test_utils::initialize_cache(&schema_name, Some(schema)),
+            endpoint: endpoint.clone(),
+        },
+    };
+    map.insert(schema_name, details.clone());
+    let tmp_dir = TempDir::new("proto_generated").unwrap();
+    let tmp_dir_path = String::from(tmp_dir.path().to_str().unwrap());
+    let api_security = ApiSecurity::Jwt("vDKrSDOrVY".to_owned());
+    let res = ProtoGenerator::generate(
+        tmp_dir_path,
+        endpoint.name,
+        details,
+        &Some(api_security),
+        &None,
+    )
+    .unwrap();
+    let msg = res
+        .descriptor
+        .get_message_by_name("dozer.generated.films.Film");
+    let token_response = res
+        .descriptor
+        .get_message_by_name("dozer.generated.films.TokenResponse");
+    let token_request = res
+        .descriptor
+        .get_message_by_name("dozer.generated.films.TokenRequest");
+    assert!(msg.is_some(), "descriptor is not decoded properly");
+    assert!(
+        token_request.is_some(),
+        "Missing Token request generated with security config"
+    );
+    assert!(
+        token_response.is_some(),
+        "Missing Token response generated with security config"
+    );
+}

--- a/dozer-api/src/grpc/client_server.rs
+++ b/dozer-api/src/grpc/client_server.rs
@@ -21,7 +21,7 @@ use dozer_types::{
     models::{
         api_config::{ApiGrpc, ApiPipelineInternal},
         api_security::ApiSecurity,
-        app_config::Flags,
+        flags::Flags,
     },
     types::Schema,
 };

--- a/dozer-orchestrator/src/cli/mod.rs
+++ b/dozer-orchestrator/src/cli/mod.rs
@@ -1,8 +1,6 @@
 mod helper;
 pub mod init;
 mod repl;
-#[cfg(test)]
-pub mod tests;
 pub mod types;
 pub use repl::configure;
 

--- a/dozer-orchestrator/src/cli/tests.rs
+++ b/dozer-orchestrator/src/cli/tests.rs
@@ -1,0 +1,302 @@
+use super::Config;
+use dozer_types::{
+    constants::DEFAULT_HOME_DIR,
+    models::{
+        api_config::{
+            default_api_config, ApiConfig, ApiGrpc, ApiInternal, ApiPipelineInternal, ApiRest,
+        },
+        api_endpoint::ApiEndpoint,
+        app_config::Flags,
+        connection::{Authentication, Connection, PostgresAuthentication},
+        source::{RefreshConfig, Source},
+    },
+    serde_yaml,
+};
+fn test_yml_content_full() -> (&'static str, Config) {
+    let test_connection = test_connection();
+    let test_source = test_source(test_connection.to_owned());
+    let api_endpoint = test_api_endpoint();
+    let api_config = test_api_config();
+    let flags = Some(Flags {
+        dynamic: true,
+        grpc_web: true,
+        push_events: false,
+    });
+    let config = Config {
+        app_name: "dozer-config-sample".to_owned(),
+        home_dir: DEFAULT_HOME_DIR.to_owned(),
+        api: Some(api_config),
+        connections: vec![test_connection],
+        sources: vec![test_source],
+        endpoints: vec![api_endpoint],
+        flags: flags,
+        ..Default::default()
+    };
+    (
+        r#"
+    app_name: dozer-config-sample
+    home_dir: './.dozer'
+    api:
+      rest:
+        port: 8080
+        host: "[::0]"
+        cors: true
+      grpc:
+        port: 50051
+        host: "[::0]"
+        cors: true
+        web: true
+      auth: false
+      api_internal:
+        port: 50052
+        host: '[::1]'
+        home_dir: './.dozer/api'
+      pipeline_internal:
+        port: 50053
+        host: '[::1]'
+        home_dir: './.dozer/pipeline'
+    flags:
+      grpc_web: true
+      dynamic: true
+      push_events: false
+    connections:
+      - db_type: Postgres
+        authentication: !Postgres
+          user: postgres
+          password: postgres
+          host: localhost
+          port: 5432
+          database: users
+        name: users
+    sources:
+      - name: users
+        table_name: users
+        columns:
+          - id
+          - email
+          - phone
+        connection: !Ref users
+    endpoints:
+      - id: null
+        name: users
+        path: /users
+        sql: select id, email, phone from users where 1=1;
+        index:
+          primary_key:
+            - id    
+    "#,
+        config,
+    )
+}
+fn test_yml_content_missing_api_config() -> &'static str {
+    r#"
+    app_name: dozer-config-sample
+    connections:
+      - db_type: Postgres
+        authentication: !Postgres
+          user: postgres
+          password: postgres
+          host: localhost
+          port: 5432
+          database: users
+        name: users
+    sources:
+      - name: users
+        table_name: users
+        columns:
+          - id
+          - email
+          - phone
+        connection: !Ref users
+    endpoints:
+      - id: null
+        name: users
+        path: /users
+        sql: select id, email, phone from users where 1=1;
+        index:
+          primary_key:
+            - id    
+    "#
+}
+fn test_yml_content_missing_internal_config() -> &'static str {
+    r#"
+    app_name: dozer-config-sample
+    api:
+      rest:
+        port: 8080
+        host: "[::0]"
+        cors: true
+      grpc:
+        port: 50051
+        host: "[::0]"
+        cors: true
+        web: true
+      auth: false
+    connections:
+      - db_type: Postgres
+        authentication: !Postgres
+          user: postgres
+          password: postgres
+          host: localhost
+          port: 5432
+          database: users
+        name: users
+    sources:
+      - name: users
+        table_name: users
+        columns:
+          - id
+          - email
+          - phone
+        connection: !Ref users
+    endpoints:
+      - id: null
+        name: users
+        path: /users
+        sql: select id, email, phone from users where 1=1;
+        index:
+          primary_key:
+            - id    
+    "#
+}
+
+fn test_connection() -> Connection {
+    Connection {
+        authentication: Some(Authentication::Postgres(PostgresAuthentication {
+            user: "postgres".to_owned(),
+            password: "postgres".to_owned(),
+            host: "localhost".to_owned(),
+            port: 5432,
+            database: "users".to_owned(),
+        })),
+        db_type: dozer_types::models::connection::DBType::Postgres as i32,
+        name: "users".to_owned(),
+        ..Default::default()
+    }
+}
+fn test_api_endpoint() -> ApiEndpoint {
+    ApiEndpoint {
+        name: "users".to_owned(),
+        path: "/users".to_owned(),
+        sql: "select id, email, phone from users where 1=1;".to_owned(),
+        index: Some(dozer_types::models::api_endpoint::ApiIndex {
+            primary_key: vec!["id".to_owned()],
+        }),
+        ..Default::default()
+    }
+}
+fn test_source(connection: Connection) -> Source {
+    Source {
+        id: None,
+        name: "users".to_owned(),
+        table_name: "users".to_owned(),
+        columns: vec!["id".to_owned(), "email".to_owned(), "phone".to_owned()],
+        connection: Some(connection),
+        refresh_config: Some(RefreshConfig::default()),
+        ..Default::default()
+    }
+}
+fn test_api_config() -> ApiConfig {
+    ApiConfig {
+        rest: Some(ApiRest {
+            port: 8080,
+            host: "[::0]".to_owned(),
+            cors: true,
+        }),
+        grpc: Some(ApiGrpc {
+            port: 50051,
+            host: "[::0]".to_owned(),
+            cors: true,
+            web: true,
+        }),
+        auth: false,
+        api_internal: Some(ApiInternal {
+            home_dir: format!("{:}/api", DEFAULT_HOME_DIR.to_owned()),
+        }),
+        pipeline_internal: Some(ApiPipelineInternal {
+            port: 50053,
+            host: "[::1]".to_owned(),
+            home_dir: format!("{:}/pipeline", DEFAULT_HOME_DIR.to_owned()),
+        }),
+        ..Default::default()
+    }
+}
+fn test_config() -> Config {
+    let test_connection = test_connection();
+    let test_source = test_source(test_connection.to_owned());
+    let api_endpoint = test_api_endpoint();
+    let api_config = test_api_config();
+    Config {
+        app_name: "dozer-config-sample".to_owned(),
+        home_dir: DEFAULT_HOME_DIR.to_owned(),
+        api: Some(api_config),
+        connections: vec![test_connection],
+        sources: vec![test_source],
+        endpoints: vec![api_endpoint],
+        ..Default::default()
+    }
+}
+#[test]
+fn test_deserialize_config() {
+    let test_full = test_yml_content_full();
+    let test_full_str = test_full.0;
+    let deserializer_result = serde_yaml::from_str::<Config>(test_full_str).unwrap();
+    let expected = test_full.1;
+    assert_eq!(deserializer_result.api, expected.api);
+    assert_eq!(deserializer_result.app_name, expected.app_name);
+    assert_eq!(deserializer_result.connections, expected.connections);
+    assert_eq!(deserializer_result.endpoints, expected.endpoints);
+    assert_eq!(deserializer_result.sources, expected.sources);
+    assert_eq!(deserializer_result, expected);
+}
+#[test]
+fn test_deserialize_default_api_config() {
+    let test_str = test_yml_content_missing_api_config();
+    let deserializer_result = serde_yaml::from_str::<Config>(test_str).unwrap();
+    let expected = test_config();
+    let default_api_config = default_api_config();
+    assert_eq!(deserializer_result.api, Some(default_api_config));
+    assert_eq!(deserializer_result.app_name, expected.app_name);
+    assert_eq!(deserializer_result.connections, expected.connections);
+    assert_eq!(deserializer_result.endpoints, expected.endpoints);
+    assert_eq!(deserializer_result.sources, expected.sources);
+    assert_eq!(deserializer_result, expected);
+}
+#[test]
+fn test_deserialize_yaml_missing_internal_config() {
+    let test_str = test_yml_content_missing_internal_config();
+    let deserializer_result = serde_yaml::from_str::<Config>(test_str).unwrap();
+    let expected = test_config();
+    let default_api_config = default_api_config();
+    assert_eq!(deserializer_result.api, Some(default_api_config.to_owned()));
+    assert_eq!(
+        deserializer_result
+            .api
+            .to_owned()
+            .unwrap()
+            .api_internal
+            .unwrap(),
+        default_api_config.api_internal.unwrap()
+    );
+    assert_eq!(
+        deserializer_result
+            .api
+            .to_owned()
+            .unwrap()
+            .pipeline_internal
+            .unwrap(),
+        default_api_config.pipeline_internal.unwrap()
+    );
+    assert_eq!(deserializer_result.app_name, expected.app_name);
+    assert_eq!(deserializer_result.connections, expected.connections);
+    assert_eq!(deserializer_result.endpoints, expected.endpoints);
+    assert_eq!(deserializer_result.sources, expected.sources);
+    assert_eq!(deserializer_result, expected);
+}
+#[test]
+fn test_serialize_config() {
+    let config = test_config();
+    let serialize_yml = serde_yaml::to_string(&config).unwrap();
+    let deserializer_result = serde_yaml::from_str::<Config>(&serialize_yml).unwrap();
+    assert_eq!(deserializer_result, config);
+}

--- a/dozer-orchestrator/src/pipeline/mod.rs
+++ b/dozer-orchestrator/src/pipeline/mod.rs
@@ -2,5 +2,5 @@ pub mod connector_source;
 mod sinks;
 pub mod source_builder;
 mod streaming_sink;
-pub use sinks::{CacheSink, CacheSinkFactory};
+pub use sinks::{CacheSink, CacheSinkFactory, CacheSinkSettings};
 pub(crate) use streaming_sink::StreamingSinkFactory;

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -216,8 +216,7 @@ impl SinkFactory for CacheSinkFactory {
         ProtoGenerator::generate(
             &self.generated_path,
             PipelineDetails {
-                schema_name: self.
-                api_endpoint.name.to_owned(),
+                schema_name: self.api_endpoint.name.to_owned(),
                 cache_endpoint: CacheEndpoint {
                     cache: self.cache.to_owned(),
                     endpoint: self.api_endpoint.to_owned(),

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -216,7 +216,8 @@ impl SinkFactory for CacheSinkFactory {
         ProtoGenerator::generate(
             &self.generated_path,
             PipelineDetails {
-                schema_name: self.api_endpoint.name.to_owned(),
+                schema_name: self.
+                api_endpoint.name.to_owned(),
                 cache_endpoint: CacheEndpoint {
                     cache: self.cache.to_owned(),
                     endpoint: self.api_endpoint.to_owned(),

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -19,6 +19,7 @@ use dozer_types::indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use dozer_types::log::debug;
 use dozer_types::models::api_endpoint::{ApiEndpoint, ApiIndex};
 use dozer_types::models::api_security::ApiSecurity;
+use dozer_types::models::app_config::Flags;
 use dozer_types::types::FieldType;
 use dozer_types::types::{IndexDefinition, Operation, Schema, SchemaIdentifier};
 use std::collections::hash_map::DefaultHasher;
@@ -57,6 +58,7 @@ pub struct CacheSinkFactory {
     generated_path: PathBuf,
     api_security: Option<ApiSecurity>,
     multi_pb: MultiProgress,
+    flags: Option<Flags>,
 }
 
 impl CacheSinkFactory {
@@ -68,6 +70,7 @@ impl CacheSinkFactory {
         generated_path: PathBuf,
         api_security: Option<ApiSecurity>,
         multi_pb: MultiProgress,
+        flags: Option<Flags>,
     ) -> Self {
         Self {
             input_ports,
@@ -77,6 +80,7 @@ impl CacheSinkFactory {
             generated_path,
             api_security,
             multi_pb,
+            flags,
         }
     }
 
@@ -219,6 +223,7 @@ impl SinkFactory for CacheSinkFactory {
                 },
             },
             &self.api_security,
+            &self.flags,
         )
         .map_err(|e| ExecutionError::InternalError(Box::new(e)))?;
 

--- a/dozer-orchestrator/src/simple/executor.rs
+++ b/dozer-orchestrator/src/simple/executor.rs
@@ -1,6 +1,7 @@
 use dozer_api::grpc::internal_grpc::PipelineResponse;
 use dozer_core::dag::app::{App, AppPipeline};
 use dozer_types::indicatif::MultiProgress;
+use dozer_types::models::app_config::Flags;
 use dozer_types::types::{Operation, SchemaWithChangesType};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -210,6 +211,7 @@ impl Executor {
         notifier: Option<crossbeam::channel::Sender<PipelineResponse>>,
         api_dir: PathBuf,
         api_security: Option<ApiSecurity>,
+        flags: Option<Flags>
     ) -> Result<dozer_core::dag::dag::Dag, OrchestrationError> {
         let grouped_connections = self.get_connection_groups();
 
@@ -235,6 +237,7 @@ impl Executor {
                     api_dir.clone(),
                     api_security.clone(),
                     self.progress.clone(),
+                    flags.clone(),
                 )),
                 cache_endpoint.endpoint.name.as_str(),
             );
@@ -300,10 +303,12 @@ impl Executor {
     pub fn run(
         &self,
         notifier: Option<crossbeam::channel::Sender<PipelineResponse>>,
+        api_security: Option<ApiSecurity>,
+        flags: Option<Flags>
     ) -> Result<(), OrchestrationError> {
         let running_wait = self.running.clone();
 
-        let parent_dag = self.build_pipeline(notifier, PathBuf::default(), None)?;
+        let parent_dag = self.build_pipeline(notifier, PathBuf::default(), api_security,flags)?;
         let path = &self.pipeline_dir;
 
         if !path.exists() {

--- a/dozer-orchestrator/src/simple/executor.rs
+++ b/dozer-orchestrator/src/simple/executor.rs
@@ -211,7 +211,7 @@ impl Executor {
         notifier: Option<crossbeam::channel::Sender<PipelineResponse>>,
         api_dir: PathBuf,
         api_security: Option<ApiSecurity>,
-        flags: Option<Flags>
+        flags: Option<Flags>,
     ) -> Result<dozer_core::dag::dag::Dag, OrchestrationError> {
         let grouped_connections = self.get_connection_groups();
 
@@ -304,11 +304,11 @@ impl Executor {
         &self,
         notifier: Option<crossbeam::channel::Sender<PipelineResponse>>,
         api_security: Option<ApiSecurity>,
-        flags: Option<Flags>
+        flags: Option<Flags>,
     ) -> Result<(), OrchestrationError> {
         let running_wait = self.running.clone();
 
-        let parent_dag = self.build_pipeline(notifier, PathBuf::default(), api_security,flags)?;
+        let parent_dag = self.build_pipeline(notifier, PathBuf::default(), api_security, flags)?;
         let path = &self.pipeline_dir;
 
         if !path.exists() {

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -186,7 +186,6 @@ impl Orchestrator for SimpleOrchestrator {
         api_notifier: Option<Sender<bool>>,
     ) -> Result<(), OrchestrationError> {
         let pipeline_home_dir = get_pipeline_dir(self.config.to_owned());
-
         // gRPC notifier channel
         let (sender, receiver) = channel::unbounded::<PipelineResponse>();
         let internal_app_config = self.config.to_owned();
@@ -218,7 +217,7 @@ impl Orchestrator for SimpleOrchestrator {
             running,
             pipeline_home_dir,
         );
-        executor.run(Some(sender))
+        executor.run(Some(sender), self.config.flags.to_owned())
     }
 
     fn list_connectors(
@@ -342,7 +341,7 @@ impl Orchestrator for SimpleOrchestrator {
         })?;
 
         let api_security = get_api_security_config(self.config.clone());
-        let dag = executor.build_pipeline(None, generated_path.clone(), api_security)?;
+        let dag = executor.build_pipeline(None, generated_path.clone(), api_security,  self.config.flags.to_owned())?;
         let schema_manager = DagSchemaManager::new(&dag)?;
         // Every sink will initialize its schema in sink and also in a proto file.
         schema_manager.prepare()?;

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -1,9 +1,10 @@
 use super::executor::Executor;
 use crate::console_helper::get_colored_text;
 use crate::errors::OrchestrationError;
+use crate::pipeline::CacheSinkSettings;
 use crate::utils::{
-    get_api_dir, get_api_security_config, get_cache_dir, get_grpc_config, get_pipeline_config,
-    get_pipeline_dir, get_rest_config,
+    get_api_dir, get_api_security_config, get_cache_dir, get_flags, get_grpc_config,
+    get_pipeline_config, get_pipeline_dir, get_rest_config,
 };
 use crate::{flatten_joinhandle, Orchestrator};
 use dozer_api::auth::{Access, Authorizer};
@@ -217,11 +218,10 @@ impl Orchestrator for SimpleOrchestrator {
             running,
             pipeline_home_dir,
         );
-        executor.run(
-            Some(sender),
-            self.config.api.to_owned().unwrap_or_default().api_security,
-            self.config.flags.to_owned(),
-        )
+        let flags = get_flags(self.config.clone());
+        let api_security = get_api_security_config(self.config.clone());
+        let settings = CacheSinkSettings::new(flags, api_security);
+        executor.run(Some(sender), settings)
     }
 
     fn list_connectors(
@@ -343,9 +343,10 @@ impl Orchestrator for SimpleOrchestrator {
                 e,
             )
         })?;
-
         let api_security = get_api_security_config(self.config.clone());
-        let dag = executor.build_pipeline(None, generated_path.clone(), api_security,  self.config.flags.to_owned())?;
+        let flags = get_flags(self.config.clone());
+        let settings = CacheSinkSettings::new(flags, api_security);
+        let dag = executor.build_pipeline(None, generated_path.clone(), settings)?;
         let schema_manager = DagSchemaManager::new(&dag)?;
         // Every sink will initialize its schema in sink and also in a proto file.
         schema_manager.prepare()?;

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -217,7 +217,11 @@ impl Orchestrator for SimpleOrchestrator {
             running,
             pipeline_home_dir,
         );
-        executor.run(Some(sender), self.config.flags.to_owned())
+        executor.run(
+            Some(sender),
+            self.config.api.to_owned().unwrap_or_default().api_security,
+            self.config.flags.to_owned(),
+        )
     }
 
     fn list_connectors(

--- a/dozer-orchestrator/src/simple/tests.rs
+++ b/dozer-orchestrator/src/simple/tests.rs
@@ -17,6 +17,7 @@ use dozer_types::{
     models::{
         self,
         api_endpoint::{ApiEndpoint, ApiIndex},
+        app_config::Flags,
         connection::EventsAuthentication,
     },
     types::{Field, OperationEvent, Record, Schema},
@@ -94,7 +95,8 @@ fn single_source_sink_impl(schema: Schema) {
             executor_running,
             tmp_path,
         );
-        match executor.run(None) {
+        let flags = Flags::default();
+        match executor.run(None, Some(flags)) {
             Ok(_) => {}
             Err(e) => warn!("Exiting: {:?}", e),
         }

--- a/dozer-orchestrator/src/simple/tests.rs
+++ b/dozer-orchestrator/src/simple/tests.rs
@@ -17,13 +17,15 @@ use dozer_types::{
     models::{
         self,
         api_endpoint::{ApiEndpoint, ApiIndex},
-        app_config::Flags,
         connection::EventsAuthentication,
+        flags::Flags,
     },
     types::{Field, OperationEvent, Record, Schema},
 };
 use serde_json::{json, Value};
 use tempdir::TempDir;
+
+use crate::pipeline::CacheSinkSettings;
 
 use super::executor::Executor;
 
@@ -96,7 +98,7 @@ fn single_source_sink_impl(schema: Schema) {
             tmp_path,
         );
         let flags = Flags::default();
-        match executor.run(None, None, Some(flags)) {
+        match executor.run(None, CacheSinkSettings::new(Some(flags), None)) {
             Ok(_) => {}
             Err(e) => warn!("Exiting: {:?}", e),
         }

--- a/dozer-orchestrator/src/simple/tests.rs
+++ b/dozer-orchestrator/src/simple/tests.rs
@@ -96,7 +96,7 @@ fn single_source_sink_impl(schema: Schema) {
             tmp_path,
         );
         let flags = Flags::default();
-        match executor.run(None, Some(flags)) {
+        match executor.run(None, None, Some(flags)) {
             Ok(_) => {}
             Err(e) => warn!("Exiting: {:?}", e),
         }

--- a/dozer-orchestrator/src/utils.rs
+++ b/dozer-orchestrator/src/utils.rs
@@ -35,6 +35,10 @@ pub fn get_api_security_config(config: Config) -> Option<ApiSecurity> {
     get_api_config(config).api_security
 }
 
+pub fn get_flags(config: Config) -> Option<dozer_types::models::flags::Flags> {
+    config.flags
+}
+
 pub fn get_repl_history_path(config: &Config) -> PathBuf {
     PathBuf::from(format!("{:}/history.txt", config.home_dir))
 }

--- a/dozer-types/src/models/app_config.rs
+++ b/dozer-types/src/models/app_config.rs
@@ -78,7 +78,7 @@ impl<'de> Deserialize<'de> for Config {
                 A: serde::de::MapAccess<'de>,
             {
                 let mut api: Option<ApiConfig> = Some(default_api_config());
-                let mut flags: Option<Flags> = Some(Default::default());
+                let mut flags: Option<Flags> = None;
                 let mut connections: Vec<Connection> = vec![];
                 let mut sources_value: Vec<serde_yaml::Value> = vec![];
                 let mut endpoints: Vec<ApiEndpoint> = vec![];

--- a/dozer-types/src/models/app_config.rs
+++ b/dozer-types/src/models/app_config.rs
@@ -1,5 +1,6 @@
 use super::{
-    api_config::ApiConfig, api_endpoint::ApiEndpoint, connection::Connection, source::Source,
+    api_config::ApiConfig, api_endpoint::ApiEndpoint, connection::Connection, flags::Flags,
+    source::Source,
 };
 use crate::{constants::DEFAULT_HOME_DIR, models::api_config::default_api_config};
 use serde::{
@@ -38,24 +39,6 @@ pub struct Config {
     pub flags: Option<Flags>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, prost::Message)]
-pub struct Flags {
-    /// dynamic grpc enabled; Default: true
-    #[prost(bool, tag = "1", default = true)]
-    pub dynamic: bool,
-    /// http1 + web support for grpc. This is required for browser clients.; Default: true
-    #[prost(bool, tag = "2", default = true)]
-    pub grpc_web: bool,
-
-    /// push events enabled. Currently unstable.; Default: false
-    #[prost(bool, tag = "3", default = false)]
-    pub push_events: bool,
-
-    /// require authentication to access grpc server reflection service if true.; Default: false
-    #[prost(bool, tag = "4", default = false)]
-    pub authenticate_server_reflection: bool,
-}
-
 pub fn default_home_dir() -> String {
     DEFAULT_HOME_DIR.to_owned()
 }
@@ -78,7 +61,7 @@ impl<'de> Deserialize<'de> for Config {
                 A: serde::de::MapAccess<'de>,
             {
                 let mut api: Option<ApiConfig> = Some(default_api_config());
-                let mut flags: Option<Flags> = None;
+                let mut flags: Option<Flags> = Some(Flags::default());
                 let mut connections: Vec<Connection> = vec![];
                 let mut sources_value: Vec<serde_yaml::Value> = vec![];
                 let mut endpoints: Vec<ApiEndpoint> = vec![];

--- a/dozer-types/src/models/flags.rs
+++ b/dozer-types/src/models/flags.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, prost::Message)]
+pub struct Flags {
+    /// dynamic grpc enabled; Default: true
+    #[prost(bool, tag = "1", default = true)]
+    #[serde(default = "default_true")]
+    pub dynamic: bool,
+    /// http1 + web support for grpc. This is required for browser clients.; Default: true
+    #[prost(bool, tag = "2", default = true)]
+    #[serde(default = "default_true")]
+    pub grpc_web: bool,
+
+    /// push events enabled. Currently unstable.; Default: false
+    #[prost(bool, tag = "3", default = false)]
+    #[serde(default = "default_false")]
+    pub push_events: bool,
+
+    /// require authentication to access grpc server reflection service if true.; Default: false
+    #[prost(bool, tag = "4", default = false)]
+    #[serde(default = "default_false")]
+    pub authenticate_server_reflection: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+fn default_false() -> bool {
+    false
+}

--- a/dozer-types/src/models/mod.rs
+++ b/dozer-types/src/models/mod.rs
@@ -3,4 +3,5 @@ pub mod api_endpoint;
 pub mod api_security;
 pub mod app_config;
 pub mod connection;
+pub mod flags;
 pub mod source;

--- a/dozer-types/src/tests.rs
+++ b/dozer-types/src/tests.rs
@@ -7,4 +7,6 @@ mod eth_yaml_deserialize;
 #[cfg(test)]
 mod field_serialize_test;
 #[cfg(test)]
+mod flags_config_yaml_deserialize;
+#[cfg(test)]
 mod postgres_yaml_deserialize;

--- a/dozer-types/src/tests/flags_config_yaml_deserialize.rs
+++ b/dozer-types/src/tests/flags_config_yaml_deserialize.rs
@@ -13,9 +13,9 @@ fn test_full_flag_config_input() {
 
     assert!(deserializer_result.flags.is_some());
     let flags_deserialize = deserializer_result.flags.unwrap();
-    assert_eq!(flags_deserialize.dynamic, true);
-    assert_eq!(flags_deserialize.grpc_web, false);
-    assert_eq!(flags_deserialize.push_events, false);
+    assert!(flags_deserialize.dynamic);
+    assert!(!flags_deserialize.grpc_web);
+    assert!(!flags_deserialize.push_events);
 }
 
 #[test]

--- a/dozer-types/src/tests/flags_config_yaml_deserialize.rs
+++ b/dozer-types/src/tests/flags_config_yaml_deserialize.rs
@@ -1,7 +1,7 @@
-use crate::models::app_config::Config;
+use crate::models::{app_config::Config, flags::Flags};
 
 #[test]
-fn test_full_flag_config_input() {
+fn test_partial_flag_config_input() {
     let input_config_with_flag = r#"
   app_name: working_app
   flags:
@@ -10,29 +10,16 @@ fn test_full_flag_config_input() {
     push_events: false
 "#;
     let deserializer_result = serde_yaml::from_str::<Config>(input_config_with_flag).unwrap();
-
+    let default_flags = Flags::default();
     assert!(deserializer_result.flags.is_some());
     let flags_deserialize = deserializer_result.flags.unwrap();
     assert!(flags_deserialize.dynamic);
     assert!(!flags_deserialize.grpc_web);
     assert!(!flags_deserialize.push_events);
-}
-
-#[test]
-fn test_flag_config_missing_field_should_throw_error() {
-    let input_config_with_flag = r#"
-  app_name: working_app
-  flags:
-    dynamic: true
-    push_events: false
-"#;
-    let deserializer_result = serde_yaml::from_str::<Config>(input_config_with_flag);
-    assert!(deserializer_result.is_err());
-    assert!(deserializer_result
-        .err()
-        .unwrap()
-        .to_string()
-        .starts_with("flags: missing field `grpc_web`"));
+    assert_eq!(
+        flags_deserialize.authenticate_server_reflection,
+        default_flags.authenticate_server_reflection,
+    );
 }
 
 #[test]
@@ -41,5 +28,7 @@ fn test_config_without_flag_config() {
   app_name: working_app
 "#;
     let deserializer_result = serde_yaml::from_str::<Config>(input_config_without_flag).unwrap();
-    assert!(deserializer_result.flags.is_none());
+    let default_flags = Flags::default();
+    assert!(deserializer_result.flags.is_some());
+    assert_eq!(deserializer_result.flags, Some(default_flags));
 }

--- a/dozer-types/src/tests/flags_config_yaml_deserialize.rs
+++ b/dozer-types/src/tests/flags_config_yaml_deserialize.rs
@@ -5,7 +5,6 @@ fn test_partial_flag_config_input() {
     let input_config_with_flag = r#"
   app_name: working_app
   flags:
-    dynamic: true
     grpc_web: false
     push_events: false
 "#;
@@ -20,6 +19,7 @@ fn test_partial_flag_config_input() {
         flags_deserialize.authenticate_server_reflection,
         default_flags.authenticate_server_reflection,
     );
+    assert_eq!(flags_deserialize.dynamic, default_flags.dynamic);
 }
 
 #[test]

--- a/dozer-types/src/tests/flags_config_yaml_deserialize.rs
+++ b/dozer-types/src/tests/flags_config_yaml_deserialize.rs
@@ -1,0 +1,45 @@
+use crate::models::app_config::Config;
+
+#[test]
+fn test_full_flag_config_input() {
+    let input_config_with_flag = r#"
+  app_name: working_app
+  flags:
+    dynamic: true
+    grpc_web: false
+    push_events: false
+"#;
+    let deserializer_result = serde_yaml::from_str::<Config>(input_config_with_flag).unwrap();
+
+    assert!(deserializer_result.flags.is_some());
+    let flags_deserialize = deserializer_result.flags.unwrap();
+    assert_eq!(flags_deserialize.dynamic, true);
+    assert_eq!(flags_deserialize.grpc_web, false);
+    assert_eq!(flags_deserialize.push_events, false);
+}
+
+#[test]
+fn test_flag_config_missing_field_should_throw_error() {
+    let input_config_with_flag = r#"
+  app_name: working_app
+  flags:
+    dynamic: true
+    push_events: false
+"#;
+    let deserializer_result = serde_yaml::from_str::<Config>(input_config_with_flag);
+    assert!(deserializer_result.is_err());
+    assert!(deserializer_result
+        .err()
+        .unwrap()
+        .to_string()
+        .starts_with("flags: missing field `grpc_web`"));
+}
+
+#[test]
+fn test_config_without_flag_config() {
+    let input_config_without_flag = r#"
+  app_name: working_app
+"#;
+    let deserializer_result = serde_yaml::from_str::<Config>(input_config_without_flag).unwrap();
+    assert!(deserializer_result.flags.is_none());
+}


### PR DESCRIPTION
- [x] Support deserializing `flags` config from `dozer-config.yaml` and propagating to pipeline
  - `flags` have default value, any subset properties defined in yaml will override it
 
- [x] if flag `push_events` is `false` proto generator shouldn't generate `on_event` method
- [x] suppress clippy complain `too_many_arguments` in CacheSinkFactory - combine arguments related to `Flag + ApiSecurity` into new struct `CacheSinkSettings`