### PR TITLE
fix: `cargo doc -F snowflake` fails because of `include_dir`

### DIFF
--- a/dozer-ingestion/src/test_util.rs
+++ b/dozer-ingestion/src/test_util.rs
@@ -1,8 +1,5 @@
 use include_dir::{include_dir, Dir};
-#[cfg(not(doc))]
 static TESTS_CONFIG_DIR: Dir<'_> = include_dir!("config/tests/local");
-#[cfg(doc)]
-static TESTS_CONFIG_DIR: Dir<'_> = include_dir!("../config/tests/local");
 
 pub fn load_config(file_name: &str) -> &str {
     TESTS_CONFIG_DIR


### PR DESCRIPTION
With this code `cargo doc -F snowflake` and `cargo test` both pass.

On `main` `cargo doc -F snowflake` fails and `cargo test` passes.