### PR TITLE
fix: Remove debugging code that sets channel capacity to 1

### DIFF
--- a/dozer-core/src/dag/executor.rs
+++ b/dozer-core/src/dag/executor.rs
@@ -257,8 +257,7 @@ impl<'a, T: Clone + 'a + 'static> DagExecutor<'a, T> {
         epoch_manager: Arc<EpochManager>,
         start_barrier: Arc<Barrier>,
     ) -> Result<JoinHandle<()>, ExecutionError> {
-        // let (sender, receiver) = bounded(self.options.channel_buffer_sz);
-        let (sender, receiver) = bounded(1);
+        let (sender, receiver) = bounded(self.options.channel_buffer_sz);
 
         let start_seq = *self
             .consistency_metadata


### PR DESCRIPTION
Before

`cargo test -p dozer-core test_checpoint_consistency_ns  4.66s user 2.53s system 358% cpu 2.008 total`

After

`cargo test -p dozer-core test_checpoint_consistency_ns  2.30s user 0.16s system 242% cpu 1.014 total`

We really need to keep commit sizes small so this kind of bug doesn't slip from the eye of the reviewer.