### PR TITLE
perf: Remove `RwCache::insert_schema` so we don't read the db on every insert

### DIFF
--- a/dozer-api/src/api_helper.rs
+++ b/dozer-api/src/api_helper.rs
@@ -1,241 +1,59 @@
 use crate::auth::Access;
 use crate::errors::{ApiError, AuthError};
+use dozer_cache::cache::expression::QueryExpression;
 use dozer_cache::cache::RecordWithId;
-use dozer_cache::cache::{expression::QueryExpression, index};
-use dozer_cache::errors::CacheError;
 use dozer_cache::{AccessFilter, CacheReader};
-use dozer_types::chrono::SecondsFormat;
-use dozer_types::errors::types::{DeserializationError, TypeError};
-use dozer_types::indexmap::IndexMap;
-use dozer_types::json_value_to_field;
-use dozer_types::ordered_float::OrderedFloat;
-use dozer_types::serde_json::{Map, Value};
-use dozer_types::types::{Field, FieldType, Schema, DATE_FORMAT};
+use dozer_types::types::Schema;
 
-pub struct ApiHelper<'a> {
-    reader: &'a CacheReader,
-    access_filter: AccessFilter,
-    endpoint_name: &'a str,
+pub fn get_record(
+    cache_reader: &CacheReader,
+    key: &[u8],
+    access: Option<Access>,
+) -> Result<RecordWithId, ApiError> {
+    let access_filter = get_access_filter(access)?;
+    let record = cache_reader
+        .get(key, &access_filter)
+        .map_err(ApiError::NotFound)?;
+    Ok(record)
 }
-impl<'a> ApiHelper<'a> {
-    pub fn new(
-        reader: &'a CacheReader,
-        endpoint_name: &'a str,
-        access: Option<Access>,
-    ) -> Result<Self, ApiError> {
-        let access = access.unwrap_or(Access::All);
 
-        // Define Access Filter based on token
-        let access_filter = match access {
-            // No access filter.
-            Access::All => AccessFilter {
-                filter: None,
-                fields: vec![],
-            },
+pub fn get_records_count(
+    cache_reader: &CacheReader,
+    endpoint_name: &str,
+    exp: &mut QueryExpression,
+    access: Option<Access>,
+) -> Result<usize, ApiError> {
+    let access_filter = get_access_filter(access)?;
+    cache_reader
+        .count(endpoint_name, exp, access_filter)
+        .map_err(ApiError::CountFailed)
+}
 
-            Access::Custom(mut access_filters) => {
-                if let Some(access_filter) = access_filters.remove(endpoint_name) {
-                    access_filter
-                } else {
-                    return Err(ApiError::ApiAuthError(AuthError::InvalidToken));
-                }
+/// Get multiple records
+pub fn get_records<'a>(
+    cache_reader: &'a CacheReader,
+    endpoint_name: &str,
+    exp: &mut QueryExpression,
+    access: Option<Access>,
+) -> Result<(&'a Schema, Vec<RecordWithId>), ApiError> {
+    let access_filter = get_access_filter(access)?;
+    cache_reader
+        .query(endpoint_name, exp, access_filter)
+        .map_err(ApiError::QueryFailed)
+}
+
+fn get_access_filter(access: Option<Access>) -> Result<AccessFilter, ApiError> {
+    match access {
+        None | Some(Access::All) => Ok(AccessFilter {
+            filter: None,
+            fields: vec![],
+        }),
+        Some(Access::Custom(mut access_filters)) => {
+            if let Some(access_filter) = access_filters.remove("get_records") {
+                Ok(access_filter)
+            } else {
+                Err(ApiError::ApiAuthError(AuthError::InvalidToken))
             }
-        };
-
-        Ok(Self {
-            reader,
-            access_filter,
-            endpoint_name,
-        })
-    }
-
-    /// Get a single record by json string as primary key
-    pub fn get_record(&self, key: &str) -> Result<IndexMap<String, Value>, CacheError> {
-        let schema = self
-            .reader
-            .get_schema_and_indexes_by_name(self.endpoint_name)?
-            .0;
-
-        let key = if schema.primary_index.is_empty() {
-            json_str_to_field(key, dozer_types::types::FieldType::UInt, false)
-                .map_err(CacheError::Type)
-        } else if schema.primary_index.len() == 1 {
-            let field = &schema.fields[schema.primary_index[0]];
-            json_str_to_field(key, field.typ, field.nullable).map_err(CacheError::Type)
-        } else {
-            Err(CacheError::Query(
-                dozer_cache::errors::QueryError::MultiIndexFetch(key.to_string()),
-            ))
-        }?;
-
-        let key = index::get_primary_key(&[0], &[key]);
-        let record = self.reader.get(&key, &self.access_filter)?;
-
-        record_to_map(record, &schema).map_err(CacheError::Type)
-    }
-
-    pub fn get_records_count(self, mut exp: QueryExpression) -> Result<usize, CacheError> {
-        self.reader
-            .count(self.endpoint_name, &mut exp, self.access_filter)
-    }
-
-    /// Get multiple records
-    pub fn get_records_map(
-        self,
-        exp: QueryExpression,
-    ) -> Result<Vec<IndexMap<String, Value>>, CacheError> {
-        let mut maps = vec![];
-        let (schema, records) = self.get_records(exp)?;
-        for record in records.into_iter() {
-            let map = record_to_map(record, &schema)?;
-            maps.push(map);
         }
-        Ok(maps)
-    }
-    /// Get multiple records
-    pub fn get_records(
-        self,
-        mut exp: QueryExpression,
-    ) -> Result<(Schema, Vec<RecordWithId>), CacheError> {
-        let schema = self
-            .reader
-            .get_schema_and_indexes_by_name(self.endpoint_name)?
-            .0;
-        let records = self
-            .reader
-            .query(self.endpoint_name, &mut exp, self.access_filter)?;
-
-        Ok((schema, records))
-    }
-
-    /// Get schema
-    pub fn get_schema(&self) -> Result<Schema, CacheError> {
-        let schema = self
-            .reader
-            .get_schema_and_indexes_by_name(self.endpoint_name)?
-            .0;
-        Ok(schema)
-    }
-}
-
-/// Used in REST APIs for converting to JSON
-fn record_to_map(
-    record: RecordWithId,
-    schema: &Schema,
-) -> Result<IndexMap<String, Value>, TypeError> {
-    let mut map = IndexMap::new();
-
-    for (field_def, field) in schema.fields.iter().zip(record.record.values) {
-        let val = field_to_json_value(field);
-        map.insert(field_def.name.clone(), val);
-    }
-
-    map.insert("__dozer_record_id".to_string(), Value::from(record.id));
-    map.insert(
-        "__dozer_record_version".to_string(),
-        Value::from(record.record.version),
-    );
-
-    Ok(map)
-}
-
-fn convert_x_y_to_object((x, y): &(OrderedFloat<f64>, OrderedFloat<f64>)) -> Value {
-    let mut m = Map::new();
-    m.insert("x".to_string(), Value::from(x.0));
-    m.insert("y".to_string(), Value::from(y.0));
-    Value::Object(m)
-}
-
-/// Used in REST APIs for converting raw value back and forth.
-///
-/// Should be consistent with `convert_cache_type_to_schema_type`.
-fn field_to_json_value(field: Field) -> Value {
-    match field {
-        Field::UInt(n) => Value::from(n),
-        Field::Int(n) => Value::from(n),
-        Field::Float(n) => Value::from(n.0),
-        Field::Boolean(b) => Value::from(b),
-        Field::String(s) => Value::from(s),
-        Field::Text(n) => Value::from(n),
-        Field::Binary(b) => Value::from(b),
-        Field::Decimal(n) => Value::String(n.to_string()),
-        Field::Timestamp(ts) => Value::String(ts.to_rfc3339_opts(SecondsFormat::Millis, true)),
-        Field::Date(n) => Value::String(n.format(DATE_FORMAT).to_string()),
-        Field::Bson(b) => Value::from(b),
-        Field::Point(point) => convert_x_y_to_object(&point.0.x_y()),
-        Field::Null => Value::Null,
-    }
-}
-
-fn json_str_to_field(value: &str, typ: FieldType, nullable: bool) -> Result<Field, TypeError> {
-    let value = dozer_types::serde_json::from_str(value)
-        .map_err(|e| TypeError::DeserializationError(DeserializationError::Json(e)))?;
-    json_value_to_field(value, typ, nullable)
-}
-
-#[cfg(test)]
-mod tests {
-    use dozer_types::types::DozerPoint;
-    use dozer_types::{
-        chrono::{NaiveDate, Offset, TimeZone, Utc},
-        ordered_float::OrderedFloat,
-        rust_decimal::Decimal,
-    };
-
-    use super::*;
-
-    fn test_field_conversion(field_type: FieldType, field: Field) {
-        // Convert the field to a JSON value.
-        let value = field_to_json_value(field.clone());
-
-        // Convert the JSON value back to a Field.
-        let deserialized = json_value_to_field(value, field_type, true).unwrap();
-
-        assert_eq!(deserialized, field, "must be equal");
-    }
-
-    #[test]
-    fn test_field_types_json_conversion() {
-        let fields = vec![
-            (FieldType::Int, Field::Int(-1)),
-            (FieldType::UInt, Field::UInt(1)),
-            (FieldType::Float, Field::Float(OrderedFloat(1.1))),
-            (FieldType::Boolean, Field::Boolean(true)),
-            (FieldType::String, Field::String("a".to_string())),
-            (FieldType::Binary, Field::Binary(b"asdf".to_vec())),
-            (FieldType::Decimal, Field::Decimal(Decimal::new(202, 2))),
-            (
-                FieldType::Timestamp,
-                Field::Timestamp(Utc.fix().with_ymd_and_hms(2001, 1, 1, 0, 4, 0).unwrap()),
-            ),
-            (
-                FieldType::Date,
-                Field::Date(NaiveDate::from_ymd_opt(2022, 11, 24).unwrap()),
-            ),
-            (
-                FieldType::Bson,
-                Field::Bson(vec![
-                    // BSON representation of `{"abc":"foo"}`
-                    123, 34, 97, 98, 99, 34, 58, 34, 102, 111, 111, 34, 125,
-                ]),
-            ),
-            (FieldType::Text, Field::Text("lorem ipsum".to_string())),
-            (
-                FieldType::Point,
-                Field::Point(DozerPoint::from((3.234, 4.567))),
-            ),
-        ];
-        for (field_type, field) in fields {
-            test_field_conversion(field_type, field);
-        }
-    }
-
-    #[test]
-    fn test_nullable_field_conversion() {
-        assert_eq!(
-            json_str_to_field("null", FieldType::Int, true).unwrap(),
-            Field::Null
-        );
-        assert!(json_str_to_field("null", FieldType::Int, false).is_err());
     }
 }

--- a/dozer-api/src/generator/oapi/generator.rs
+++ b/dozer-api/src/generator/oapi/generator.rs
@@ -11,13 +11,13 @@ use openapiv3::*;
 use serde_json::{json, Value};
 use tempdir::TempDir;
 
-pub struct OpenApiGenerator {
-    schema: dozer_types::types::Schema,
-    secondary_indexes: Vec<IndexDefinition>,
+pub struct OpenApiGenerator<'a> {
+    schema: &'a dozer_types::types::Schema,
+    secondary_indexes: &'a [IndexDefinition],
     endpoint: ApiEndpoint,
     server_host: Vec<String>,
 }
-impl OpenApiGenerator {
+impl<'a> OpenApiGenerator<'a> {
     fn get_singular_name(&self) -> String {
         self.endpoint.name.to_string()
     }
@@ -244,7 +244,7 @@ impl OpenApiGenerator {
     }
 }
 
-impl OpenApiGenerator {
+impl<'a> OpenApiGenerator<'a> {
     pub fn generate_oas3(&self) -> Result<OpenAPI, GenerationError> {
         let component_schemas = self.generate_component_schema();
         let paths_available = self._generate_available_paths();
@@ -289,8 +289,8 @@ impl OpenApiGenerator {
     }
 
     pub fn new(
-        schema: dozer_types::types::Schema,
-        secondary_indexes: Vec<IndexDefinition>,
+        schema: &'a dozer_types::types::Schema,
+        secondary_indexes: &'a [IndexDefinition],
         endpoint: ApiEndpoint,
         server_host: Vec<String>,
     ) -> Self {

--- a/dozer-api/src/generator/protoc/generator/implementation.rs
+++ b/dozer-api/src/generator/protoc/generator/implementation.rs
@@ -31,7 +31,7 @@ struct ProtoMetadata {
 
 pub struct ProtoGeneratorImpl<'a> {
     handlebars: Handlebars<'a>,
-    schema: dozer_types::types::Schema,
+    schema: &'a dozer_types::types::Schema,
     names: Names,
     folder_path: &'a Path,
     security: &'a Option<ApiSecurity>,
@@ -41,12 +41,12 @@ pub struct ProtoGeneratorImpl<'a> {
 impl<'a> ProtoGeneratorImpl<'a> {
     pub fn new(
         schema_name: &str,
-        schema: Schema,
+        schema: &'a Schema,
         folder_path: &'a Path,
         security: &'a Option<ApiSecurity>,
         flags: &'a Option<Flags>,
     ) -> Result<Self, GenerationError> {
-        let names = Names::new(schema_name, &schema);
+        let names = Names::new(schema_name, schema);
         let mut generator = Self {
             handlebars: Handlebars::new(),
             schema,

--- a/dozer-api/src/generator/protoc/generator/mod.rs
+++ b/dozer-api/src/generator/protoc/generator/mod.rs
@@ -113,7 +113,7 @@ impl ProtoGenerator {
     pub fn generate(
         folder_path: &Path,
         schema_name: &str,
-        schema: Schema,
+        schema: &Schema,
         security: &Option<ApiSecurity>,
         flags: &Option<Flags>,
     ) -> Result<(), GenerationError> {

--- a/dozer-api/src/generator/protoc/tests.rs
+++ b/dozer-api/src/generator/protoc/tests.rs
@@ -28,7 +28,7 @@ fn test_generate_proto_and_descriptor() {
     ProtoGenerator::generate(
         tmp_dir_path,
         schema_name,
-        schema,
+        &schema,
         &api_security,
         &Some(flags),
     )
@@ -64,7 +64,7 @@ fn test_generate_proto_and_descriptor_with_security() {
     ProtoGenerator::generate(
         tmp_dir_path,
         schema_name,
-        schema,
+        &schema,
         &api_security,
         &Some(flags),
     )
@@ -106,7 +106,7 @@ fn test_generate_proto_and_descriptor_with_push_event_off() {
     ProtoGenerator::generate(
         tmp_dir_path,
         schema_name,
-        schema,
+        &schema,
         &Some(api_security),
         &None,
     )

--- a/dozer-api/src/rest/api_generator.rs
+++ b/dozer-api/src/rest/api_generator.rs
@@ -1,19 +1,24 @@
 use actix_web::web::ReqData;
 use actix_web::{web, HttpResponse};
 use dozer_cache::cache::expression::{default_limit_for_query, QueryExpression, Skip};
+use dozer_cache::cache::{index, RecordWithId};
 use dozer_cache::CacheReader;
+use dozer_types::chrono::SecondsFormat;
+use dozer_types::errors::types::{DeserializationError, TypeError};
+use dozer_types::indexmap::IndexMap;
 use dozer_types::log::info;
 use dozer_types::models::api_endpoint::ApiEndpoint;
+use dozer_types::ordered_float::OrderedFloat;
+use dozer_types::types::{Field, FieldType, Schema, DATE_FORMAT};
 use openapiv3::OpenAPI;
 
-use super::super::api_helper::ApiHelper;
+use crate::api_helper::{get_record, get_records, get_records_count};
 use crate::generator::oapi::generator::OpenApiGenerator;
 use crate::grpc::health_grpc::health_check_response::ServingStatus;
 use crate::RoCacheEndpoint;
 use crate::{auth::Access, errors::ApiError};
-use dozer_cache::errors::CacheError;
-use dozer_types::serde_json;
-use dozer_types::serde_json::{json, Value};
+use dozer_types::serde_json::{json, Map, Value};
+use dozer_types::{json_value_to_field, serde_json};
 
 fn generate_oapi3(reader: &CacheReader, endpoint: ApiEndpoint) -> Result<OpenAPI, ApiError> {
     let (schema, secondary_indexes) = reader
@@ -49,16 +54,30 @@ pub async fn get(
     cache_endpoint: ReqData<RoCacheEndpoint>,
     path: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
-    let helper = ApiHelper::new(
+    let schema = &cache_endpoint
+        .cache_reader
+        .get_schema_and_indexes_by_name(&cache_endpoint.endpoint.name)
+        .map_err(ApiError::SchemaNotFound)?
+        .0;
+
+    let key = path.as_str();
+    let key = if schema.primary_index.is_empty() {
+        json_str_to_field(key, dozer_types::types::FieldType::UInt, false)?
+    } else if schema.primary_index.len() == 1 {
+        let field = &schema.fields[schema.primary_index[0]];
+        json_str_to_field(key, field.typ, field.nullable)?
+    } else {
+        return Err(ApiError::MultiIndexFetch(key.to_string()));
+    };
+
+    let key = index::get_primary_key(&[0], &[key]);
+    let record = get_record(
         &cache_endpoint.cache_reader,
-        &cache_endpoint.endpoint.name,
+        &key,
         access.map(|a| a.into_inner()),
     )?;
-    let key = path.as_str();
-    helper
-        .get_record(key)
-        .map(|map| HttpResponse::Ok().json(map))
-        .map_err(ApiError::NotFound)
+
+    Ok(record_to_map(record, schema).map(|map| HttpResponse::Ok().json(map))?)
 }
 
 // Generated list function for multiple records with a default query expression
@@ -66,19 +85,11 @@ pub async fn list(
     access: Option<ReqData<Access>>,
     cache_endpoint: ReqData<RoCacheEndpoint>,
 ) -> Result<HttpResponse, ApiError> {
-    let helper = ApiHelper::new(
-        &cache_endpoint.cache_reader,
-        &cache_endpoint.endpoint.name,
-        access.map(|a| a.into_inner()),
-    )?;
-    let exp = QueryExpression::new(None, vec![], Some(50), Skip::Skip(0));
-    match helper
-        .get_records_map(exp)
-        .map(|maps| HttpResponse::Ok().json(maps))
-    {
-        Ok(res) => Ok(res),
+    let mut exp = QueryExpression::new(None, vec![], Some(50), Skip::Skip(0));
+    match get_records_map(access, cache_endpoint, &mut exp) {
+        Ok(maps) => Ok(HttpResponse::Ok().json(maps)),
         Err(e) => match e {
-            CacheError::Query(_) => {
+            ApiError::QueryFailed(_) => {
                 let res: Vec<String> = vec![];
                 info!("No records found.");
                 Ok(HttpResponse::Ok().json(res))
@@ -100,25 +111,19 @@ pub async fn count(
     cache_endpoint: ReqData<RoCacheEndpoint>,
     query_info: Option<web::Json<Value>>,
 ) -> Result<HttpResponse, ApiError> {
-    let query_expression = match query_info {
+    let mut query_expression = match query_info {
         Some(query_info) => serde_json::from_value::<QueryExpression>(query_info.0)
             .map_err(ApiError::map_deserialization_error)?,
         None => QueryExpression::with_no_limit(),
     };
 
-    let helper = ApiHelper::new(
+    get_records_count(
         &cache_endpoint.cache_reader,
         &cache_endpoint.endpoint.name,
+        &mut query_expression,
         access.map(|a| a.into_inner()),
-    )?;
-    helper
-        .get_records_count(query_expression)
-        .map(|count| HttpResponse::Ok().json(count))
-        .map_err(|e| match e {
-            CacheError::Type(e) => ApiError::TypeError(e),
-            CacheError::Internal(e) => ApiError::InternalError(e),
-            e => ApiError::InternalError(Box::new(e)),
-        })
+    )
+    .map(|count| HttpResponse::Ok().json(count))
 }
 
 // Generated query function for multiple records
@@ -135,17 +140,150 @@ pub async fn query(
     if query_expression.limit.is_none() {
         query_expression.limit = Some(default_limit_for_query());
     }
-    let helper = ApiHelper::new(
+
+    get_records_map(access, cache_endpoint, &mut query_expression)
+        .map(|maps| HttpResponse::Ok().json(maps))
+}
+
+/// Get multiple records
+fn get_records_map(
+    access: Option<ReqData<Access>>,
+    cache_endpoint: ReqData<RoCacheEndpoint>,
+    exp: &mut QueryExpression,
+) -> Result<Vec<IndexMap<String, Value>>, ApiError> {
+    let mut maps = vec![];
+    let (schema, records) = get_records(
         &cache_endpoint.cache_reader,
         &cache_endpoint.endpoint.name,
+        exp,
         access.map(|a| a.into_inner()),
     )?;
-    helper
-        .get_records_map(query_expression)
-        .map(|maps| HttpResponse::Ok().json(maps))
-        .map_err(|e| match e {
-            CacheError::Type(e) => ApiError::TypeError(e),
-            CacheError::Internal(e) => ApiError::InternalError(e),
-            e => ApiError::InternalError(Box::new(e)),
-        })
+    for record in records.into_iter() {
+        let map = record_to_map(record, schema)?;
+        maps.push(map);
+    }
+    Ok(maps)
+}
+
+/// Used in REST APIs for converting to JSON
+fn record_to_map(
+    record: RecordWithId,
+    schema: &Schema,
+) -> Result<IndexMap<String, Value>, TypeError> {
+    let mut map = IndexMap::new();
+
+    for (field_def, field) in schema.fields.iter().zip(record.record.values) {
+        let val = field_to_json_value(field);
+        map.insert(field_def.name.clone(), val);
+    }
+
+    map.insert("__dozer_record_id".to_string(), Value::from(record.id));
+    map.insert(
+        "__dozer_record_version".to_string(),
+        Value::from(record.record.version),
+    );
+
+    Ok(map)
+}
+
+fn convert_x_y_to_object((x, y): &(OrderedFloat<f64>, OrderedFloat<f64>)) -> Value {
+    let mut m = Map::new();
+    m.insert("x".to_string(), Value::from(x.0));
+    m.insert("y".to_string(), Value::from(y.0));
+    Value::Object(m)
+}
+
+/// Used in REST APIs for converting raw value back and forth.
+///
+/// Should be consistent with `convert_cache_type_to_schema_type`.
+fn field_to_json_value(field: Field) -> Value {
+    match field {
+        Field::UInt(n) => Value::from(n),
+        Field::Int(n) => Value::from(n),
+        Field::Float(n) => Value::from(n.0),
+        Field::Boolean(b) => Value::from(b),
+        Field::String(s) => Value::from(s),
+        Field::Text(n) => Value::from(n),
+        Field::Binary(b) => Value::from(b),
+        Field::Decimal(n) => Value::String(n.to_string()),
+        Field::Timestamp(ts) => Value::String(ts.to_rfc3339_opts(SecondsFormat::Millis, true)),
+        Field::Date(n) => Value::String(n.format(DATE_FORMAT).to_string()),
+        Field::Bson(b) => Value::from(b),
+        Field::Point(point) => convert_x_y_to_object(&point.0.x_y()),
+        Field::Null => Value::Null,
+    }
+}
+
+fn json_str_to_field(value: &str, typ: FieldType, nullable: bool) -> Result<Field, TypeError> {
+    let value = dozer_types::serde_json::from_str(value)
+        .map_err(|e| TypeError::DeserializationError(DeserializationError::Json(e)))?;
+    json_value_to_field(value, typ, nullable)
+}
+
+#[cfg(test)]
+mod tests {
+    use dozer_types::{
+        chrono::{NaiveDate, Offset, TimeZone, Utc},
+        json_value_to_field,
+        ordered_float::OrderedFloat,
+        rust_decimal::Decimal,
+        types::{DozerPoint, Field, FieldType},
+    };
+
+    use super::*;
+
+    fn test_field_conversion(field_type: FieldType, field: Field) {
+        // Convert the field to a JSON value.
+        let value = field_to_json_value(field.clone());
+
+        // Convert the JSON value back to a Field.
+        let deserialized = json_value_to_field(value, field_type, true).unwrap();
+
+        assert_eq!(deserialized, field, "must be equal");
+    }
+
+    #[test]
+    fn test_field_types_json_conversion() {
+        let fields = vec![
+            (FieldType::Int, Field::Int(-1)),
+            (FieldType::UInt, Field::UInt(1)),
+            (FieldType::Float, Field::Float(OrderedFloat(1.1))),
+            (FieldType::Boolean, Field::Boolean(true)),
+            (FieldType::String, Field::String("a".to_string())),
+            (FieldType::Binary, Field::Binary(b"asdf".to_vec())),
+            (FieldType::Decimal, Field::Decimal(Decimal::new(202, 2))),
+            (
+                FieldType::Timestamp,
+                Field::Timestamp(Utc.fix().with_ymd_and_hms(2001, 1, 1, 0, 4, 0).unwrap()),
+            ),
+            (
+                FieldType::Date,
+                Field::Date(NaiveDate::from_ymd_opt(2022, 11, 24).unwrap()),
+            ),
+            (
+                FieldType::Bson,
+                Field::Bson(vec![
+                    // BSON representation of `{"abc":"foo"}`
+                    123, 34, 97, 98, 99, 34, 58, 34, 102, 111, 111, 34, 125,
+                ]),
+            ),
+            (FieldType::Text, Field::Text("lorem ipsum".to_string())),
+            (
+                FieldType::Point,
+                Field::Point(DozerPoint::from((3.234, 4.567))),
+            ),
+        ];
+        for (field_type, field) in fields {
+            test_field_conversion(field_type, field);
+        }
+    }
+
+    #[test]
+    fn test_nullable_field_conversion() {
+        assert_eq!(
+            json_str_to_field("null", FieldType::Int, true).unwrap(),
+            Field::Null
+        );
+        assert!(json_str_to_field("null", FieldType::Int, false).is_err());
+    }
 }

--- a/dozer-api/src/rest/tests/routes.rs
+++ b/dozer-api/src/rest/tests/routes.rs
@@ -12,8 +12,8 @@ fn test_generate_oapi() {
     let endpoint = test_utils::get_endpoint();
 
     let oapi_generator = OpenApiGenerator::new(
-        schema,
-        secondary_indexes,
+        &schema,
+        &secondary_indexes,
         endpoint,
         vec![format!("http://localhost:{}", "8080")],
     );

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -105,10 +105,13 @@ pub fn initialize_cache(
     schema: Option<(dozer_types::types::Schema, Vec<IndexDefinition>)>,
 ) -> Arc<dyn RoCache> {
     let cache_manager = LmdbCacheManager::new(Default::default()).unwrap();
-    let cache = cache_manager.create_cache().unwrap();
     let (schema, secondary_indexes) = schema.unwrap_or_else(get_schema);
-    cache
-        .insert_schema(schema_name, &schema, &secondary_indexes)
+    let cache = cache_manager
+        .create_cache(vec![(
+            schema_name.to_string(),
+            schema.clone(),
+            secondary_indexes,
+        )])
         .unwrap();
     let records = get_sample_records(schema);
     for mut record in records {

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -27,6 +27,8 @@ fn get(cache: &dyn RwCache, n: usize) {
     let _get_record = cache.get(&key).unwrap();
 }
 
+const SCHEMA_NAME: &str = "benches";
+
 fn query(cache: &dyn RwCache, _n: usize) {
     let exp = QueryExpression::new(
         Some(FilterExpression::Simple(
@@ -39,16 +41,18 @@ fn query(cache: &dyn RwCache, _n: usize) {
         Skip::Skip(0),
     );
 
-    let _get_record = cache.query("benches", &exp).unwrap();
+    let _get_record = cache.query(SCHEMA_NAME, &exp).unwrap();
 }
 
 fn cache(c: &mut Criterion) {
     let (schema, secondary_indexes) = test_utils::schema_0();
     let cache_manager = LmdbCacheManager::new(Default::default()).unwrap();
-    let cache = cache_manager.create_cache().unwrap();
-
-    cache
-        .insert_schema("benches", &schema, &secondary_indexes)
+    let cache = cache_manager
+        .create_cache(vec![(
+            SCHEMA_NAME.to_string(),
+            schema.clone(),
+            secondary_indexes,
+        )])
         .unwrap();
 
     let size: usize = 1000000;

--- a/dozer-cache/src/cache/lmdb/cache/query/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/query/tests.rs
@@ -1,6 +1,9 @@
 use crate::cache::{
     expression::{FilterExpression, Operator, QueryExpression},
-    lmdb::{cache::LmdbRwCache, tests::utils::insert_rec_1},
+    lmdb::{
+        cache::LmdbRwCache,
+        tests::utils::{create_cache, insert_rec_1},
+    },
     test_utils::{query_from_filter, schema_1, schema_full_text, schema_multi_indices},
     RecordWithId, RoCache, RwCache,
 };
@@ -11,8 +14,25 @@ use dozer_types::{
 
 #[test]
 fn query_secondary() {
-    let cache = LmdbRwCache::new(Default::default(), Default::default()).unwrap();
+    let schema_name = "sample";
     let (schema, secondary_indexes) = schema_1();
+
+    let full_text_schema_name = "full_text_sample";
+    let (full_text_schema, full_text_secondary_indexes) = schema_full_text();
+
+    let cache = LmdbRwCache::create(
+        [
+            (schema_name.to_string(), schema.clone(), secondary_indexes),
+            (
+                full_text_schema_name.to_string(),
+                full_text_schema.clone(),
+                full_text_secondary_indexes,
+            ),
+        ],
+        Default::default(),
+        Default::default(),
+    )
+    .unwrap();
     let mut record = Record::new(
         schema.identifier,
         vec![
@@ -23,9 +43,6 @@ fn query_secondary() {
         None,
     );
 
-    cache
-        .insert_schema("sample", &schema, &secondary_indexes)
-        .unwrap();
     cache.insert(&mut record).unwrap();
     assert!(record.version.is_some());
 
@@ -41,15 +58,14 @@ fn query_secondary() {
     // Query with an expression
     let query = query_from_filter(filter);
 
-    let records = cache.query("sample", &query).unwrap();
-    assert_eq!(cache.count("sample", &query).unwrap(), 1);
+    let records = cache.query(schema_name, &query).unwrap().1;
+    assert_eq!(cache.count(schema_name, &query).unwrap(), 1);
     assert_eq!(records.len(), 1, "must be equal");
     assert_eq!(records[0].record, record, "must be equal");
 
     // Full text query.
-    let (schema, secondary_indexes) = schema_full_text();
     let mut record = Record::new(
-        schema.identifier,
+        full_text_schema.identifier,
         vec![
             Field::String("today is a good day".into()),
             Field::Text("marry has a little lamb".into()),
@@ -57,9 +73,6 @@ fn query_secondary() {
         None,
     );
 
-    cache
-        .insert_schema("full_text_sample", &schema, &secondary_indexes)
-        .unwrap();
     cache.insert(&mut record).unwrap();
     assert!(record.version.is_some());
 
@@ -67,27 +80,23 @@ fn query_secondary() {
 
     let query = query_from_filter(filter);
 
-    let records = cache.query("full_text_sample", &query).unwrap();
-    assert_eq!(cache.count("full_text_sample", &query).unwrap(), 1);
+    let records = cache.query(full_text_schema_name, &query).unwrap().1;
+    assert_eq!(cache.count(full_text_schema_name, &query).unwrap(), 1);
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].record, record);
 
     let filter = FilterExpression::Simple("bar".into(), Operator::Contains, "lamb".into());
     let query = query_from_filter(filter);
-    let records = cache.query("full_text_sample", &query).unwrap();
-    assert_eq!(cache.count("full_text_sample", &query).unwrap(), 1);
+    let records = cache.query(full_text_schema_name, &query).unwrap().1;
+    assert_eq!(cache.count(full_text_schema_name, &query).unwrap(), 1);
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].record, record);
 }
 
 #[test]
 fn query_secondary_vars() {
-    let cache = LmdbRwCache::new(Default::default(), Default::default()).unwrap();
-    let (schema, secondary_indexes) = schema_1();
-
-    cache
-        .insert_schema("sample", &schema, &secondary_indexes)
-        .unwrap();
+    let schema_name = "sample";
+    let (cache, schema, _) = create_cache(schema_name, schema_1);
 
     let items = vec![
         (1, Some("yuri".to_string()), Some(521)),
@@ -104,7 +113,7 @@ fn query_secondary_vars() {
         insert_rec_1(&cache, &schema, val);
     }
 
-    test_query(json!({}), 8, &cache);
+    test_query(json!({}), 8, &cache, schema_name);
 
     test_query(
         json!({
@@ -112,24 +121,46 @@ fn query_secondary_vars() {
         }),
         8,
         &cache,
+        schema_name,
     );
 
-    test_query(json!({"$filter":{ "a": {"$eq": 1}}}), 1, &cache);
+    test_query(
+        json!({"$filter":{ "a": {"$eq": 1}}}),
+        1,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "a": {"$eq": null}}}), 0, &cache);
+    test_query(
+        json!({"$filter":{ "a": {"$eq": null}}}),
+        0,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$eq": 521}}}), 2, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$eq": 521}}}),
+        2,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$eq": null}}}), 1, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$eq": null}}}),
+        1,
+        &cache,
+        schema_name,
+    );
 
     test_query(
         json!({"$filter":{ "a": 1, "b": "yuri".to_string()}}),
         1,
         &cache,
+        schema_name,
     );
 
     // No compound index for a,c
-    test_query_err(json!({"$filter":{ "a": 1, "c": 521}}), &cache);
+    test_query_err(json!({"$filter":{ "a": 1, "c": 521}}), &cache, schema_name);
 
     test_query(
         json!({
@@ -138,6 +169,7 @@ fn query_secondary_vars() {
         }),
         2,
         &cache,
+        schema_name,
     );
 
     test_query_record(
@@ -148,24 +180,65 @@ fn query_secondary_vars() {
         vec![(0, 1, "yuri".to_string(), 521)],
         &schema,
         &cache,
+        schema_name,
     );
 
     // Range tests
-    test_query(json!({"$filter":{ "c": {"$lte": null}}}), 0, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$lte": null}}}),
+        0,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$lte": 521}}}), 2, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$lte": 521}}}),
+        2,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$gte": 521}}}), 7, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$gte": 521}}}),
+        7,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$gt": 521}}}), 5, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$gt": 521}}}),
+        5,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$lte": 524}}}), 4, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$lte": 524}}}),
+        4,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$lt": 524}}}), 3, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$lt": 524}}}),
+        3,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$lt": 600}}}), 7, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$lt": 600}}}),
+        7,
+        &cache,
+        schema_name,
+    );
 
-    test_query(json!({"$filter":{ "c": {"$gt": 200}}}), 7, &cache);
+    test_query(
+        json!({"$filter":{ "c": {"$gt": 200}}}),
+        7,
+        &cache,
+        schema_name,
+    );
 
     test_query_record(
         json!({
@@ -178,6 +251,7 @@ fn query_secondary_vars() {
         ],
         &schema,
         &cache,
+        schema_name,
     );
 
     test_query_record(
@@ -191,17 +265,14 @@ fn query_secondary_vars() {
         ],
         &schema,
         &cache,
+        schema_name,
     );
 }
 
 #[test]
 fn query_secondary_multi_indices() {
-    let cache = LmdbRwCache::new(Default::default(), Default::default()).unwrap();
-    let (schema, secondary_indexes) = schema_multi_indices();
-
-    cache
-        .insert_schema("sample", &schema, &secondary_indexes)
-        .unwrap();
+    let schema_name = "sample";
+    let (cache, schema, _) = create_cache(schema_name, schema_multi_indices);
 
     for (id, text) in [
         (1, "apple ball cake dance"),
@@ -226,8 +297,8 @@ fn query_secondary_multi_indices() {
         FilterExpression::Simple("text".into(), Operator::Contains, Value::from("dance")),
     ]));
 
-    let records = cache.query("sample", &query).unwrap();
-    assert_eq!(cache.count("sample", &query).unwrap(), 2);
+    let records = cache.query(schema_name, &query).unwrap().1;
+    assert_eq!(cache.count(schema_name, &query).unwrap(), 2);
     assert_eq!(
         records,
         vec![
@@ -251,10 +322,10 @@ fn query_secondary_multi_indices() {
     );
 }
 
-fn test_query_err(query: Value, cache: &LmdbRwCache) {
+fn test_query_err(query: Value, cache: &dyn RwCache, schema_name: &str) {
     let query = from_value::<QueryExpression>(query).unwrap();
-    let count_result = cache.count("sample", &query);
-    let result = cache.query("sample", &query);
+    let count_result = cache.count(schema_name, &query);
+    let result = cache.query(schema_name, &query);
 
     assert!(matches!(
         count_result.unwrap_err(),
@@ -265,10 +336,10 @@ fn test_query_err(query: Value, cache: &LmdbRwCache) {
         crate::errors::CacheError::Plan(_)
     ),);
 }
-fn test_query(query: Value, count: usize, cache: &LmdbRwCache) {
+fn test_query(query: Value, count: usize, cache: &dyn RwCache, schema_name: &str) {
     let query = from_value::<QueryExpression>(query).unwrap();
-    assert_eq!(cache.count("sample", &query).unwrap(), count);
-    let records = cache.query("sample", &query).unwrap();
+    assert_eq!(cache.count(schema_name, &query).unwrap(), count);
+    let records = cache.query(schema_name, &query).unwrap().1;
 
     assert_eq!(records.len(), count, "Count must be equal : {query:?}");
 }
@@ -277,11 +348,12 @@ fn test_query_record(
     query: Value,
     expected: Vec<(u64, i64, String, i64)>,
     schema: &Schema,
-    cache: &LmdbRwCache,
+    cache: &dyn RwCache,
+    schema_name: &str,
 ) {
     let query = from_value::<QueryExpression>(query).unwrap();
-    assert_eq!(cache.count("sample", &query).unwrap(), expected.len());
-    let records = cache.query("sample", &query).unwrap();
+    assert_eq!(cache.count(schema_name, &query).unwrap(), expected.len());
+    let records = cache.query(schema_name, &query).unwrap().1;
     let expected = expected
         .into_iter()
         .map(|(id, a, b, c)| {

--- a/dozer-cache/src/cache/lmdb/tests/basic.rs
+++ b/dozer-cache/src/cache/lmdb/tests/basic.rs
@@ -7,53 +7,47 @@ use crate::cache::{
 };
 use dozer_types::{
     serde_json::Value,
-    types::{Field, IndexDefinition, Record, Schema},
+    types::{Field, Record, Schema},
 };
 
-fn _setup() -> (LmdbRwCache, Schema, Vec<IndexDefinition>) {
-    let (schema, secondary_indexes) = test_utils::schema_0();
-    let cache = LmdbRwCache::new(Default::default(), Default::default()).unwrap();
-    (cache, schema, secondary_indexes)
+use super::utils::create_cache;
+
+fn _setup() -> (LmdbRwCache, Schema, &'static str) {
+    let schema_name = "doc";
+    let (cache, schema, _) = create_cache(schema_name, test_utils::schema_0);
+    (cache, schema, schema_name)
 }
 
-fn _setup_empty_primary_index() -> (LmdbRwCache, Schema, Vec<IndexDefinition>) {
-    let (schema, secondary_indexes) = test_utils::schema_empty_primary_index();
-    let cache = LmdbRwCache::new(Default::default(), Default::default()).unwrap();
-    (cache, schema, secondary_indexes)
+fn _setup_empty_primary_index() -> (LmdbRwCache, Schema, &'static str) {
+    let schema_name = "doc";
+    let (cache, schema, _) = create_cache(schema_name, test_utils::schema_empty_primary_index);
+    (cache, schema, schema_name)
 }
 
 fn query_and_test(
-    cache: &LmdbRwCache,
+    cache: &dyn RwCache,
     inserted_record: &Record,
     schema_name: &str,
     exp: &QueryExpression,
 ) {
-    let records = cache.query(schema_name, exp).unwrap();
+    let records = cache.query(schema_name, exp).unwrap().1;
     assert_eq!(records[0].record, inserted_record.clone(), "must be equal");
 }
 
 #[test]
-fn insert_and_get_schema() {
-    let (cache, schema, secondary_indexes) = _setup();
-    cache
-        .insert_schema("test", &schema, &secondary_indexes)
-        .unwrap();
-    let schema = cache.get_schema_and_indexes_by_name("test").unwrap().0;
+fn get_schema() {
+    let (cache, _, schema_name) = _setup();
+    let schema = &cache.get_schema_and_indexes_by_name(schema_name).unwrap().0;
 
-    let get_schema = cache
-        .get_schema(&schema.identifier.to_owned().unwrap())
-        .unwrap();
+    let get_schema = cache.get_schema(schema.identifier.unwrap()).unwrap();
     assert_eq!(get_schema, schema, "must be equal");
 }
 
 #[test]
 fn insert_get_and_delete_record() {
     let val = "bar".to_string();
-    let (cache, schema, secondary_indexes) = _setup();
+    let (cache, schema, _) = _setup();
     let mut record = Record::new(schema.identifier, vec![Field::String(val.clone())], None);
-    cache
-        .insert_schema("docs", &schema, &secondary_indexes)
-        .unwrap();
     cache.insert(&mut record).unwrap();
     let version = record.version.unwrap();
 
@@ -69,7 +63,7 @@ fn insert_get_and_delete_record() {
 
 #[test]
 fn insert_and_update_record() {
-    let (cache, schema, secondary_indexes) = _setup();
+    let (cache, schema, _) = _setup();
     let mut foo = Record::new(
         schema.identifier,
         vec![Field::String("foo".to_string())],
@@ -80,9 +74,6 @@ fn insert_and_update_record() {
         vec![Field::String("bar".to_string())],
         None,
     );
-    cache
-        .insert_schema("test", &schema, &secondary_indexes)
-        .unwrap();
     cache.insert(&mut foo).unwrap();
     let old_version = foo.version.unwrap();
     cache.insert(&mut bar).unwrap();
@@ -93,17 +84,10 @@ fn insert_and_update_record() {
     assert_eq!(foo.version.unwrap(), old_version + 1);
 }
 
-fn insert_and_query_record_impl(
-    cache: LmdbRwCache,
-    schema: Schema,
-    secondary_indexes: Vec<IndexDefinition>,
-) {
+fn insert_and_query_record_impl(cache: LmdbRwCache, schema: Schema, schema_name: &str) {
     let val = "bar".to_string();
     let mut record = Record::new(schema.identifier, vec![Field::String(val)], None);
 
-    cache
-        .insert_schema("docs", &schema, &secondary_indexes)
-        .unwrap();
     cache.insert(&mut record).unwrap();
 
     // Query with an expression
@@ -113,21 +97,21 @@ fn insert_and_query_record_impl(
         Value::from("bar".to_string()),
     ));
 
-    query_and_test(&cache, &record, "docs", &exp);
+    query_and_test(&cache, &record, schema_name, &exp);
 
     // Query without an expression
     query_and_test(
         &cache,
         &record,
-        "docs",
+        schema_name,
         &QueryExpression::new(None, vec![], Some(10), Skip::Skip(0)),
     );
 }
 
 #[test]
 fn insert_and_query_record() {
-    let (cache, schema, secondary_indexes) = _setup();
-    insert_and_query_record_impl(cache, schema, secondary_indexes);
-    let (cache, schema, secondary_indexes) = _setup_empty_primary_index();
-    insert_and_query_record_impl(cache, schema, secondary_indexes);
+    let (cache, schema, schema_name) = _setup();
+    insert_and_query_record_impl(cache, schema, schema_name);
+    let (cache, schema, schema_name) = _setup_empty_primary_index();
+    insert_and_query_record_impl(cache, schema, schema_name);
 }

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -11,7 +11,10 @@ fn read_and_write() {
 
     // write and read from cache from two different threads.
 
-    let cache_writer = LmdbRwCache::new(
+    let schema_name = "sample";
+    let (schema, secondary_indexes) = test_utils::schema_1();
+    let cache_writer = LmdbRwCache::create(
+        [(schema_name.to_string(), schema.clone(), secondary_indexes)],
         CacheCommonOptions {
             max_readers: 1,
             max_db_size: 100,
@@ -24,11 +27,6 @@ fn read_and_write() {
     )
     .unwrap();
 
-    let (schema, secondary_indexes) = test_utils::schema_1();
-
-    cache_writer
-        .insert_schema("sample", &schema, &secondary_indexes)
-        .unwrap();
     let items = vec![
         (1, Some("a".to_string()), Some(521)),
         (2, Some("a".to_string()), None),
@@ -67,6 +65,7 @@ fn read_and_write() {
                 ..Default::default()
             },
         )
-        .unwrap();
+        .unwrap()
+        .1;
     assert_eq!(records.len(), 1);
 }

--- a/dozer-cache/src/cache/lmdb/tests/utils.rs
+++ b/dozer-cache/src/cache/lmdb/tests/utils.rs
@@ -1,7 +1,25 @@
 use dozer_storage::lmdb::Cursor;
-use dozer_types::types::{Field, Record, Schema};
+use dozer_types::types::{Field, IndexDefinition, Record, Schema};
 
 use crate::cache::{lmdb::cache::LmdbRwCache, RwCache};
+
+pub fn create_cache(
+    schema_name: &str,
+    schema_gen: impl FnOnce() -> (Schema, Vec<IndexDefinition>),
+) -> (LmdbRwCache, Schema, Vec<IndexDefinition>) {
+    let (schema, secondary_indexes) = schema_gen();
+    let cache = LmdbRwCache::create(
+        [(
+            schema_name.to_string(),
+            schema.clone(),
+            secondary_indexes.clone(),
+        )],
+        Default::default(),
+        Default::default(),
+    )
+    .unwrap();
+    (cache, schema, secondary_indexes)
+}
 
 pub fn insert_rec_1(
     cache: &LmdbRwCache,

--- a/dozer-cache/src/errors.rs
+++ b/dozer-cache/src/errors.rs
@@ -3,6 +3,7 @@ use dozer_types::thiserror::Error;
 
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::errors::types::{DeserializationError, SerializationError, TypeError};
+use dozer_types::types::SchemaIdentifier;
 
 #[derive(Error, Debug)]
 pub enum CacheError {
@@ -18,8 +19,14 @@ pub enum CacheError {
     Type(#[from] TypeError),
     #[error(transparent)]
     Storage(#[from] dozer_storage::errors::StorageError),
-    #[error("Schema Identifier is not present")]
-    SchemaIdentifierNotFound,
+    #[error("Schema has no identifier")]
+    SchemaHasNoIdentifier,
+    #[error("Schema Identifier is not present: {0:?}")]
+    SchemaIdentifierNotFound(SchemaIdentifier),
+    #[error("Schema is not present: {0}")]
+    SchemaNotFound(String),
+    #[error("Schema Identifier is duplicated: {0:?}")]
+    DuplicateSchemaIdentifier(SchemaIdentifier),
     #[error("Path not initialized for Cache Reader")]
     PathNotInitialized,
     #[error("Secondary index database is not found")]
@@ -43,8 +50,6 @@ impl CacheError {
 pub enum QueryError {
     #[error("Failed to get a record by id - {0:?}")]
     GetValue(#[source] dozer_storage::lmdb::Error),
-    #[error("Get by primary key is not supported when it is composite: {0:?}")]
-    MultiIndexFetch(String),
     #[error("Failed to get a schema by id - {0:?}")]
     GetSchema(#[source] dozer_storage::lmdb::Error),
     #[error("Failed to insert a record - {0:?}")]

--- a/dozer-cache/src/reader.rs
+++ b/dozer-cache/src/reader.rs
@@ -41,7 +41,7 @@ impl CacheReader {
     pub fn get_schema_and_indexes_by_name(
         &self,
         name: &str,
-    ) -> Result<(Schema, Vec<IndexDefinition>), CacheError> {
+    ) -> Result<&(Schema, Vec<IndexDefinition>), CacheError> {
         self.cache.get_schema_and_indexes_by_name(name)
     }
 
@@ -62,7 +62,7 @@ impl CacheReader {
         schema_name: &str,
         query: &mut QueryExpression,
         access_filter: AccessFilter,
-    ) -> Result<Vec<RecordWithId>, CacheError> {
+    ) -> Result<(&Schema, Vec<RecordWithId>), CacheError> {
         self.apply_access_filter(query, access_filter);
         self.cache.query(schema_name, query)
     }
@@ -79,6 +79,7 @@ impl CacheReader {
 
     // Apply filter if specified in access
     fn apply_access_filter(&self, query: &mut QueryExpression, access_filter: AccessFilter) {
+        // TODO: Use `fields` in `access_filter`.
         if let Some(access_filter) = access_filter.filter {
             let filter = match query.filter.take() {
                 Some(query_filter) => FilterExpression::And(vec![access_filter, query_filter]),

--- a/dozer-orchestrator/src/pipeline/builder.rs
+++ b/dozer-orchestrator/src/pipeline/builder.rs
@@ -117,8 +117,10 @@ impl PipelineBuilder {
 
         let conn_ports = source_builder.get_ports();
 
-        let cache_manager = LmdbCacheManager::new(cache_manager_options)
-            .map_err(OrchestrationError::CacheInitFailed)?;
+        let cache_manager = Arc::new(
+            LmdbCacheManager::new(cache_manager_options)
+                .map_err(OrchestrationError::CacheInitFailed)?,
+        );
         for api_endpoint in &self.api_endpoints {
             let table_name = &api_endpoint.table_name;
 
@@ -127,8 +129,7 @@ impl PipelineBuilder {
                 .ok_or_else(|| OrchestrationError::EndpointTableNotFound(table_name.clone()))?;
 
             let snk_factory = Arc::new(CacheSinkFactory::new(
-                vec![DEFAULT_PORT_HANDLE],
-                &cache_manager,
+                cache_manager.clone(),
                 api_endpoint.clone(),
                 notifier.clone(),
                 self.progress.clone(),

--- a/dozer-tests/src/cache_tests/film/load_database.rs
+++ b/dozer-tests/src/cache_tests/film/load_database.rs
@@ -9,7 +9,7 @@ use crate::{cache_tests::string_record_to_record, init::init, read_csv::read_csv
 use super::{film_schema, Film};
 
 pub async fn load_database(
-    secondary_indexes: &[IndexDefinition],
+    secondary_indexes: Vec<IndexDefinition>,
 ) -> (Box<dyn RoCache>, &'static str, Collection<Film>) {
     // Initialize tracing and data.
     init();
@@ -18,9 +18,12 @@ pub async fn load_database(
     let schema = film_schema();
     let schema_name = "film";
     let cache_manager = LmdbCacheManager::new(Default::default()).unwrap();
-    let cache = cache_manager.create_cache().unwrap();
-    cache
-        .insert_schema(schema_name, &schema, secondary_indexes)
+    let cache = cache_manager
+        .create_cache(vec![(
+            schema_name.to_string(),
+            schema.clone(),
+            secondary_indexes,
+        )])
         .unwrap();
 
     // Connect to mongodb and clear collection.

--- a/dozer-tests/src/cache_tests/skip_and_limit.rs
+++ b/dozer-tests/src/cache_tests/skip_and_limit.rs
@@ -14,7 +14,7 @@ pub fn validate(
     mut query: QueryExpression,
 ) -> (QueryExpression, Vec<Record>) {
     let count = cache.count(schema_name, &query).unwrap();
-    let records = cache.query(schema_name, &query).unwrap();
+    let records = cache.query(schema_name, &query).unwrap().1;
 
     let skip = query.skip;
     let limit = query.limit;
@@ -22,7 +22,7 @@ pub fn validate(
     query.skip = Skip::Skip(0);
     query.limit = None;
     let all_count = cache.count(schema_name, &query).unwrap();
-    let all_records = cache.query(schema_name, &query).unwrap();
+    let all_records = cache.query(schema_name, &query).unwrap().1;
 
     let expected_count = match skip {
         Skip::Skip(skip) => (all_count - skip).min(limit.unwrap_or(usize::MAX)),

--- a/dozer-tests/src/tests/cache.rs
+++ b/dozer-tests/src/tests/cache.rs
@@ -24,7 +24,7 @@ async fn test_cache_query() {
         IndexDefinition::FullText(12),
     ];
 
-    let (cache, schema_name, collection) = load_database(&secondary_indexes).await;
+    let (cache, schema_name, collection) = load_database(secondary_indexes).await;
 
     let test_cases = vec![
         // empty


### PR DESCRIPTION
# Core change

`RwCache::insert_schema` is removed, and `CacheManager::create_cache` not takes a `schemas` parameter.

All schema writes are performed at cache creation. Implemented in `LmdbRwCache::create`.

Schema lookup is changed from database read from hash map lookup. Implemented in `dozer-cache/src/cache/lmdb/cache/schema_database.rs`.

# Minor change

`RoCache::get_schema` and `RoCache::query` now returns `&Schema` to avoid cloning or repetitive lookup.

# Style change

Remove `ApiHelper` and use free functions instead. Functions only used in REST are moved to `dozer-api/src/rest/api_generator.rs`.

`MultiIndexFetch` is moved from `CacheError` to `ApiError`.

`OpenApiGenerator`, `ProtoGeneratorImpl` and `LmdbQueryHandler` now own references instead of values.