### PR TITLE
fix: `TypedService` didn't filter events based on endpoint

### DIFF
--- a/dozer-api/src/grpc/typed/service.rs
+++ b/dozer-api/src/grpc/typed/service.rs
@@ -358,13 +358,20 @@ fn on_event(
         })
         .transpose()?;
 
+    let endpoint_to_be_streamed = endpoint_name.to_string();
     shared_impl::on_event(
         reader,
         endpoint_name,
         filter,
         event_notifier,
         access.cloned(),
-        move |op, _| Some(Ok(on_event_to_typed_response(op, event_desc.clone()))),
+        move |op, endpoint| {
+            if endpoint_to_be_streamed == endpoint {
+                Some(Ok(on_event_to_typed_response(op, event_desc.clone())))
+            } else {
+                None
+            }
+        },
     )
 }
 

--- a/dozer-api/src/rest/tests/auth.rs
+++ b/dozer-api/src/rest/tests/auth.rs
@@ -45,7 +45,6 @@ async fn verify_token_test() {
 
     // Without ApiSecurity
     let res = check_status(None, None).await;
-    dbg!(&res.status());
     assert!(res.status().is_success());
 
     // With ApiSecurity but no token


### PR DESCRIPTION
Fixes #657 