### PR TITLE
refactor: Don't try to get schema of unconnected ports

### DIFF
--- a/dozer-core/src/dag/errors.rs
+++ b/dozer-core/src/dag/errors.rs
@@ -15,8 +15,10 @@ pub enum ExecutionError {
     InvalidPortHandle(PortHandle),
     #[error("Invalid node handle: {0}")]
     InvalidNodeHandle(NodeHandle),
-    #[error("Missing input for node {node}")]
-    MissingInput { node: NodeHandle },
+    #[error("Missing input for node {node} on port {port}")]
+    MissingInput { node: NodeHandle, port: PortHandle },
+    #[error("Duplicate input for node {node} on port {port}")]
+    DuplicateInput { node: NodeHandle, port: PortHandle },
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
     #[error("Schema not initialized")]

--- a/dozer-core/src/dag/executor.rs
+++ b/dozer-core/src/dag/executor.rs
@@ -16,7 +16,7 @@ use dozer_types::types::{Operation, Record, Schema};
 use crate::dag::epoch::{Epoch, EpochManager};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::panic::panic_any;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -106,7 +106,7 @@ pub struct DagExecutor<'a, T: Clone> {
     consistency_metadata: HashMap<NodeHandle, Option<OpIdentifier>>,
 }
 
-impl<'a, T: Clone + 'a + 'static> DagExecutor<'a, T> {
+impl<'a, T: Clone + Debug + 'static> DagExecutor<'a, T> {
     fn check_consistency(
         dag: &'a Dag<T>,
         path: &Path,
@@ -211,22 +211,22 @@ impl<'a, T: Clone + 'a + 'static> DagExecutor<'a, T> {
         let current_schemas = dag_schemas.get_all_schemas();
         match meta_manager.get_metadata() {
             Ok(existing_schemas) => {
-                for (handle, current) in current_schemas {
+                for (handle, current) in &current_schemas {
                     if let Some(existing) = existing_schemas.get(handle) {
                         Self::validate_schemas(current, existing)?;
                     } else {
                         meta_manager.delete_metadata();
-                        meta_manager.init_metadata(current_schemas)?;
+                        meta_manager.init_metadata(&current_schemas)?;
                     }
                 }
             }
             Err(_) => {
                 meta_manager.delete_metadata();
-                meta_manager.init_metadata(current_schemas)?;
+                meta_manager.init_metadata(&current_schemas)?;
             }
         };
 
-        Ok(current_schemas.clone())
+        Ok(current_schemas)
     }
 
     fn start_source(

--- a/dozer-core/src/dag/executor_utils.rs
+++ b/dozer-core/src/dag/executor_utils.rs
@@ -140,7 +140,7 @@ pub(crate) fn create_ports_databases_and_fill_downstream_record_readers(
                 Some(StateOptions {
                     db,
                     meta_db,
-                    typ: typ.clone(),
+                    typ: *typ,
                 })
             }
         };

--- a/dozer-core/src/dag/forwarder.rs
+++ b/dozer-core/src/dag/forwarder.rs
@@ -36,19 +36,16 @@ impl StateWriter {
     ) -> Result<Self, ExecutionError> {
         let mut record_writers = HashMap::<PortHandle, Box<dyn RecordWriter>>::new();
         for (port, options) in dbs {
-            let schema = output_schemas
-                .get(&port)
-                .ok_or(ExecutionError::InvalidPortHandle(port))?
-                .clone();
-
-            let writer = RecordWriterUtils::create_writer(
-                options.typ,
-                options.db,
-                options.meta_db,
-                schema,
-                retention_queue_size,
-            )?;
-            record_writers.insert(port, writer);
+            if let Some(schema) = output_schemas.get(&port) {
+                let writer = RecordWriterUtils::create_writer(
+                    options.typ,
+                    options.db,
+                    options.meta_db,
+                    schema.clone(),
+                    retention_queue_size,
+                )?;
+                record_writers.insert(port, writer);
+            }
         }
 
         Ok(Self {

--- a/dozer-core/src/dag/node.rs
+++ b/dozer-core/src/dag/node.rs
@@ -68,7 +68,7 @@ impl Display for NodeHandle {
 
 pub type PortHandle = u16;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum OutputPortType {
     Stateless,
     StatefulWithPrimaryKeyLookup {

--- a/dozer-core/src/dag/tests/app.rs
+++ b/dozer-core/src/dag/tests/app.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use tempdir::TempDir;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct NoneContext {}
 
 #[derive(Debug)]

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -19,7 +19,7 @@ use dozer_api::{
 };
 use dozer_cache::cache::{CacheCommonOptions, CacheOptions, CacheReadOptions, CacheWriteOptions};
 use dozer_cache::cache::{CacheOptionsKind, LmdbCache};
-use dozer_core::dag::dag_schemas::{prepare_dag, DagSchemas};
+use dozer_core::dag::dag_schemas::DagSchemas;
 use dozer_core::dag::errors::ExecutionError::InternalError;
 use dozer_ingestion::ingestion::IngestionConfig;
 use dozer_ingestion::ingestion::Ingestor;
@@ -273,9 +273,9 @@ impl Orchestrator for SimpleOrchestrator {
 
         let dag = executor.query(sql, sender)?;
         let dag_schemas = DagSchemas::new(&dag)?;
-        let streaming_sink_handle = dag.sinks().next().expect("Sink is expected").0;
+        let streaming_sink_index = dag.sink_identifiers().next().expect("Sink is expected");
         let (schema, _ctx) = dag_schemas
-            .get_node_input_schemas(streaming_sink_handle)?
+            .get_node_input_schemas(streaming_sink_index)
             .values()
             .next()
             .expect("schema is expected")
@@ -349,7 +349,7 @@ impl Orchestrator for SimpleOrchestrator {
         let dag = executor.build_pipeline(None, generated_path.clone(), settings)?;
         let dag_schemas = DagSchemas::new(&dag)?;
         // Every sink will initialize its schema in sink and also in a proto file.
-        prepare_dag(&dag, &dag_schemas)?;
+        dag_schemas.prepare()?;
 
         let mut resources = Vec::new();
         for e in &self.config.endpoints {

--- a/dozer-tests/src/sql_tests/pipeline.rs
+++ b/dozer-tests/src/sql_tests/pipeline.rs
@@ -1,7 +1,7 @@
 use dozer_core::dag::app::App;
 use dozer_core::dag::appsource::{AppSource, AppSourceManager};
 use dozer_core::dag::channels::SourceChannelForwarder;
-use dozer_core::dag::dag_schemas::{prepare_dag, DagSchemas};
+use dozer_core::dag::dag_schemas::DagSchemas;
 use dozer_core::dag::errors::ExecutionError;
 use dozer_core::dag::node::{
     OutputPortDef, OutputPortType, PortHandle, Sink, SinkFactory, Source, SourceFactory,
@@ -321,10 +321,10 @@ impl TestPipeline {
         let dag = app.get_dag().unwrap();
 
         let dag_schemas = DagSchemas::new(&dag)?;
-        prepare_dag(&dag, &dag_schemas)?;
-        let streaming_sink_handle = dag.sinks().next().expect("Sink is expected").0;
+        dag_schemas.prepare()?;
+        let streaming_sink_index = dag.sink_identifiers().next().expect("Sink is expected");
         let (schema, _) = dag_schemas
-            .get_node_input_schemas(streaming_sink_handle)?
+            .get_node_input_schemas(streaming_sink_index)
             .values()
             .next()
             .expect("schema is expected")


### PR DESCRIPTION
This PR merges `Dag` and `DagSchema` to a single struct `DagSchema`, and keeps the schema information on the edges, for convenient future use.

A side effect is that, now if an output port is not used (not connected to any input port), we won't try to get its schema.

I'm not sure if it's the behaviour we want? @snork-alt 