### PR TITLE
chore: Don't hold `AccessFilter` in `CacheReader`. Don't hold `CacheReader` or `ApiEndpoint` in `ApiHelper`

### DIFF
--- a/dozer-api/src/api_helper.rs
+++ b/dozer-api/src/api_helper.rs
@@ -1,27 +1,24 @@
 use crate::auth::Access;
 use crate::errors::{ApiError, AuthError};
-use crate::generator::oapi::generator::OpenApiGenerator;
 use dozer_cache::cache::RecordWithId;
 use dozer_cache::cache::{expression::QueryExpression, index};
 use dozer_cache::errors::CacheError;
 use dozer_cache::{AccessFilter, CacheReader};
 use dozer_types::indexmap::IndexMap;
 use dozer_types::json_str_to_field;
-use dozer_types::models::api_endpoint::ApiEndpoint;
 use dozer_types::record_to_map;
 use dozer_types::serde_json::Value;
 use dozer_types::types::Schema;
-use openapiv3::OpenAPI;
 
 pub struct ApiHelper<'a> {
     reader: &'a CacheReader,
     access_filter: AccessFilter,
-    endpoint: &'a ApiEndpoint,
+    endpoint_name: &'a str,
 }
 impl<'a> ApiHelper<'a> {
     pub fn new(
         reader: &'a CacheReader,
-        endpoint: &'a ApiEndpoint,
+        endpoint_name: &'a str,
         access: Option<Access>,
     ) -> Result<Self, ApiError> {
         let access = access.unwrap_or(Access::All);
@@ -35,7 +32,7 @@ impl<'a> ApiHelper<'a> {
             },
 
             Access::Custom(mut access_filters) => {
-                if let Some(access_filter) = access_filters.remove(&endpoint.name) {
+                if let Some(access_filter) = access_filters.remove(endpoint_name) {
                     access_filter
                 } else {
                     return Err(ApiError::ApiAuthError(AuthError::InvalidToken));
@@ -46,33 +43,15 @@ impl<'a> ApiHelper<'a> {
         Ok(Self {
             reader,
             access_filter,
-            endpoint,
+            endpoint_name,
         })
-    }
-
-    pub fn generate_oapi3(&self) -> Result<OpenAPI, ApiError> {
-        let (schema, secondary_indexes) = self
-            .reader
-            .get_schema_and_indexes_by_name(&self.endpoint.name)
-            .map_err(ApiError::SchemaNotFound)?;
-
-        let oapi_generator = OpenApiGenerator::new(
-            schema,
-            secondary_indexes,
-            self.endpoint.clone(),
-            vec![format!("http://localhost:{}", "8080")],
-        );
-
-        oapi_generator
-            .generate_oas3()
-            .map_err(ApiError::ApiGenerationError)
     }
 
     /// Get a single record by json string as primary key
     pub fn get_record(&self, key: &str) -> Result<IndexMap<String, Value>, CacheError> {
         let schema = self
             .reader
-            .get_schema_and_indexes_by_name(&self.endpoint.name)?
+            .get_schema_and_indexes_by_name(self.endpoint_name)?
             .0;
 
         let key = if schema.primary_index.is_empty() {
@@ -95,7 +74,7 @@ impl<'a> ApiHelper<'a> {
 
     pub fn get_records_count(self, mut exp: QueryExpression) -> Result<usize, CacheError> {
         self.reader
-            .count(&self.endpoint.name, &mut exp, self.access_filter)
+            .count(self.endpoint_name, &mut exp, self.access_filter)
     }
 
     /// Get multiple records
@@ -118,11 +97,11 @@ impl<'a> ApiHelper<'a> {
     ) -> Result<(Schema, Vec<RecordWithId>), CacheError> {
         let schema = self
             .reader
-            .get_schema_and_indexes_by_name(&self.endpoint.name)?
+            .get_schema_and_indexes_by_name(self.endpoint_name)?
             .0;
         let records = self
             .reader
-            .query(&self.endpoint.name, &mut exp, self.access_filter)?;
+            .query(self.endpoint_name, &mut exp, self.access_filter)?;
 
         Ok((schema, records))
     }
@@ -131,7 +110,7 @@ impl<'a> ApiHelper<'a> {
     pub fn get_schema(&self) -> Result<Schema, CacheError> {
         let schema = self
             .reader
-            .get_schema_and_indexes_by_name(&self.endpoint.name)?
+            .get_schema_and_indexes_by_name(self.endpoint_name)?
             .0;
         Ok(schema)
     }

--- a/dozer-api/src/grpc/common/service.rs
+++ b/dozer-api/src/grpc/common/service.rs
@@ -53,7 +53,7 @@ impl CommonGrpcService for CommonService {
 
         let count = shared_impl::count(
             &cache_endpoint.cache_reader,
-            &cache_endpoint.endpoint,
+            &cache_endpoint.endpoint.name,
             query_request.query.as_deref(),
             access,
         )?;
@@ -72,7 +72,7 @@ impl CommonGrpcService for CommonService {
 
         let (schema, records) = shared_impl::query(
             &cache_endpoint.cache_reader,
-            &cache_endpoint.endpoint,
+            &cache_endpoint.endpoint.name,
             query_request.query.as_deref(),
             access,
         )?;
@@ -99,7 +99,7 @@ impl CommonGrpcService for CommonService {
 
         shared_impl::on_event(
             &cache_endpoint.cache_reader,
-            &cache_endpoint.endpoint,
+            &cache_endpoint.endpoint.name,
             query_request.filter.as_deref(),
             self.event_notifier.as_ref().map(|r| r.resubscribe()),
             access.cloned(),
@@ -134,7 +134,7 @@ impl CommonGrpcService for CommonService {
 
         let api_helper = api_helper::ApiHelper::new(
             &cache_endpoint.cache_reader,
-            &cache_endpoint.endpoint,
+            &cache_endpoint.endpoint.name,
             None,
         )?;
         let schema = api_helper

--- a/dozer-api/src/grpc/shared_impl/mod.rs
+++ b/dozer-api/src/grpc/shared_impl/mod.rs
@@ -2,7 +2,6 @@ use dozer_cache::cache::expression::{default_limit_for_query, QueryExpression};
 use dozer_cache::cache::RecordWithId;
 use dozer_cache::CacheReader;
 use dozer_types::log::warn;
-use dozer_types::models::api_endpoint::ApiEndpoint;
 use dozer_types::serde_json;
 use dozer_types::types::Schema;
 use tokio::sync::broadcast::error::RecvError;
@@ -41,18 +40,18 @@ fn parse_query(
 
 pub fn count(
     reader: &CacheReader,
-    endpoint: &ApiEndpoint,
+    endpoint_name: &str,
     query: Option<&str>,
     access: Option<Access>,
 ) -> Result<usize, Status> {
     let query = parse_query(query, QueryExpression::with_no_limit)?;
-    let api_helper = ApiHelper::new(reader, endpoint, access)?;
+    let api_helper = ApiHelper::new(reader, endpoint_name, access)?;
     api_helper.get_records_count(query).map_err(from_error)
 }
 
 pub fn query(
     reader: &CacheReader,
-    endpoint: &ApiEndpoint,
+    endpoint_name: &str,
     query: Option<&str>,
     access: Option<Access>,
 ) -> Result<(Schema, Vec<RecordWithId>), Status> {
@@ -60,14 +59,14 @@ pub fn query(
     if query.limit.is_none() {
         query.limit = Some(default_limit_for_query());
     }
-    let api_helper = ApiHelper::new(reader, endpoint, access)?;
+    let api_helper = ApiHelper::new(reader, endpoint_name, access)?;
     let (schema, records) = api_helper.get_records(query).map_err(from_error)?;
     Ok((schema, records))
 }
 
 pub fn on_event<T: Send + 'static>(
     reader: &CacheReader,
-    endpoint: &ApiEndpoint,
+    endpoint_name: &str,
     filter: Option<&str>,
     mut broadcast_receiver: Option<Receiver<PipelineResponse>>,
     access: Option<Access>,
@@ -89,10 +88,10 @@ pub fn on_event<T: Send + 'static>(
         }
         None => None,
     };
-    let api_helper = ApiHelper::new(reader, endpoint, access)?;
+    let api_helper = ApiHelper::new(reader, endpoint_name, access)?;
     let schema = api_helper
         .get_schema()
-        .map_err(|_| Status::invalid_argument(&endpoint.name))?;
+        .map_err(|_| Status::invalid_argument(endpoint_name))?;
 
     let (tx, rx) = tokio::sync::mpsc::channel(1);
 

--- a/dozer-api/src/grpc/typed/tests/service.rs
+++ b/dozer-api/src/grpc/typed/tests/service.rs
@@ -18,7 +18,10 @@ use crate::{
     },
     RoCacheEndpoint,
 };
-use dozer_cache::cache::expression::{FilterExpression, QueryExpression};
+use dozer_cache::{
+    cache::expression::{FilterExpression, QueryExpression},
+    CacheReader,
+};
 use dozer_types::models::{api_config::default_api_config, api_security::ApiSecurity};
 use futures_util::FutureExt;
 use std::{collections::HashMap, env, path::PathBuf, str::FromStr, time::Duration};
@@ -42,7 +45,7 @@ use tonic::{
 pub fn setup_pipeline() -> (HashMap<String, RoCacheEndpoint>, Receiver<PipelineResponse>) {
     let endpoint = test_utils::get_endpoint();
     let cache_endpoint = RoCacheEndpoint {
-        cache: test_utils::initialize_cache(&endpoint.name, None),
+        cache_reader: CacheReader::new(test_utils::initialize_cache(&endpoint.name, None)),
         endpoint,
     };
 

--- a/dozer-api/src/lib.rs
+++ b/dozer-api/src/lib.rs
@@ -1,17 +1,23 @@
-use dozer_cache::cache::{RoCache, RwCache};
+use dozer_cache::{
+    cache::{RoCache, RwCache},
+    CacheReader,
+};
 use dozer_types::models::api_endpoint::ApiEndpoint;
 use std::sync::Arc;
 mod api_helper;
 
 #[derive(Clone, Debug)]
 pub struct RoCacheEndpoint {
-    pub cache: Arc<dyn RoCache>,
+    pub cache_reader: CacheReader,
     pub endpoint: ApiEndpoint,
 }
 
 impl RoCacheEndpoint {
-    pub fn new(cache: Arc<dyn RoCache>, endpoint: ApiEndpoint) -> Result<Self, CacheError> {
-        Ok(Self { cache, endpoint })
+    pub fn new(cache: Arc<dyn RoCache>, endpoint: ApiEndpoint) -> Self {
+        Self {
+            cache_reader: CacheReader::new(cache),
+            endpoint,
+        }
     }
 }
 
@@ -22,8 +28,8 @@ pub struct RwCacheEndpoint {
 }
 
 impl RwCacheEndpoint {
-    pub fn new(cache: Arc<dyn RwCache>, endpoint: ApiEndpoint) -> Result<Self, CacheError> {
-        Ok(Self { cache, endpoint })
+    pub fn new(cache: Arc<dyn RwCache>, endpoint: ApiEndpoint) -> Self {
+        Self { cache, endpoint }
     }
 }
 
@@ -36,7 +42,6 @@ pub mod rest;
 // Re-exports
 pub use actix_web;
 pub use async_trait;
-use dozer_cache::errors::CacheError;
 pub use openapiv3;
 pub use tokio;
 pub use tonic;

--- a/dozer-api/src/rest/api_generator.rs
+++ b/dozer-api/src/rest/api_generator.rs
@@ -16,7 +16,11 @@ pub async fn generate_oapi(
     access: Option<ReqData<Access>>,
     cache_endpoint: ReqData<RoCacheEndpoint>,
 ) -> Result<HttpResponse, ApiError> {
-    let helper = ApiHelper::new(&cache_endpoint, access.map(|a| a.into_inner()))?;
+    let helper = ApiHelper::new(
+        &cache_endpoint.cache_reader,
+        &cache_endpoint.endpoint,
+        access.map(|a| a.into_inner()),
+    )?;
 
     helper
         .generate_oapi3()
@@ -29,7 +33,11 @@ pub async fn get(
     cache_endpoint: ReqData<RoCacheEndpoint>,
     path: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
-    let helper = ApiHelper::new(&cache_endpoint, access.map(|a| a.into_inner()))?;
+    let helper = ApiHelper::new(
+        &cache_endpoint.cache_reader,
+        &cache_endpoint.endpoint,
+        access.map(|a| a.into_inner()),
+    )?;
     let key = path.as_str();
     helper
         .get_record(key)
@@ -42,7 +50,11 @@ pub async fn list(
     access: Option<ReqData<Access>>,
     cache_endpoint: ReqData<RoCacheEndpoint>,
 ) -> Result<HttpResponse, ApiError> {
-    let helper = ApiHelper::new(&cache_endpoint, access.map(|a| a.into_inner()))?;
+    let helper = ApiHelper::new(
+        &cache_endpoint.cache_reader,
+        &cache_endpoint.endpoint,
+        access.map(|a| a.into_inner()),
+    )?;
     let exp = QueryExpression::new(None, vec![], Some(50), 0);
     match helper
         .get_records_map(exp)
@@ -78,7 +90,11 @@ pub async fn count(
         None => QueryExpression::with_no_limit(),
     };
 
-    let helper = ApiHelper::new(&cache_endpoint, access.map(|a| a.into_inner()))?;
+    let helper = ApiHelper::new(
+        &cache_endpoint.cache_reader,
+        &cache_endpoint.endpoint,
+        access.map(|a| a.into_inner()),
+    )?;
     helper
         .get_records_count(query_expression)
         .map(|count| HttpResponse::Ok().json(count))
@@ -104,7 +120,11 @@ pub async fn query(
     if query_expression.limit.is_none() {
         query_expression.limit = Some(default_limit_for_query());
     }
-    let helper = ApiHelper::new(&cache_endpoint, access.map(|a| a.into_inner()))?;
+    let helper = ApiHelper::new(
+        &cache_endpoint.cache_reader,
+        &cache_endpoint.endpoint,
+        access.map(|a| a.into_inner()),
+    )?;
     helper
         .get_records_map(query_expression)
         .map(|maps| HttpResponse::Ok().json(maps))

--- a/dozer-api/src/rest/tests/auth.rs
+++ b/dozer-api/src/rest/tests/auth.rs
@@ -69,10 +69,7 @@ async fn check_status(
     let api_server = ApiServer::create_app_entry(
         security,
         CorsOptions::Permissive,
-        vec![RoCacheEndpoint {
-            cache,
-            endpoint: endpoint.clone(),
-        }],
+        vec![RoCacheEndpoint::new(cache, endpoint.clone())],
     );
     let app = actix_web::test::init_service(api_server).await;
 
@@ -98,7 +95,7 @@ async fn _call_auth_token_api(
     let api_server = ApiServer::create_app_entry(
         Some(ApiSecurity::Jwt(secret)),
         CorsOptions::Permissive,
-        vec![RoCacheEndpoint { cache, endpoint }],
+        vec![RoCacheEndpoint::new(cache, endpoint)],
     );
     let app = actix_web::test::init_service(api_server).await;
 

--- a/dozer-api/src/rest/tests/routes.rs
+++ b/dozer-api/src/rest/tests/routes.rs
@@ -31,10 +31,7 @@ async fn list_route() {
     let api_server = ApiServer::create_app_entry(
         None,
         CorsOptions::Permissive,
-        vec![RoCacheEndpoint {
-            cache,
-            endpoint: endpoint.clone(),
-        }],
+        vec![RoCacheEndpoint::new(cache, endpoint.clone())],
     );
     let app = actix_web::test::init_service(api_server).await;
 
@@ -93,10 +90,7 @@ async fn count_and_query_route() {
     let api_server = ApiServer::create_app_entry(
         None,
         CorsOptions::Permissive,
-        vec![RoCacheEndpoint {
-            cache,
-            endpoint: endpoint.clone(),
-        }],
+        vec![RoCacheEndpoint::new(cache, endpoint.clone())],
     );
     let app = actix_web::test::init_service(api_server).await;
 
@@ -141,10 +135,7 @@ async fn get_route() {
     let api_server = ApiServer::create_app_entry(
         None,
         CorsOptions::Permissive,
-        vec![RoCacheEndpoint {
-            cache,
-            endpoint: endpoint.clone(),
-        }],
+        vec![RoCacheEndpoint::new(cache, endpoint.clone())],
     );
     let app = actix_web::test::init_service(api_server).await;
     let req = actix_web::test::TestRequest::get()

--- a/dozer-cache/src/reader.rs
+++ b/dozer-cache/src/reader.rs
@@ -22,15 +22,19 @@ pub struct AccessFilter {
     pub fields: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
 /// CacheReader dynamically attaches permissions on top of queries
 pub struct CacheReader {
-    pub cache: Arc<dyn RoCache>,
-    pub access: AccessFilter,
+    cache: Arc<dyn RoCache>,
 }
 
 impl CacheReader {
+    pub fn new(cache: Arc<dyn RoCache>) -> Self {
+        Self { cache }
+    }
+
     // TODO: Implement check_access
-    pub fn check_access(&self, _rec: &Record) -> Result<(), CacheError> {
+    fn check_access(&self, _rec: &Record, _access_filter: &AccessFilter) -> Result<(), CacheError> {
         Ok(())
     }
 
@@ -41,9 +45,9 @@ impl CacheReader {
         self.cache.get_schema_and_indexes_by_name(name)
     }
 
-    pub fn get(&self, key: &[u8]) -> Result<Record, CacheError> {
+    pub fn get(&self, key: &[u8], access_filter: &AccessFilter) -> Result<Record, CacheError> {
         let record = self.cache.get(key)?;
-        match self.check_access(&record) {
+        match self.check_access(&record, access_filter) {
             Ok(_) => Ok(record.to_owned()),
             Err(e) => Err(e),
         }
@@ -53,8 +57,9 @@ impl CacheReader {
         &self,
         schema_name: &str,
         query: &mut QueryExpression,
+        access_filter: AccessFilter,
     ) -> Result<Vec<RecordWithId>, CacheError> {
-        self.apply_access_filter(query);
+        self.apply_access_filter(query, access_filter);
         self.cache.query(schema_name, query)
     }
 
@@ -62,20 +67,19 @@ impl CacheReader {
         &self,
         schema_name: &str,
         query: &mut QueryExpression,
+        access_filter: AccessFilter,
     ) -> Result<usize, CacheError> {
-        self.apply_access_filter(query);
+        self.apply_access_filter(query, access_filter);
         self.cache.count(schema_name, query)
     }
 
     // Apply filter if specified in access
-    fn apply_access_filter(&self, query: &mut QueryExpression) {
-        if let Some(access_filter) = self.access.filter.to_owned() {
-            let filter = query
-                .filter
-                .as_ref()
-                .map_or(access_filter.to_owned(), |query_filter| {
-                    FilterExpression::And(vec![access_filter.to_owned(), query_filter.to_owned()])
-                });
+    fn apply_access_filter(&self, query: &mut QueryExpression, access_filter: AccessFilter) {
+        if let Some(access_filter) = access_filter.filter {
+            let filter = match query.filter.take() {
+                Some(query_filter) => FilterExpression::And(vec![access_filter, query_filter]),
+                None => access_filter,
+            };
 
             query.filter = Some(filter);
         }

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -102,13 +102,13 @@ impl Orchestrator for SimpleOrchestrator {
         for ce in &self.config.endpoints {
             let mut cache_common_options = self.cache_common_options.clone();
             cache_common_options.set_path(cache_dir.clone(), ce.name.clone());
-            cache_endpoints.push(RoCacheEndpoint {
-                cache: Arc::new(
+            cache_endpoints.push(RoCacheEndpoint::new(
+                Arc::new(
                     LmdbRoCache::new(cache_common_options)
                         .map_err(OrchestrationError::CacheInitFailed)?,
                 ),
-                endpoint: ce.to_owned(),
-            });
+                ce.clone(),
+            ));
         }
 
         let ce2 = cache_endpoints.clone();


### PR DESCRIPTION
This is part of the typed service refactoring.