### PR TITLE
Revert "Bump chrono from 0.4.22 to 0.4.23 (#697)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,9 +793,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = {version = "0.4.23", features = ["serde"]}
+chrono = {version = "0.4.0", features = ["serde"]}
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.91"
 rust_decimal =  {version = "1.27", features = ["serde-float", "db-postgres"]}


### PR DESCRIPTION
This reverts commit 118d0fa5e4b7d28348fc06a7e38cacd6fda683be.