### PR TITLE
feat: Return record id and version in REST API

### DIFF
--- a/dozer-cache/src/cache/lmdb/tests/basic.rs
+++ b/dozer-cache/src/cache/lmdb/tests/basic.rs
@@ -58,7 +58,7 @@ fn insert_get_and_delete_record() {
 
     let key = index::get_primary_key(&[0], &[Field::String(val)]);
 
-    let get_record = cache.get(&key).unwrap();
+    let get_record = cache.get(&key).unwrap().record;
     assert_eq!(get_record, record, "must be equal");
 
     assert_eq!(cache.delete(&key).unwrap(), version);

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -55,7 +55,7 @@ fn read_and_write() {
             b.map_or(Field::Null, Field::String),
             c.map_or(Field::Null, Field::Int),
         ];
-        assert_eq!(rec.values, values, "should be equal");
+        assert_eq!(rec.record.values, values, "should be equal");
     }
     let records = cache_reader
         .query(

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -38,7 +38,7 @@ pub trait RoCache: Send + Sync + Debug {
     ) -> Result<(Schema, Vec<IndexDefinition>), CacheError>;
 
     // Record Operations
-    fn get(&self, key: &[u8]) -> Result<Record, CacheError>;
+    fn get(&self, key: &[u8]) -> Result<RecordWithId, CacheError>;
     fn count(&self, schema_name: &str, query: &QueryExpression) -> Result<usize, CacheError>;
     fn query(
         &self,

--- a/dozer-cache/src/reader.rs
+++ b/dozer-cache/src/reader.rs
@@ -45,10 +45,14 @@ impl CacheReader {
         self.cache.get_schema_and_indexes_by_name(name)
     }
 
-    pub fn get(&self, key: &[u8], access_filter: &AccessFilter) -> Result<Record, CacheError> {
+    pub fn get(
+        &self,
+        key: &[u8],
+        access_filter: &AccessFilter,
+    ) -> Result<RecordWithId, CacheError> {
         let record = self.cache.get(key)?;
-        match self.check_access(&record, access_filter) {
-            Ok(_) => Ok(record.to_owned()),
+        match self.check_access(&record.record, access_filter) {
+            Ok(_) => Ok(record),
             Err(e) => Err(e),
         }
     }

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -481,7 +481,7 @@ mod tests {
         .unwrap();
 
         let key = index::get_primary_key(&schema.primary_index, &initial_values);
-        let record = cache.get(&key).unwrap();
+        let record = cache.get(&key).unwrap().record;
 
         assert_eq!(initial_values, record.values);
 
@@ -504,7 +504,7 @@ mod tests {
 
         // Primary key with updated values
         let key = index::get_primary_key(&schema.primary_index, &updated_values);
-        let record = cache.get(&key).unwrap();
+        let record = cache.get(&key).unwrap().record;
 
         assert_eq!(updated_values, record.values);
     }

--- a/dozer-types/src/helper.rs
+++ b/dozer-types/src/helper.rs
@@ -1,51 +1,12 @@
 use crate::errors::types::{DeserializationError, TypeError};
 use crate::types::DATE_FORMAT;
-use crate::types::{Field, FieldType, Record, Schema};
-use chrono::{DateTime, NaiveDate, SecondsFormat};
-use indexmap::IndexMap;
+use crate::types::{Field, FieldType};
+use chrono::{DateTime, NaiveDate};
 use rust_decimal::Decimal;
 use serde_json::Value;
 use std::str::FromStr;
-use std::string::FromUtf8Error;
-/// Used in REST APIs for converting to JSON
-pub fn record_to_map(rec: &Record, schema: &Schema) -> Result<IndexMap<String, Value>, TypeError> {
-    let mut map = IndexMap::new();
 
-    for (idx, field_def) in schema.fields.iter().enumerate() {
-        if rec.values.len() > idx {
-            let field = rec.values[idx].clone();
-            let val = field_to_json_value(field)
-                .map_err(|_| TypeError::InvalidFieldValue("Bson field is not valid utf8".into()))?;
-            map.insert(field_def.name.clone(), val);
-        }
-    }
-
-    Ok(map)
-}
-
-/// Used in REST APIs for converting raw value back and forth.
-///
-/// Should be consistent with `convert_cache_type_to_schema_type`.
-fn field_to_json_value(field: Field) -> Result<Value, FromUtf8Error> {
-    match field {
-        Field::UInt(n) => Ok(Value::from(n)),
-        Field::Int(n) => Ok(Value::from(n)),
-        Field::Float(n) => Ok(Value::from(n.0)),
-        Field::Boolean(b) => Ok(Value::from(b)),
-        Field::String(s) => Ok(Value::from(s)),
-        Field::Text(n) => Ok(Value::from(n)),
-        Field::Binary(b) => Ok(Value::from(b)),
-        Field::Decimal(n) => Ok(Value::String(n.to_string())),
-        Field::Timestamp(ts) => Ok(Value::String(
-            ts.to_rfc3339_opts(SecondsFormat::Millis, true),
-        )),
-        Field::Date(n) => Ok(Value::String(n.format(DATE_FORMAT).to_string())),
-        Field::Bson(b) => Ok(Value::from(b)),
-        Field::Null => Ok(Value::Null),
-    }
-}
-
-/// Used in REST APIs for converting raw value back and forth
+/// Used in REST APIs and query expressions for converting JSON value to `Field`
 pub fn json_value_to_field(
     value: Value,
     typ: FieldType,
@@ -98,72 +59,4 @@ pub fn json_value_to_field(
         )),
     }
     .map_err(TypeError::DeserializationError)
-}
-
-pub fn json_str_to_field(value: &str, typ: FieldType, nullable: bool) -> Result<Field, TypeError> {
-    let value = serde_json::from_str(value)
-        .map_err(|e| TypeError::DeserializationError(DeserializationError::Json(e)))?;
-    json_value_to_field(value, typ, nullable)
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{
-        helper::{field_to_json_value, json_value_to_field},
-        json_str_to_field,
-        types::{Field, FieldType},
-    };
-    use chrono::{NaiveDate, Offset, TimeZone, Utc};
-    use ordered_float::OrderedFloat;
-    use rust_decimal::Decimal;
-    fn test_field_conversion(field_type: FieldType, field: Field) {
-        // Convert the field to a JSON value.
-        let value = field_to_json_value(field.clone()).unwrap();
-
-        // Convert the JSON value back to a Field.
-        let deserialized = json_value_to_field(value, field_type, true).unwrap();
-
-        assert_eq!(deserialized, field, "must be equal");
-    }
-
-    #[test]
-    fn test_field_types_json_conversion() {
-        let fields = vec![
-            (FieldType::Int, Field::Int(-1)),
-            (FieldType::UInt, Field::UInt(1)),
-            (FieldType::Float, Field::Float(OrderedFloat(1.1))),
-            (FieldType::Boolean, Field::Boolean(true)),
-            (FieldType::String, Field::String("a".to_string())),
-            (FieldType::Binary, Field::Binary(b"asdf".to_vec())),
-            (FieldType::Decimal, Field::Decimal(Decimal::new(202, 2))),
-            (
-                FieldType::Timestamp,
-                Field::Timestamp(Utc.fix().with_ymd_and_hms(2001, 1, 1, 0, 4, 0).unwrap()),
-            ),
-            (
-                FieldType::Date,
-                Field::Date(NaiveDate::from_ymd_opt(2022, 11, 24).unwrap()),
-            ),
-            (
-                FieldType::Bson,
-                Field::Bson(vec![
-                    // BSON representation of `{"abc":"foo"}`
-                    123, 34, 97, 98, 99, 34, 58, 34, 102, 111, 111, 34, 125,
-                ]),
-            ),
-            (FieldType::Text, Field::Text("lorem ipsum".to_string())),
-        ];
-        for (field_type, field) in fields {
-            test_field_conversion(field_type, field);
-        }
-    }
-
-    #[test]
-    fn test_nullable_field_conversion() {
-        assert_eq!(
-            json_str_to_field("null", FieldType::Int, true).unwrap(),
-            Field::Null
-        );
-        assert!(json_str_to_field("null", FieldType::Int, false).is_err());
-    }
 }

--- a/dozer-types/src/lib.rs
+++ b/dozer-types/src/lib.rs
@@ -8,7 +8,7 @@ pub mod node;
 mod tests;
 pub mod types;
 
-pub use helper::{json_str_to_field, json_value_to_field, record_to_map};
+pub use helper::json_value_to_field;
 
 // Re-exports
 pub use bincode;


### PR DESCRIPTION
Moved `record_to_map` out of `dozer_types` because now it uses `RecrodWithId` from `dozer-cache`.

Query:

![Screenshot 2023-02-14 at 9 26 41 PM](https://user-images.githubusercontent.com/11880732/218752161-30d2808e-e2b3-4c97-80d3-de451bdb1e36.png)

Get using PK:

![Screenshot 2023-02-14 at 9 27 48 PM](https://user-images.githubusercontent.com/11880732/218752352-51dbce9f-c217-4c14-82cc-af54619cada0.png)
