### PR TITLE
fix: Health check should not return `NotServing` when `dynamic` is `false`

### DIFF
--- a/dozer-api/src/grpc/client_server.rs
+++ b/dozer-api/src/grpc/client_server.rs
@@ -135,6 +135,7 @@ impl ApiServer {
         let reflection_service = web_config.enable(reflection_service);
 
         let mut service_map: HashMap<String, ServingStatus> = HashMap::new();
+        service_map.insert("".to_string(), ServingStatus::Serving);
         service_map.insert(common::SERVICE_NAME.to_string(), ServingStatus::Serving);
         if typed_service.is_some() {
             service_map.insert(typed::SERVICE_NAME.to_string(), ServingStatus::Serving);

--- a/dozer-api/src/grpc/health/tests/mod.rs
+++ b/dozer-api/src/grpc/health/tests/mod.rs
@@ -8,7 +8,8 @@ use crate::grpc::health_grpc::HealthCheckRequest;
 use super::HealthService;
 
 fn setup_health_service() -> HealthService {
-    let serving_status = HashMap::new();
+    let mut serving_status = HashMap::new();
+    serving_status.insert("".to_string(), ServingStatus::Serving);
     HealthService { serving_status }
 }
 
@@ -23,4 +24,10 @@ async fn test_grpc_health_check() {
         .unwrap()
         .into_inner();
     assert!(response.status.eq(&(ServingStatus::Serving as i32)));
+    let response = service
+        .health_check(Request::new(HealthCheckRequest {
+            service: "non-existent".to_string(),
+        }))
+        .await;
+    assert_eq!(response.unwrap_err().code(), tonic::Code::NotFound);
 }

--- a/dozer-tests/src/e2e_tests/cases/flags_dynamic_false/dozer-config.yaml
+++ b/dozer-tests/src/e2e_tests/cases/flags_dynamic_false/dozer-config.yaml
@@ -1,0 +1,48 @@
+app_name: working_app
+connections:
+  - authentication: !Ethereum
+      filter:
+        from_block: 0
+        to_block: 1
+        addresses: []
+        topics: []
+      wss_url: "{{ETH_WSS_URL}}"
+      name: eth_logs
+    db_type: Ethereum
+    name: eth_logs
+sql: |
+  -- Eth stats table
+  select block_number, sum(id) into eth_stats
+  from eth_logs
+  group by block_number;
+
+  -- Eth block stats
+  select block_number, id into eth_block_stats
+  from eth_logs
+  group by block_number, id;
+
+sources:
+  - name: eth_logs
+    table_name: eth_logs
+    columns:
+      - block_number
+      - id
+    connection: !Ref eth_logs
+endpoints:
+  - id: 1b44cca2-7631-4f0c-8b6e-254c08d28dae
+    name: eth_stats
+    table_name: eth_stats
+    path: /eth/stats
+    index:
+      primary_key:
+        - block_number
+  - name: eth_logs
+    path: /eth/logs
+    table_name: eth_block_stats
+    index:
+      primary_key:
+        - block_number
+        - id
+
+flags:
+  dynamic: false

--- a/dozer-tests/src/e2e_tests/cases/flags_dynamic_false/expectations.json
+++ b/dozer-tests/src/e2e_tests/cases/flags_dynamic_false/expectations.json
@@ -1,0 +1,3 @@
+[
+    "HealthyService"
+]


### PR DESCRIPTION
I think this implementation still conforms to https://grpc.github.io/grpc/core/md_doc_health-checking.html while not having the problem returning `NotServing` for empty string when `dynamic` is `false`.