### PR TITLE
Showcase usage of workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,9 @@ postgres = { git = "https://github.com/getdozer/rust-postgres" }
 postgres-protocol = { git = "https://github.com/getdozer/rust-postgres" }
 postgres-types = { git = "https://github.com/getdozer/rust-postgres" }
 tokio-postgres = { git = "https://github.com/getdozer/rust-postgres" }
+
+[workspace.dependencies]
+futures = "0.3.26"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.93"
+serde_yaml = "0.9.17"

--- a/dozer-admin/Cargo.toml
+++ b/dozer-admin/Cargo.toml
@@ -10,11 +10,11 @@ dozer-orchestrator = {path = "../dozer-orchestrator"}
 dozer-types = {path = "../dozer-types"}
 dozer-tracing = {path = "../dozer-tracing"}
 
-futures = "0.3.23"
+futures = { workspace = true }
 json = "0.12.4"
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.91"
-serde_yaml = "0.9.17"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 r2d2 = "0.8.2"
 diesel = { version = "2.0.3", features = ["sqlite", "serde_json", "r2d2"] }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }

--- a/dozer-cache/Cargo.toml
+++ b/dozer-cache/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 dozer-types = {path = "../dozer-types"}
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 tempdir = "0.3.7"
-futures = "0.3.26"
+futures = { workspace = true }
 unicode-segmentation = "1.10.1"
 itertools = "0.10.5"
 roaring = "0.10.1"

--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-futures = "0.3.26"
+futures = { workspace = true }
 dozer-types = { path = "../dozer-types" }
 crossbeam = "0.8.2"
 # Postgres connector

--- a/dozer-orchestrator/Cargo.toml
+++ b/dozer-orchestrator/Cargo.toml
@@ -14,8 +14,8 @@ dozer-sql = {path = "../dozer-sql"}
 dozer-types = {path = "../dozer-types"}
 dozer-tracing = {path = "../dozer-tracing"}
 dotenvy = "0.15.3"
-serde_json = "1.0.93"
-serde = "1.0.152"
+serde_json = { workspace = true }
+serde = { workspace = true }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 tokio = { version = "1", features = ["full"] }
 tempdir = "0.3.7"
@@ -28,7 +28,7 @@ handlebars = "4.3.6"
 rustyline = "10.1.1"
 rustyline-derive = "0.7.0"
 crossterm = "0.26.0"
-futures = "0.3.26"
+futures = { workspace = true }
 dozer-storage = { path = "../dozer-storage" }
 
 [[bin]]

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 chrono = {version = "0.4.23", features = ["serde"]}
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.93"
+serde = { workspace = true }
+serde_json = { workspace = true }
 rust_decimal =  {version = "1.28", features = ["serde-str", "db-postgres"]}
 bincode= "1.3.3"
 ahash = "0.8.3"
@@ -20,7 +20,7 @@ indexmap = "1.9.2"
 ordered-float = { version = "3.4.0", features = ["serde"] }
 tracing = "0.1.34"
 log = "0.4.17"
-serde_yaml = "0.9.17"
+serde_yaml = { workspace = true }
 prost = "0.11.3"
 fp_rust = "0.3.5"
 prettytable-rs = "0.10.0"


### PR DESCRIPTION
I recently saw some dependency getting the version updated across multiple sub-crates which reminded me of this recent feature for `workspace.dependencies`. I've done the change for a few to show the functionality and if it makes sense, either I can move more or someone else can take the task :)

This feature allows for defining the version/features of a given dependency at the workspace's `Cargo.toml` so that any version change can be done in a single place rather than on every sub-crate