### PR TITLE
refactor: Split execution dag construction and execution

### DIFF
--- a/dozer-core/src/dag_metadata.rs
+++ b/dozer-core/src/dag_metadata.rs
@@ -53,7 +53,7 @@ impl<'a, T: Clone + 'a> DagMetadataManager<'a, T> {
         path: &Path,
         name: &NodeHandle,
     ) -> Result<Option<DagMetadata>, ExecutionError> {
-        let env_name = metadata_environment_name(name);
+        let env_name = node_environment_name(name);
         if !LmdbEnvironmentManager::exists(path, &env_name) {
             return Ok(None);
         }
@@ -184,7 +184,7 @@ impl<'a, T: Clone + 'a> DagMetadataManager<'a, T> {
 
     pub(crate) fn delete_metadata(&self) {
         for node in self.dag.node_handles() {
-            LmdbEnvironmentManager::remove(self.path, &metadata_environment_name(node));
+            LmdbEnvironmentManager::remove(self.path, &node_environment_name(node));
         }
     }
 
@@ -201,7 +201,7 @@ impl<'a, T: Clone + 'a> DagMetadataManager<'a, T> {
                 .get(node)
                 .ok_or_else(|| InvalidNodeHandle(node.clone()))?;
 
-            let env_name = metadata_environment_name(node);
+            let env_name = node_environment_name(node);
             if LmdbEnvironmentManager::exists(self.path, &env_name) {
                 return Err(MetadataAlreadyExists(node.clone()));
             }
@@ -242,7 +242,7 @@ impl<'a, T: Clone + 'a> DagMetadataManager<'a, T> {
     }
 }
 
-fn metadata_environment_name(node_handle: &NodeHandle) -> String {
+pub fn node_environment_name(node_handle: &NodeHandle) -> String {
     format!("{node_handle}")
 }
 

--- a/dozer-core/src/epoch.rs
+++ b/dozer-core/src/epoch.rs
@@ -79,7 +79,7 @@ enum EpochManagerState {
 }
 
 #[derive(Debug)]
-pub(crate) struct EpochManager {
+pub struct EpochManager {
     num_sources: usize,
     state: Mutex<EpochManagerState>,
 }

--- a/dozer-core/src/executor/execution_dag.rs
+++ b/dozer-core/src/executor/execution_dag.rs
@@ -1,0 +1,297 @@
+use std::{
+    borrow::BorrowMut,
+    cell::RefCell,
+    collections::{hash_map::Entry, HashMap},
+    fmt::Debug,
+    path::Path,
+    rc::Rc,
+    sync::Arc,
+};
+
+use crossbeam::channel::{bounded, Receiver, Sender};
+use daggy::petgraph::{
+    visit::{EdgeRef, IntoEdges, IntoEdgesDirected, IntoNodeReferences},
+    Direction,
+};
+use dozer_storage::{lmdb::Database, lmdb_storage::SharedTransaction};
+
+use crate::{
+    dag_schemas::{DagHaveSchemas, DagSchemas},
+    epoch::EpochManager,
+    errors::ExecutionError,
+    executor_utils::init_component,
+    hash_map_to_vec::insert_vec_element,
+    node::{NodeHandle, PortHandle, Processor, Sink, Source},
+    record_store::{create_record_store, RecordReader, RecordWriter},
+    NodeKind as DagNodeKind,
+};
+
+use super::ExecutorOperation;
+
+#[derive(Debug)]
+/// Node in the execution DAG.
+pub struct NodeType {
+    /// The node storage environment.
+    pub storage: NodeStorage,
+    /// The node kind. Will be moved to execution node.
+    pub kind: Option<NodeKind>,
+}
+
+#[derive(Debug, Clone)]
+/// A node's storage environment.
+pub struct NodeStorage {
+    /// Name of the node.
+    pub handle: NodeHandle,
+    pub master_tx: SharedTransaction,
+    pub meta_db: Database,
+}
+
+#[derive(Debug)]
+/// Node kind, source, processor or sink.
+pub enum NodeKind {
+    Source(Box<dyn Source>),
+    Processor(Box<dyn Processor>),
+    Sink(Box<dyn Sink>),
+}
+
+pub type SharedRecordWriter = Rc<RefCell<Option<Box<dyn RecordWriter>>>>;
+
+#[derive(Debug, Clone)]
+pub struct EdgeType {
+    /// Output port handle.
+    pub output_port: PortHandle,
+    /// The sender for data flowing downstream.
+    pub sender: Sender<ExecutorOperation>,
+    /// The record writer for persisting data for downstream queries, if persistency is needed. Different edges with the same output port share the same record writer.
+    pub record_writer: SharedRecordWriter,
+    /// Input port handle.
+    pub input_port: PortHandle,
+    /// The receiver from receiving data from upstream.
+    pub receiver: Receiver<ExecutorOperation>,
+    /// The record reader for reading persisted data of corresponding output port, if there's some.
+    pub record_reader: Option<Box<dyn RecordReader>>,
+}
+
+#[derive(Debug)]
+pub struct ExecutionDag {
+    graph: daggy::Dag<NodeType, EdgeType>,
+    epoch_manager: Arc<EpochManager>,
+}
+
+impl ExecutionDag {
+    pub fn new<T: Clone>(
+        dag_schemas: &DagSchemas<T>,
+        base_path: &Path,
+        channel_buf_sz: usize,
+    ) -> Result<Self, ExecutionError> {
+        let dag = &dag_schemas.graph;
+
+        // Create new nodes.
+        let mut nodes = vec![];
+        let mut num_sources = 0;
+        for (node_index, node) in dag.node_references() {
+            let input_schemas = dag_schemas.get_node_input_schemas(node_index);
+            let input_schemas = input_schemas
+                .into_iter()
+                .map(|(key, value)| (key, value.0))
+                .collect();
+            let output_schemas = dag_schemas.get_node_output_schemas(node_index);
+            let output_schemas = output_schemas
+                .into_iter()
+                .map(|(key, value)| (key, value.0))
+                .collect();
+
+            let (storage_metadata, node_kind) = match &node.kind {
+                DagNodeKind::Source(source) => {
+                    num_sources += 1;
+                    let source = source.build(output_schemas)?;
+                    (
+                        init_component(&node.handle, base_path, |_| Ok(()))?,
+                        NodeKind::Source(source),
+                    )
+                }
+                DagNodeKind::Processor(processor) => {
+                    let mut processor = processor.build(input_schemas, output_schemas)?;
+                    (
+                        init_component(&node.handle, base_path, |state| processor.init(state))?,
+                        NodeKind::Processor(processor),
+                    )
+                }
+                DagNodeKind::Sink(sink) => {
+                    let mut sink = sink.build(input_schemas)?;
+                    (
+                        init_component(&node.handle, base_path, |state| sink.init(state))?,
+                        NodeKind::Sink(sink),
+                    )
+                }
+            };
+
+            let master_tx = storage_metadata.env.create_txn()?;
+
+            let node_storage = NodeStorage {
+                handle: node.handle.clone(),
+                master_tx,
+                meta_db: storage_metadata.meta_db,
+            };
+
+            nodes.push(Some(NodeType {
+                storage: node_storage,
+                kind: Some(node_kind),
+            }));
+        }
+
+        // We only create record stored once for every output port. Every `HashMap` in this `Vec` tracks if a node's output ports already have the record store created.
+        let mut all_record_stores =
+            vec![
+                HashMap::<PortHandle, (SharedRecordWriter, Option<Box<dyn RecordReader>>)>::new();
+                dag.node_count()
+            ];
+
+        // Create new edges.
+        let mut edges = vec![];
+        for dag_schema_edge in dag.raw_edges().iter() {
+            let source_node_index = dag_schema_edge.source().index();
+            let edge = &dag_schema_edge.weight;
+            let output_port = dag_schema_edge.weight.output_port;
+
+            // Create or get record store.
+            let (record_writer, record_reader) =
+                match all_record_stores[source_node_index].entry(output_port) {
+                    Entry::Vacant(entry) => {
+                        let record_store = create_record_store(
+                            &nodes[source_node_index]
+                                .as_ref()
+                                .expect("We created all nodes")
+                                .storage
+                                .master_tx,
+                            output_port,
+                            edge.output_port_type,
+                            edge.schema.clone(),
+                            channel_buf_sz + 1,
+                        )?;
+                        let (record_writer, record_reader) =
+                            if let Some((record_writer, record_reader)) = record_store {
+                                (
+                                    Rc::new(RefCell::new(Some(record_writer))),
+                                    Some(record_reader),
+                                )
+                            } else {
+                                (Rc::new(RefCell::new(None)), None)
+                            };
+                        entry.insert((record_writer, record_reader)).clone()
+                    }
+                    Entry::Occupied(entry) => entry.get().clone(),
+                };
+
+            // Create channel.
+            let (sender, receiver) = bounded(channel_buf_sz);
+
+            // Create edge.
+            let edge = EdgeType {
+                output_port,
+                sender,
+                record_writer,
+                input_port: edge.input_port,
+                receiver,
+                record_reader,
+            };
+            edges.push(Some(edge));
+        }
+
+        // Create new graph.
+        let graph = dag.map(
+            |node_index, _| {
+                nodes[node_index.index()]
+                    .take()
+                    .expect("We created all nodes")
+            },
+            |edge_index, _| {
+                edges[edge_index.index()]
+                    .take()
+                    .expect("We created all edges")
+            },
+        );
+        Ok(ExecutionDag {
+            graph,
+            epoch_manager: Arc::new(EpochManager::new(num_sources)),
+        })
+    }
+
+    pub fn graph_mut(&mut self) -> &mut daggy::Dag<NodeType, EdgeType> {
+        &mut self.graph
+    }
+
+    pub fn epoch_manager(&self) -> &Arc<EpochManager> {
+        &self.epoch_manager
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn collect_senders_and_record_writers(
+        &mut self,
+        node_index: daggy::NodeIndex,
+    ) -> (
+        HashMap<PortHandle, Vec<Sender<ExecutorOperation>>>,
+        HashMap<PortHandle, Box<dyn RecordWriter>>,
+    ) {
+        let edge_indexes = self
+            .graph
+            .edges(node_index)
+            .map(|edge| edge.id())
+            .collect::<Vec<_>>();
+
+        let mut senders = HashMap::new();
+        let mut record_writers = HashMap::new();
+        for edge_index in edge_indexes {
+            let edge = self
+                .graph
+                .edge_weight_mut(edge_index)
+                .expect("We don't modify graph structure, only modify the edge weight");
+            insert_vec_element(&mut senders, edge.output_port, edge.sender.clone());
+            if let Entry::Vacant(entry) = record_writers.entry(edge.output_port) {
+                // This interior mutability is to word around `Rc`. Other parts of this function is correctly marked `mut`.
+                if let Some(record_writer) = edge.record_writer.borrow_mut().take() {
+                    entry.insert(record_writer);
+                }
+            }
+        }
+
+        (senders, record_writers)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn collect_receivers_and_record_readers(
+        &mut self,
+        node_index: daggy::NodeIndex,
+    ) -> (
+        Vec<PortHandle>,
+        Vec<Receiver<ExecutorOperation>>,
+        HashMap<PortHandle, Box<dyn RecordReader>>,
+    ) {
+        let edge_indexes = self
+            .graph
+            .edges_directed(node_index, Direction::Incoming)
+            .map(|edge| edge.id())
+            .collect::<Vec<_>>();
+
+        let mut input_ports = Vec::new();
+        let mut receivers = Vec::new();
+        let mut record_readers = HashMap::new();
+        for edge_index in edge_indexes {
+            let edge = self
+                .graph
+                .edge_weight_mut(edge_index)
+                .expect("We don't modify graph structure, only modify the edge weight");
+            input_ports.push(edge.input_port);
+            receivers.push(edge.receiver.clone());
+            if let Some(record_reader) = edge.record_reader.take() {
+                debug_assert!(
+                    record_readers
+                        .insert(edge.input_port, record_reader)
+                        .is_none(),
+                    "More than one output connect to a input port"
+                );
+            }
+        }
+        (input_ports, receivers, record_readers)
+    }
+}

--- a/dozer-core/src/executor/processor_node.rs
+++ b/dozer-core/src/executor/processor_node.rs
@@ -1,23 +1,22 @@
-use std::{borrow::Cow, collections::HashMap, mem::swap, path::Path, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, mem::swap};
 
-use crossbeam::channel::{Receiver, Sender};
+use crossbeam::channel::Receiver;
+use daggy::NodeIndex;
 use dozer_storage::lmdb_storage::SharedTransaction;
-use dozer_types::parking_lot::RwLock;
-use dozer_types::types::Schema;
 
 use crate::{
     errors::ExecutionError,
-    executor_utils::{
-        build_receivers_lists, create_ports_databases_and_fill_downstream_record_readers,
-        init_component,
-    },
     forwarder::{ProcessorChannelManager, StateWriter},
-    node::{NodeHandle, PortHandle, Processor, ProcessorFactory},
+    node::{NodeHandle, PortHandle, Processor},
     record_store::RecordReader,
-    Edge,
 };
 
-use super::{name::Name, receiver_loop::ReceiverLoop, ExecutorOperation};
+use super::{
+    execution_dag::{ExecutionDag, NodeKind},
+    name::Name,
+    receiver_loop::ReceiverLoop,
+    ExecutorOperation,
+};
 
 /// A processor in the execution DAG.
 #[derive(Debug)]
@@ -30,8 +29,8 @@ pub struct ProcessorNode {
     receivers: Vec<Receiver<ExecutorOperation>>,
     /// The processor.
     processor: Box<dyn Processor>,
-    /// Record readers of all stateful ports. Using `self.node_handle`, we can find the record readers of our stateful inputs.
-    record_readers: Arc<RwLock<HashMap<NodeHandle, HashMap<PortHandle, Box<dyn RecordReader>>>>>,
+    /// Record readers of the input ports. Every record reader reads the state of corresponding output port.
+    record_readers: HashMap<PortHandle, Box<dyn RecordReader>>,
     /// The transaction for this node's environment. Processor uses it to persist data.
     master_tx: SharedTransaction,
     /// This node's output channel manager, for forwarding data, writing metadata and writing port state.
@@ -39,65 +38,38 @@ pub struct ProcessorNode {
 }
 
 impl ProcessorNode {
-    /// # Arguments
-    ///
-    /// - `node_handle`: Node handle in description DAG.
-    /// - `processor_factory`: Processor factory in description DAG.
-    /// - `base_path`: Base path of persisted data for the last execution of the description DAG.
-    /// - `record_readers`: Record readers of all stateful ports.
-    /// - `receivers`: Input channels to this processor.
-    /// - `senders`: Output channels from this processor.
-    /// - `edges`: All edges in the description DAG, used for creating record readers for input ports which is connected to this processor's stateful output ports.
-    /// - `node_schemas`: Input and output data schemas.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new<T: Clone>(
-        node_handle: NodeHandle,
-        processor_factory: &dyn ProcessorFactory<T>,
-        base_path: &Path,
-        record_readers: Arc<
-            RwLock<HashMap<NodeHandle, HashMap<PortHandle, Box<dyn RecordReader>>>>,
-        >,
-        receivers: HashMap<PortHandle, Vec<Receiver<ExecutorOperation>>>,
-        senders: HashMap<PortHandle, Vec<Sender<ExecutorOperation>>>,
-        edges: &[Edge],
-        input_schemas: HashMap<PortHandle, Schema>,
-        output_schemas: HashMap<PortHandle, Schema>,
-        retention_queue_size: usize,
-    ) -> Result<Self, ExecutionError> {
-        let mut processor = processor_factory.build(input_schemas, output_schemas.to_owned())?;
-        let state_meta = init_component(&node_handle, base_path, |e| processor.init(e))?;
+    pub fn new(dag: &mut ExecutionDag, node_index: NodeIndex) -> Self {
+        let node = &mut dag.graph_mut()[node_index];
+        let (node_storage, Some(NodeKind::Processor(processor))) = (node.storage.clone(), node.kind.take()) else {
+            panic!("Must pass in a processor node");
+        };
 
-        let (master_tx, port_databases) =
-            create_ports_databases_and_fill_downstream_record_readers(
-                &node_handle,
-                edges,
-                state_meta.env,
-                &processor_factory.get_output_ports(),
-                &mut record_readers.write(),
-            )?;
-        let (port_handles, receivers) = build_receivers_lists(receivers);
-        let channel_manager = ProcessorChannelManager::new(
-            node_handle.clone(),
-            senders,
-            StateWriter::new(
-                state_meta.meta_db,
-                port_databases,
-                master_tx.clone(),
-                output_schemas,
-                retention_queue_size,
-            )?,
-            true,
+        let (port_handles, receivers, record_readers) =
+            dag.collect_receivers_and_record_readers(node_index);
+
+        let (senders, record_writers) = dag.collect_senders_and_record_writers(node_index);
+
+        let state_writer = StateWriter::new(
+            node_storage.meta_db,
+            record_writers,
+            node_storage.master_tx.clone(),
         );
+        let channel_manager =
+            ProcessorChannelManager::new(node_storage.handle.clone(), senders, state_writer, true);
 
-        Ok(Self {
-            node_handle,
+        Self {
+            node_handle: node_storage.handle,
             port_handles,
             receivers,
             processor,
             record_readers,
-            master_tx,
+            master_tx: node_storage.master_tx,
             channel_manager,
-        })
+        }
+    }
+
+    pub fn handle(&self) -> &NodeHandle {
+        &self.node_handle
     }
 }
 
@@ -123,17 +95,12 @@ impl ReceiverLoop for ProcessorNode {
         index: usize,
         op: dozer_types::types::Operation,
     ) -> Result<(), ExecutionError> {
-        let record_readers = self.record_readers.read();
-        let reader = record_readers
-            .get(&self.node_handle)
-            .ok_or_else(|| ExecutionError::InvalidNodeHandle(self.node_handle.clone()))?;
-
         self.processor.process(
             self.port_handles[index],
             op,
             &mut self.channel_manager,
             &self.master_tx,
-            reader,
+            &self.record_readers,
         )
     }
 

--- a/dozer-core/src/executor/sink_node.rs
+++ b/dozer-core/src/executor/sink_node.rs
@@ -1,19 +1,19 @@
-use std::{borrow::Cow, collections::HashMap, mem::swap, path::Path, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, mem::swap};
 
 use crossbeam::channel::Receiver;
+use daggy::NodeIndex;
 use dozer_storage::lmdb_storage::SharedTransaction;
 use dozer_types::log::debug;
-use dozer_types::{parking_lot::RwLock, types::Schema};
 
 use crate::{
     epoch::Epoch,
     errors::ExecutionError,
-    executor_utils::{build_receivers_lists, init_component},
     forwarder::StateWriter,
-    node::{NodeHandle, PortHandle, Sink, SinkFactory},
+    node::{NodeHandle, PortHandle, Sink},
     record_store::RecordReader,
 };
 
+use super::execution_dag::{ExecutionDag, NodeKind};
 use super::{name::Name, receiver_loop::ReceiverLoop, ExecutorOperation};
 
 /// A sink in the execution DAG.
@@ -22,13 +22,13 @@ pub struct SinkNode {
     /// Node handle in description DAG.
     node_handle: NodeHandle,
     /// Input port handles.
-    port_handles: Vec<u16>,
+    port_handles: Vec<PortHandle>,
     /// Input data channels.
     receivers: Vec<Receiver<ExecutorOperation>>,
     /// The sink.
     sink: Box<dyn Sink>,
-    /// Record readers of all stateful ports. Using `self.node_handle`, we can find the record readers of our stateful inputs.
-    record_readers: Arc<RwLock<HashMap<NodeHandle, HashMap<PortHandle, Box<dyn RecordReader>>>>>,
+    /// Record readers of the input ports. Every record reader reads the state of corresponding output port.
+    record_readers: HashMap<PortHandle, Box<dyn RecordReader>>,
     /// The transaction for this node's environment. Sink uses it to persist data.
     master_tx: SharedTransaction,
     /// This node's state writer, for writing metadata and port state.
@@ -36,45 +36,34 @@ pub struct SinkNode {
 }
 
 impl SinkNode {
-    /// # Arguments
-    ///
-    /// - `node_handle`: Node handle in description DAG.
-    /// - `sink_factory`: Sink factory in description DAG.
-    /// - `base_path`: Base path of persisted data for the last execution of the description DAG.
-    /// - `record_readers`: Record readers of all stateful ports.
-    /// - `receivers`: Input channels to this sink.
-    /// - `input_schemas`: Input data schemas.
-    pub fn new<T: Clone>(
-        node_handle: NodeHandle,
-        sink_factory: &dyn SinkFactory<T>,
-        base_path: &Path,
-        record_readers: Arc<
-            RwLock<HashMap<NodeHandle, HashMap<PortHandle, Box<dyn RecordReader>>>>,
-        >,
-        receivers: HashMap<PortHandle, Vec<Receiver<ExecutorOperation>>>,
-        input_schemas: HashMap<PortHandle, Schema>,
-        retention_queue_size: usize,
-    ) -> Result<Self, ExecutionError> {
-        let mut sink = sink_factory.build(input_schemas)?;
-        let state_meta = init_component(&node_handle, base_path, |e| sink.init(e))?;
-        let master_tx = state_meta.env.create_txn()?;
+    pub fn new(dag: &mut ExecutionDag, node_index: NodeIndex) -> Self {
+        let node = &mut dag.graph_mut()[node_index];
+        let (node_storage, Some(NodeKind::Sink(sink))) = (node.storage.clone(), node.kind.take()) else {
+            panic!("Must pass in a sink node");
+        };
+
+        let (port_handles, receivers, record_readers) =
+            dag.collect_receivers_and_record_readers(node_index);
+
         let state_writer = StateWriter::new(
-            state_meta.meta_db,
+            node_storage.meta_db,
             HashMap::new(),
-            master_tx.clone(),
-            HashMap::new(),
-            retention_queue_size,
-        )?;
-        let (port_handles, receivers) = build_receivers_lists(receivers);
-        Ok(Self {
-            node_handle,
+            node_storage.master_tx.clone(),
+        );
+
+        Self {
+            node_handle: node_storage.handle,
             port_handles,
             receivers,
             sink,
             record_readers,
-            master_tx,
+            master_tx: node_storage.master_tx,
             state_writer,
-        })
+        }
+    }
+
+    pub fn handle(&self) -> &NodeHandle {
+        &self.node_handle
     }
 }
 
@@ -100,12 +89,12 @@ impl ReceiverLoop for SinkNode {
         index: usize,
         op: dozer_types::types::Operation,
     ) -> Result<(), ExecutionError> {
-        let record_readers = self.record_readers.read();
-        let reader = record_readers
-            .get(&self.node_handle)
-            .ok_or_else(|| ExecutionError::InvalidNodeHandle(self.node_handle.clone()))?;
-        self.sink
-            .process(self.port_handles[index], op, &self.master_tx, reader)
+        self.sink.process(
+            self.port_handles[index],
+            op,
+            &self.master_tx,
+            &self.record_readers,
+        )
     }
 
     fn on_commit(&mut self, epoch: &Epoch) -> Result<(), ExecutionError> {

--- a/dozer-core/src/executor_utils.rs
+++ b/dozer-core/src/executor_utils.rs
@@ -1,23 +1,12 @@
-#![allow(clippy::type_complexity)]
 use crate::dag_metadata::METADATA_DB_NAME;
 use crate::errors::ExecutionError;
 use crate::executor::ExecutorOperation;
-use crate::node::{NodeHandle, OutputPortDef, OutputPortType, PortHandle};
-use crate::record_store::{
-    AutogenRowKeyLookupRecordReader, PrimaryKeyValueLookupRecordReader, RecordReader,
-};
-use crate::{Dag, Edge, Endpoint};
-use crossbeam::channel::{bounded, Receiver, Select, Sender};
+use crate::node::NodeHandle;
+use crossbeam::channel::{Receiver, Select};
 use dozer_storage::common::Database;
 use dozer_storage::lmdb::DatabaseFlags;
-use dozer_storage::lmdb_storage::{
-    LmdbEnvironmentManager, LmdbEnvironmentOptions, SharedTransaction,
-};
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use dozer_storage::lmdb_storage::{LmdbEnvironmentManager, LmdbEnvironmentOptions};
 use std::path::Path;
-
-use super::hash_map_to_vec::insert_vec_element;
 
 pub(crate) struct StorageMetadata {
     pub env: LmdbEnvironmentManager,
@@ -54,140 +43,4 @@ pub(crate) fn init_select(receivers: &Vec<Receiver<ExecutorOperation>>) -> Selec
         sel.recv(r);
     }
     sel
-}
-
-pub(crate) fn index_edges<T: Clone>(
-    dag: &Dag<T>,
-    channel_buf_sz: usize,
-) -> (
-    HashMap<NodeHandle, HashMap<PortHandle, Vec<Sender<ExecutorOperation>>>>,
-    HashMap<NodeHandle, HashMap<PortHandle, Vec<Receiver<ExecutorOperation>>>>,
-) {
-    let mut senders = HashMap::new();
-    let mut receivers = HashMap::new();
-
-    for edge in dag.edge_handles() {
-        let (tx, rx) = bounded(channel_buf_sz);
-        // let (tx, rx) = match dag.nodes.get(&edge.from.node).unwrap() {
-        //     NodeType::Source(_) => bounded(1),
-        //     _ => bounded(channel_buf_sz),
-        // };
-
-        insert_sender_or_receiver(&mut senders, edge.from.clone(), tx);
-        insert_sender_or_receiver(&mut receivers, edge.to.clone(), rx);
-    }
-
-    (senders, receivers)
-}
-
-fn insert_sender_or_receiver<T>(
-    map: &mut HashMap<NodeHandle, HashMap<PortHandle, Vec<T>>>,
-    endpoint: Endpoint,
-    value: T,
-) {
-    match map.entry(endpoint.node) {
-        Entry::Occupied(mut entry) => {
-            insert_vec_element(entry.get_mut(), endpoint.port, value);
-        }
-        Entry::Vacant(entry) => {
-            let mut port_map = HashMap::new();
-            port_map.insert(endpoint.port, vec![value]);
-            entry.insert(port_map);
-        }
-    }
-}
-
-pub(crate) fn build_receivers_lists(
-    receivers: HashMap<PortHandle, Vec<Receiver<ExecutorOperation>>>,
-) -> (Vec<PortHandle>, Vec<Receiver<ExecutorOperation>>) {
-    let mut handles_ls: Vec<PortHandle> = Vec::new();
-    let mut receivers_ls: Vec<Receiver<ExecutorOperation>> = Vec::new();
-    for e in receivers {
-        for r in e.1 {
-            receivers_ls.push(r);
-            handles_ls.push(e.0);
-        }
-    }
-    (handles_ls, receivers_ls)
-}
-
-fn get_inputs_for_output(edges: &[Edge], node: &NodeHandle, port: &PortHandle) -> Vec<Endpoint> {
-    edges
-        .iter()
-        .filter(|e| e.from.node == *node && e.from.port == *port)
-        .map(|e| e.to.clone())
-        .collect()
-}
-
-const PORT_STATE_KEY: &str = "__PORT_STATE_";
-
-#[derive(Debug)]
-pub(crate) struct StateOptions {
-    pub(crate) db: Database,
-    pub(crate) meta_db: Database,
-    pub(crate) typ: OutputPortType,
-}
-
-pub(crate) fn create_ports_databases_and_fill_downstream_record_readers(
-    handle: &NodeHandle,
-    edges: &[Edge],
-    mut env: LmdbEnvironmentManager,
-    output_ports: &[OutputPortDef],
-    record_stores: &mut HashMap<NodeHandle, HashMap<PortHandle, Box<dyn RecordReader>>>,
-) -> Result<(SharedTransaction, HashMap<PortHandle, StateOptions>), ExecutionError> {
-    let mut port_databases: Vec<Option<StateOptions>> = Vec::new();
-    for port in output_ports {
-        let opt = match &port.typ {
-            OutputPortType::Stateless => None,
-            typ => {
-                let db = env.create_database(
-                    Some(&format!("{}_{}", PORT_STATE_KEY, port.handle)),
-                    Some(DatabaseFlags::empty()),
-                )?;
-                let meta_db = env.create_database(
-                    Some(&format!("{}_{}_META", PORT_STATE_KEY, port.handle)),
-                    Some(DatabaseFlags::empty()),
-                )?;
-                Some(StateOptions {
-                    db,
-                    meta_db,
-                    typ: *typ,
-                })
-            }
-        };
-        port_databases.push(opt);
-    }
-
-    let master_tx = env.create_txn()?;
-
-    for (state_options, port) in port_databases.iter().zip(output_ports.iter()) {
-        if let Some(state_options) = state_options {
-            for endpoint in get_inputs_for_output(edges, handle, &port.handle) {
-                let record_reader: Box<dyn RecordReader> = match port.typ {
-                    OutputPortType::AutogenRowKeyLookup => Box::new(
-                        AutogenRowKeyLookupRecordReader::new(master_tx.clone(), state_options.db),
-                    ),
-                    OutputPortType::StatefulWithPrimaryKeyLookup { .. } => Box::new(
-                        PrimaryKeyValueLookupRecordReader::new(master_tx.clone(), state_options.db),
-                    ),
-                    OutputPortType::Stateless => panic!("Internal error: Invalid port type"),
-                };
-
-                record_stores
-                    .get_mut(&endpoint.node)
-                    .expect("Record store HashMap must be created for every node upfront")
-                    .insert(endpoint.port, record_reader);
-            }
-        }
-    }
-
-    let port_databases = output_ports
-        .iter()
-        .zip(port_databases.into_iter())
-        .flat_map(|(output_port, state_option)| {
-            state_option.map(|state_option| (output_port.handle, state_option))
-        })
-        .collect();
-
-    Ok((master_tx, port_databases))
 }

--- a/dozer-core/src/lib.rs
+++ b/dozer-core/src/lib.rs
@@ -15,6 +15,6 @@ pub mod node;
 pub mod record_store;
 
 #[cfg(test)]
-mod tests;
+pub mod tests;
 
 pub use dozer_storage as storage;

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -115,7 +115,7 @@ pub trait SourceFactory<T>: Send + Sync + Debug {
     ) -> Result<Box<dyn Source>, ExecutionError>;
 }
 
-pub trait Source: Debug {
+pub trait Source: Send + Sync + Debug {
     fn start(
         &self,
         fw: &mut dyn SourceChannelForwarder,
@@ -143,7 +143,7 @@ pub trait ProcessorFactory<T>: Send + Sync + Debug {
     ) -> Result<Box<dyn Processor>, ExecutionError>;
 }
 
-pub trait Processor: Debug {
+pub trait Processor: Send + Sync + Debug {
     fn init(&mut self, state: &mut LmdbEnvironmentManager) -> Result<(), ExecutionError>;
     fn commit(&self, epoch_details: &Epoch, tx: &SharedTransaction) -> Result<(), ExecutionError>;
     fn process(
@@ -168,7 +168,7 @@ pub trait SinkFactory<T>: Send + Sync + Debug {
     ) -> Result<Box<dyn Sink>, ExecutionError>;
 }
 
-pub trait Sink: Debug {
+pub trait Sink: Send + Sync + Debug {
     fn init(&mut self, state: &mut LmdbEnvironmentManager) -> Result<(), ExecutionError>;
     fn commit(
         &mut self,

--- a/dozer-core/src/tests.rs
+++ b/dozer-core/src/tests.rs
@@ -23,8 +23,10 @@ mod dag_schemas;
 #[cfg(test)]
 mod node;
 #[cfg(test)]
+pub mod processors;
+#[cfg(test)]
 mod record_store;
 #[cfg(test)]
-mod sinks;
+pub mod sinks;
 #[cfg(test)]
-mod sources;
+pub mod sources;

--- a/dozer-core/src/tests/app.rs
+++ b/dozer-core/src/tests/app.rs
@@ -286,8 +286,9 @@ fn test_app_dag() {
     app.add_pipeline(p2);
 
     let dag = app.get_dag().unwrap();
+    let edges = dag.edge_handles();
 
-    assert!(dag.edge_handles().any(|e| *e
+    assert!(edges.iter().any(|e| *e
         == Edge::new(
             Endpoint::new(
                 NodeHandle::new(None, "postgres".to_string()),
@@ -299,7 +300,7 @@ fn test_app_dag() {
             )
         )));
 
-    assert!(dag.edge_handles().any(|e| *e
+    assert!(edges.iter().any(|e| *e
         == Edge::new(
             Endpoint::new(
                 NodeHandle::new(None, "postgres".to_string()),
@@ -311,7 +312,7 @@ fn test_app_dag() {
             )
         )));
 
-    assert!(dag.edge_handles().any(|e| *e
+    assert!(edges.iter().any(|e| *e
         == Edge::new(
             Endpoint::new(
                 NodeHandle::new(None, "snowflake".to_string()),
@@ -323,7 +324,7 @@ fn test_app_dag() {
             )
         )));
 
-    assert!(dag.edge_handles().any(|e| *e
+    assert!(edges.iter().any(|e| *e
         == Edge::new(
             Endpoint::new(
                 NodeHandle::new(None, "postgres".to_string()),
@@ -335,7 +336,7 @@ fn test_app_dag() {
             )
         )));
 
-    assert!(dag.edge_handles().any(|e| *e
+    assert!(edges.iter().any(|e| *e
         == Edge::new(
             Endpoint::new(
                 NodeHandle::new(Some(1), "join".to_string()),
@@ -347,7 +348,7 @@ fn test_app_dag() {
             )
         )));
 
-    assert!(dag.edge_handles().any(|e| *e
+    assert!(edges.iter().any(|e| *e
         == Edge::new(
             Endpoint::new(
                 NodeHandle::new(Some(2), "join".to_string()),
@@ -359,7 +360,7 @@ fn test_app_dag() {
             )
         )));
 
-    assert_eq!(dag.edge_handles().count(), 6);
+    assert_eq!(edges.len(), 6);
 
     let tmp_dir = chk!(TempDir::new("test"));
     let mut executor = chk!(DagExecutor::new(

--- a/dozer-core/src/tests/dag_schemas.rs
+++ b/dozer-core/src/tests/dag_schemas.rs
@@ -1,4 +1,4 @@
-use crate::dag_schemas::DagSchemas;
+use crate::dag_schemas::{DagHaveSchemas, DagSchemas};
 use crate::errors::ExecutionError;
 use crate::executor::{DagExecutor, ExecutorOptions};
 use crate::node::{

--- a/dozer-core/src/tests/processors.rs
+++ b/dozer-core/src/tests/processors.rs
@@ -1,225 +1,116 @@
-use crate::channels::{ProcessorChannelForwarder, SourceChannelForwarder};
-use crate::errors::ExecutionError;
-use crate::executor_local::DEFAULT_PORT_HANDLE;
-use crate::node::{
-    OutputPortDef, OutputPortDefOptions, PortHandle, Processor, ProcessorFactory, Sink,
-    SinkFactory, Source, SourceFactory,
+use crate::{
+    node::{OutputPortDef, OutputPortType, PortHandle, Processor, ProcessorFactory},
+    DEFAULT_PORT_HANDLE,
 };
-use crate::record_store::RecordReader;
-use dozer_storage::common::{Database, Environment, RwTransaction};
-use dozer_types::log::debug;
-use dozer_types::types::{Field, FieldDefinition, FieldType, Operation, Record, Schema};
-use std::collections::HashMap;
 
-/// Test Source
-pub struct DynPortsSourceFactory {
-    id: i32,
-    output_ports: Vec<PortHandle>,
-}
+use super::app::NoneContext;
 
-impl DynPortsSourceFactory {
-    pub fn new(id: i32, output_ports: Vec<PortHandle>) -> Self {
-        Self { id, output_ports }
+#[derive(Debug)]
+pub struct ConnectivityTestProcessorFactory;
+
+impl ProcessorFactory<NoneContext> for ConnectivityTestProcessorFactory {
+    fn get_input_ports(&self) -> Vec<PortHandle> {
+        vec![DEFAULT_PORT_HANDLE]
     }
-}
 
-impl SourceFactory for DynPortsSourceFactory {
     fn get_output_ports(&self) -> Vec<OutputPortDef> {
-        self.output_ports
-            .iter()
-            .map(|e| OutputPortDef::new(*e, OutputPortDefOptions::default()))
-            .collect()
+        vec![OutputPortDef::new(
+            DEFAULT_PORT_HANDLE,
+            OutputPortType::Stateless,
+        )]
     }
-    fn build(&self) -> Box<dyn Source> {
-        Box::new(DynPortsSource { id: self.id })
-    }
-}
 
-pub struct DynPortsSource {
-    id: i32,
-}
-
-impl Source for DynPortsSource {
-    fn get_output_schema(&self, _port: PortHandle) -> Option<Schema> {
-        Some(
-            Schema::empty()
-                .field(
-                    FieldDefinition::new("user_id".to_string(), FieldType::UInt, false),
-                    true,
-                    true,
-                )
-                .field(
-                    FieldDefinition::new("first_name".to_string(), FieldType::String, false),
-                    true,
-                    false,
-                )
-                .field(
-                    FieldDefinition::new("last_name".to_string(), FieldType::String, false),
-                    true,
-                    false,
-                )
-                .clone(),
+    fn get_output_schema(
+        &self,
+        _output_port: &PortHandle,
+        _input_schemas: &std::collections::HashMap<
+            PortHandle,
+            (dozer_types::types::Schema, NoneContext),
+        >,
+    ) -> Result<(dozer_types::types::Schema, NoneContext), crate::errors::ExecutionError> {
+        unimplemented!(
+            "This struct is for connectivity test, only input and output ports are defined"
         )
     }
 
-    fn start(
+    fn prepare(
         &self,
-        fw: &mut dyn SourceChannelForwarder,
-        _from_seq: Option<u64>,
-    ) -> Result<(), ExecutionError> {
-        for n in 0..1_000 {
-            fw.send(
-                n,
-                Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(n),
-                            Field::String(format!("first name {}", n)),
-                            Field::String(format!("last name {}", n)),
-                        ],
-                    ),
-                },
-                DEFAULT_PORT_HANDLE,
-            )?;
-        }
-        fw.terminate().unwrap();
-        Ok(())
+        _input_schemas: std::collections::HashMap<
+            PortHandle,
+            (dozer_types::types::Schema, NoneContext),
+        >,
+        _output_schemas: std::collections::HashMap<
+            PortHandle,
+            (dozer_types::types::Schema, NoneContext),
+        >,
+    ) -> Result<(), crate::errors::ExecutionError> {
+        unimplemented!(
+            "This struct is for connectivity test, only input and output ports are defined"
+        )
+    }
+
+    fn build(
+        &self,
+        _input_schemas: std::collections::HashMap<PortHandle, dozer_types::types::Schema>,
+        _output_schemas: std::collections::HashMap<PortHandle, dozer_types::types::Schema>,
+    ) -> Result<Box<dyn Processor>, crate::errors::ExecutionError> {
+        unimplemented!(
+            "This struct is for connectivity test, only input and output ports are defined"
+        )
     }
 }
 
-pub struct DynPortsSinkFactory {
-    id: i32,
-    input_ports: Vec<PortHandle>,
-}
+#[derive(Debug)]
+pub struct NoInputPortProcessorFactory;
 
-impl DynPortsSinkFactory {
-    pub fn new(id: i32, input_ports: Vec<PortHandle>) -> Self {
-        Self { id, input_ports }
-    }
-}
-
-impl SinkFactory for DynPortsSinkFactory {
+impl ProcessorFactory<NoneContext> for NoInputPortProcessorFactory {
     fn get_input_ports(&self) -> Vec<PortHandle> {
-        self.input_ports.clone()
-    }
-    fn build(&self) -> Box<dyn Sink> {
-        Box::new(DynPortsSink { id: self.id })
-    }
-}
-
-pub struct DynPortsSink {
-    id: i32,
-}
-
-impl Sink for DynPortsSink {
-    fn update_schema(
-        &mut self,
-        _input_schemas: &HashMap<PortHandle, Schema>,
-    ) -> Result<(), ExecutionError> {
-        Ok(())
+        vec![]
     }
 
-    fn init(&mut self, _env: &mut dyn Environment) -> Result<(), ExecutionError> {
-        debug!("SINK {}: Initialising TestSink", self.id);
-        Ok(())
-    }
-
-    fn process(
-        &mut self,
-        _from_port: PortHandle,
-        _seq: u64,
-        _op: Operation,
-        _tx: &mut dyn RwTransaction,
-        _reader: &HashMap<PortHandle, RecordReader>,
-    ) -> Result<(), ExecutionError> {
-        Ok(())
-    }
-
-    fn commit(&self, _tx: &mut dyn RwTransaction) -> Result<(), ExecutionError> {
-        Ok(())
-    }
-}
-
-pub struct DynPortsProcessorFactory {
-    id: i32,
-    input_ports: Vec<PortHandle>,
-    output_ports: Vec<PortHandle>,
-}
-
-impl DynPortsProcessorFactory {
-    pub fn new(id: i32, input_ports: Vec<PortHandle>, output_ports: Vec<PortHandle>) -> Self {
-        Self {
-            id,
-            input_ports,
-            output_ports,
-        }
-    }
-}
-
-impl ProcessorFactory for DynPortsProcessorFactory {
-    fn get_input_ports(&self) -> Vec<PortHandle> {
-        self.input_ports.clone()
-    }
     fn get_output_ports(&self) -> Vec<OutputPortDef> {
-        self.output_ports
-            .clone()
-            .iter()
-            .map(|e| OutputPortDef::new(*e, OutputPortDefOptions::default()))
-            .collect()
-    }
-    fn build(&self) -> Box<dyn Processor> {
-        Box::new(DynPortsProcessor {
-            id: self.id,
-            ctr: 0,
-            db: None,
-        })
-    }
-}
-
-pub struct DynPortsProcessor {
-    id: i32,
-    ctr: u64,
-    db: Option<Database>,
-}
-
-impl Processor for DynPortsProcessor {
-    fn update_schema(
-        &mut self,
-        _output_port: PortHandle,
-        input_schemas: &HashMap<PortHandle, Schema>,
-    ) -> Result<Schema, ExecutionError> {
-        Ok(input_schemas.get(&DEFAULT_PORT_HANDLE).unwrap().clone())
+        vec![OutputPortDef::new(
+            DEFAULT_PORT_HANDLE,
+            OutputPortType::Stateless,
+        )]
     }
 
-    fn init(&mut self, tx: &mut dyn Environment) -> Result<(), ExecutionError> {
-        debug!("PROC {}: Initialising TestProcessor", self.id);
-        self.db = Some(tx.open_database("test", false)?);
-        Ok(())
+    fn get_output_schema(
+        &self,
+        _output_port: &PortHandle,
+        _input_schemas: &std::collections::HashMap<
+            PortHandle,
+            (dozer_types::types::Schema, NoneContext),
+        >,
+    ) -> Result<(dozer_types::types::Schema, NoneContext), crate::errors::ExecutionError> {
+        unimplemented!(
+            "This struct is for connectivity test, only input and output ports are defined"
+        )
     }
 
-    fn process(
-        &mut self,
-        _from_port: PortHandle,
-        op: Operation,
-        fw: &mut dyn ProcessorChannelForwarder,
-        tx: &mut dyn RwTransaction,
-        _readers: &HashMap<PortHandle, RecordReader>,
-    ) -> Result<(), ExecutionError> {
-        self.ctr += 1;
-
-        tx.put(
-            self.db.as_ref().unwrap(),
-            &self.ctr.to_le_bytes(),
-            &self.id.to_le_bytes(),
-        )?;
-        let v = tx.get(self.db.as_ref().unwrap(), &self.ctr.to_le_bytes())?;
-        assert!(v.is_some());
-        fw.send(op, DEFAULT_PORT_HANDLE)?;
-        Ok(())
+    fn prepare(
+        &self,
+        _input_schemas: std::collections::HashMap<
+            PortHandle,
+            (dozer_types::types::Schema, NoneContext),
+        >,
+        _output_schemas: std::collections::HashMap<
+            PortHandle,
+            (dozer_types::types::Schema, NoneContext),
+        >,
+    ) -> Result<(), crate::errors::ExecutionError> {
+        unimplemented!(
+            "This struct is for connectivity test, only input and output ports are defined"
+        )
     }
 
-    fn commit(&self, _tx: &mut dyn RwTransaction) -> Result<(), ExecutionError> {
-        Ok(())
+    fn build(
+        &self,
+        _input_schemas: std::collections::HashMap<PortHandle, dozer_types::types::Schema>,
+        _output_schemas: std::collections::HashMap<PortHandle, dozer_types::types::Schema>,
+    ) -> Result<Box<dyn Processor>, crate::errors::ExecutionError> {
+        unimplemented!(
+            "This struct is for connectivity test, only input and output ports are defined"
+        )
     }
 }

--- a/dozer-core/src/tests/record_store.rs
+++ b/dozer-core/src/tests/record_store.rs
@@ -1,6 +1,6 @@
 use crate::record_store::{
-    AutogenRowKeyLookupRecordReader, AutogenRowKeyLookupRecordWriter, PrimaryKeyLookupRecordWriter,
-    PrimaryKeyValueLookupRecordReader, RecordReader, RecordWriter,
+    AutogenRowKeyLookupRecordReader, AutogenRowKeyLookupRecordWriter, PrimaryKeyLookupRecordReader,
+    PrimaryKeyLookupRecordWriter, RecordReader, RecordWriter,
 };
 use dozer_storage::{
     lmdb::DatabaseFlags,
@@ -251,7 +251,7 @@ fn test_read_write_kv() {
     let lookup_record = Record::new(None, vec![Field::Int(1), Field::Null], None);
     let lookup_key = lookup_record.get_key(&schema.primary_index);
 
-    let reader = PrimaryKeyValueLookupRecordReader::new(tx, master_db);
+    let reader = PrimaryKeyLookupRecordReader::new(tx, master_db);
     let r = reader.get(&lookup_key, 1).unwrap();
     assert_eq!(
         r,

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -2,6 +2,7 @@ use crate::epoch::Epoch;
 use crate::errors::ExecutionError;
 use crate::node::{PortHandle, Sink, SinkFactory};
 use crate::record_store::RecordReader;
+use crate::DEFAULT_PORT_HANDLE;
 use dozer_storage::lmdb_storage::{LmdbEnvironmentManager, SharedTransaction};
 use dozer_types::types::{Operation, Schema};
 
@@ -95,5 +96,51 @@ impl Sink for CountingSink {
             self.running.store(false, Ordering::Relaxed);
         }
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct ConnectivityTestSinkFactory;
+
+impl SinkFactory<NoneContext> for ConnectivityTestSinkFactory {
+    fn get_input_ports(&self) -> Vec<PortHandle> {
+        vec![DEFAULT_PORT_HANDLE]
+    }
+
+    fn prepare(
+        &self,
+        _input_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
+    ) -> Result<(), ExecutionError> {
+        unimplemented!("This struct is for connectivity test, only input ports are defined")
+    }
+
+    fn build(
+        &self,
+        _input_schemas: HashMap<PortHandle, Schema>,
+    ) -> Result<Box<dyn Sink>, ExecutionError> {
+        unimplemented!("This struct is for connectivity test, only input ports are defined")
+    }
+}
+
+#[derive(Debug)]
+pub struct NoInputPortSinkFactory;
+
+impl SinkFactory<NoneContext> for NoInputPortSinkFactory {
+    fn get_input_ports(&self) -> Vec<PortHandle> {
+        vec![]
+    }
+
+    fn prepare(
+        &self,
+        _input_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
+    ) -> Result<(), ExecutionError> {
+        unimplemented!("This struct is for connectivity test, only input ports are defined")
+    }
+
+    fn build(
+        &self,
+        _input_schemas: HashMap<PortHandle, Schema>,
+    ) -> Result<Box<dyn Sink>, ExecutionError> {
+        unimplemented!("This struct is for connectivity test, only input ports are defined")
     }
 }

--- a/dozer-core/src/tests/sources.rs
+++ b/dozer-core/src/tests/sources.rs
@@ -1,6 +1,7 @@
 use crate::channels::SourceChannelForwarder;
 use crate::errors::ExecutionError;
 use crate::node::{OutputPortDef, OutputPortType, PortHandle, Source, SourceFactory};
+use crate::DEFAULT_PORT_HANDLE;
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
 };
@@ -402,5 +403,38 @@ impl Source for NoPkGeneratorSource {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct ConnectivityTestSourceFactory;
+
+impl SourceFactory<NoneContext> for ConnectivityTestSourceFactory {
+    fn get_output_schema(
+        &self,
+        _port: &PortHandle,
+    ) -> Result<(Schema, NoneContext), ExecutionError> {
+        unimplemented!("This struct is for connectivity test, only output ports are defined")
+    }
+
+    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
+        Ok(vec![OutputPortDef::new(
+            DEFAULT_PORT_HANDLE,
+            OutputPortType::Stateless,
+        )])
+    }
+
+    fn prepare(
+        &self,
+        _output_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
+    ) -> Result<(), ExecutionError> {
+        unimplemented!("This struct is for connectivity test, only output ports are defined")
+    }
+
+    fn build(
+        &self,
+        _output_schemas: HashMap<PortHandle, Schema>,
+    ) -> Result<Box<dyn Source>, ExecutionError> {
+        unimplemented!("This struct is for connectivity test, only output ports are defined")
     }
 }

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -22,7 +22,7 @@ use dozer_cache::cache::{
     CacheCommonOptions, CacheReadOptions, CacheWriteOptions, LmdbRoCache, LmdbRwCache,
 };
 use dozer_core::app::AppPipeline;
-use dozer_core::dag_schemas::DagSchemas;
+use dozer_core::dag_schemas::{DagHaveSchemas, DagSchemas};
 use dozer_core::errors::ExecutionError::InternalError;
 use dozer_sql::pipeline::builder::statement_to_pipeline;
 use dozer_sql::pipeline::errors::PipelineError;

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_sum_tests.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_sum_tests.rs
@@ -1,4 +1,3 @@
-#![allow(unused_mut)]
 use crate::output;
 use crate::pipeline::aggregation::tests::aggregation_tests_utils::{
     delete_exp, delete_field, get_decimal_field, init_input_schema, init_processor, insert_exp,

--- a/dozer-tests/src/sql_tests/pipeline.rs
+++ b/dozer-tests/src/sql_tests/pipeline.rs
@@ -1,7 +1,7 @@
 use dozer_core::app::{App, AppPipeline};
 use dozer_core::appsource::{AppSource, AppSourceManager};
 use dozer_core::channels::SourceChannelForwarder;
-use dozer_core::dag_schemas::DagSchemas;
+use dozer_core::dag_schemas::{DagHaveSchemas, DagSchemas};
 use dozer_core::errors::ExecutionError;
 use dozer_core::node::{
     OutputPortDef, OutputPortType, PortHandle, Sink, SinkFactory, Source, SourceFactory,


### PR DESCRIPTION
This PR splits the execution dag's construction phase and execution phase.

The construction phase is self-contained in `ExecutionDag::new` and can be reused across different execution stages.

Utilizing the DAG structure of `ExecutionDag`, we're able to get rid of the overwhelming type `Arc<RwLock<HashMap<NodeHandle, HashMap<PortHandle, Box<dyn RecordReader>>>>>`.

We also added a extra validation step in `DagSchemas::new`, which checks if the dag is properly connected so that data can flow from source to sink.