### PR TITLE
Add missing types.proto reference

### DIFF
--- a/dozer-api/src/generator/protoc/generator/mod.rs
+++ b/dozer-api/src/generator/protoc/generator/mod.rs
@@ -92,6 +92,7 @@ impl ProtoGenerator {
     pub fn copy_common(folder_path: &Path) -> Result<Vec<String>, GenerationError> {
         let mut resource_names = vec![];
         let protos = vec![
+            ("types", include_str!("../../../../protos/types.proto")),
             ("common", include_str!("../../../../protos/common.proto")),
             ("health", include_str!("../../../../protos/health.proto")),
         ];


### PR DESCRIPTION
When trying to run the code base it compiles but it fails to run as the `types.proto` file is not copied to the `.dozer/api/generated` folder