### PR TITLE
feat: Include id in grpc event stream

### DIFF
--- a/dozer-api/protos/films.proto
+++ b/dozer-api/protos/films.proto
@@ -73,7 +73,9 @@ message FilmEvent {
   // Old record data, only applicable for UPDATE type.
   optional Film old = 2;
   // New record data.
-  optional Film new = 3;
+  Film new = 3;
+  // New record id, only applicable for INSERT type.
+  optional uint64 new_id = 4;
 }
 
 /**

--- a/dozer-api/protos/types.proto
+++ b/dozer-api/protos/types.proto
@@ -25,8 +25,10 @@ message Operation {
   optional Record old = 2;
   // New record data.
   Record new = 3;
+  // New record id, only applicable for INSERT type.
+  optional uint64 new_id = 4;
   // Name of the endpoint that this event is from.
-  string endpoint_name = 4;
+  string endpoint_name = 5;
 }
 
 // A record, can be thought of a row in the database table.

--- a/dozer-api/src/generator/protoc/generator/implementation.rs
+++ b/dozer-api/src/generator/protoc/generator/implementation.rs
@@ -238,6 +238,7 @@ impl<'a> ProtoGeneratorImpl<'a> {
                     let typ_field = get_field(&message, "typ")?;
                     let old_field = get_field(&message, "old")?;
                     let new_field = get_field(&message, "new")?;
+                    let new_id_field = get_field(&message, "new_id")?;
                     let old_field_kind = old_field.kind();
                     let Kind::Message(record_message) = old_field_kind else {
                         return Err(GenerationError::ExpectedMessageField {
@@ -252,6 +253,7 @@ impl<'a> ProtoGeneratorImpl<'a> {
                             typ_field,
                             old_field,
                             new_field,
+                            new_id_field,
                             record_desc: record_desc_from_message(record_message)?,
                         },
                     });

--- a/dozer-api/src/generator/protoc/generator/mod.rs
+++ b/dozer-api/src/generator/protoc/generator/mod.rs
@@ -77,6 +77,7 @@ pub struct EventDesc {
     pub typ_field: FieldDescriptor,
     pub old_field: FieldDescriptor,
     pub new_field: FieldDescriptor,
+    pub new_id_field: FieldDescriptor,
     pub record_desc: RecordDesc,
 }
 

--- a/dozer-api/src/generator/protoc/generator/template/proto.tmpl
+++ b/dozer-api/src/generator/protoc/generator/template/proto.tmpl
@@ -74,7 +74,9 @@ message {{pascal_name}}Event {
   // Old record data, only applicable for UPDATE type.
   optional {{pascal_name}} old = 2;
   // New record data.
-  optional {{pascal_name}} new = 3;
+  {{pascal_name}} new = 3;
+  // New record id, only applicable for INSERT type.
+  optional uint64 new_id = 4;
 }
 {{/if}}
 /**

--- a/dozer-api/src/grpc/shared_impl/filter/tests.rs
+++ b/dozer-api/src/grpc/shared_impl/filter/tests.rs
@@ -808,6 +808,7 @@ fn test_op_satisfies_filter() {
                     typ: typ as _,
                     old: old.cloned(),
                     new: Some(new.clone()),
+                    new_id: None,
                     endpoint_name: "".into()
                 },
                 filter,

--- a/dozer-api/src/grpc/typed/helper.rs
+++ b/dozer-api/src/grpc/typed/helper.rs
@@ -25,11 +25,16 @@ pub fn on_event_to_typed_response(
         );
     }
 
-    if let Some(new) = op.new {
-        event.set_field(
-            &event_desc.new_field,
-            prost_reflect::Value::Message(internal_record_to_pb(new, &event_desc.record_desc)),
-        );
+    event.set_field(
+        &event_desc.new_field,
+        prost_reflect::Value::Message(internal_record_to_pb(
+            op.new.unwrap(),
+            &event_desc.record_desc,
+        )),
+    );
+
+    if let Some(new_id) = op.new_id {
+        event.set_field(&event_desc.new_id_field, prost_reflect::Value::U64(new_id));
     }
 
     TypedResponse::new(event)

--- a/dozer-api/src/grpc/typed/tests/fake_internal_pipeline_server.rs
+++ b/dozer-api/src/grpc/typed/tests/fake_internal_pipeline_server.rs
@@ -45,6 +45,7 @@ impl InternalPipelineService for FakeInternalPipelineServer {
                         ],
                         version: 1,
                     }),
+                    new_id: Some(0),
                     endpoint_name: "films".to_string(),
                 })),
             };

--- a/dozer-api/src/grpc/types_helper.rs
+++ b/dozer-api/src/grpc/types_helper.rs
@@ -13,8 +13,8 @@ pub fn map_operation(endpoint_name: String, operation: &DozerOperation) -> Opera
     match operation.to_owned() {
         DozerOperation::Delete { old } => Operation {
             typ: OperationType::Delete as i32,
-            old: Some(record_to_internal_record(old)),
-            new: None,
+            old: None,
+            new: Some(record_to_internal_record(old)),
             endpoint_name,
         },
         DozerOperation::Insert { new } => Operation {

--- a/dozer-api/src/grpc/types_helper.rs
+++ b/dozer-api/src/grpc/types_helper.rs
@@ -1,34 +1,43 @@
 use dozer_cache::cache::RecordWithId as CacheRecordWithId;
 use dozer_types::chrono::SecondsFormat;
 use dozer_types::ordered_float::OrderedFloat;
-use dozer_types::types::{
-    Field, FieldType, Operation as DozerOperation, Record as DozerRecord, DATE_FORMAT,
-};
+use dozer_types::types::{Field, FieldType, Record as DozerRecord, DATE_FORMAT};
 
 use crate::grpc::types::{value, Operation, OperationType, PointType, Record, Type, Value};
 
 use super::types::RecordWithId;
 
-pub fn map_operation(endpoint_name: String, operation: &DozerOperation) -> Operation {
-    match operation.to_owned() {
-        DozerOperation::Delete { old } => Operation {
-            typ: OperationType::Delete as i32,
-            old: None,
-            new: Some(record_to_internal_record(old)),
-            endpoint_name,
-        },
-        DozerOperation::Insert { new } => Operation {
-            typ: OperationType::Insert as i32,
-            old: None,
-            new: Some(record_to_internal_record(new)),
-            endpoint_name,
-        },
-        DozerOperation::Update { old, new } => Operation {
-            typ: OperationType::Insert as i32,
-            old: Some(record_to_internal_record(old)),
-            new: Some(record_to_internal_record(new)),
-            endpoint_name,
-        },
+pub fn map_insert_operation(endpoint_name: String, record: DozerRecord, id: u64) -> Operation {
+    Operation {
+        typ: OperationType::Insert as i32,
+        old: None,
+        new: Some(record_to_internal_record(record)),
+        new_id: Some(id),
+        endpoint_name,
+    }
+}
+
+pub fn map_delete_operation(endpoint_name: String, record: DozerRecord) -> Operation {
+    Operation {
+        typ: OperationType::Delete as i32,
+        old: None,
+        new: Some(record_to_internal_record(record)),
+        new_id: None,
+        endpoint_name,
+    }
+}
+
+pub fn map_update_operation(
+    endpoint_name: String,
+    old: DozerRecord,
+    new: DozerRecord,
+) -> Operation {
+    Operation {
+        typ: OperationType::Update as i32,
+        old: Some(record_to_internal_record(old)),
+        new: Some(record_to_internal_record(new)),
+        new_id: None,
+        endpoint_name,
     }
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/mod.rs
@@ -168,7 +168,7 @@ impl<C: LmdbCache> RoCache for C {
 }
 
 impl RwCache for LmdbRwCache {
-    fn insert(&self, record: &mut Record) -> Result<(), CacheError> {
+    fn insert(&self, record: &mut Record) -> Result<u64, CacheError> {
         record.version = Some(INITIAL_RECORD_VERSION);
         self.insert_impl(record)
     }
@@ -234,7 +234,7 @@ impl RwCache for LmdbRwCache {
 }
 
 impl LmdbRwCache {
-    fn insert_impl(&self, record: &Record) -> Result<(), CacheError> {
+    fn insert_impl(&self, record: &Record) -> Result<u64, CacheError> {
         let (schema, secondary_indexes) = self.get_schema_and_indexes_from_record(record)?;
 
         let mut txn = self.txn.write();
@@ -252,7 +252,9 @@ impl LmdbRwCache {
             secondary_indexes: self.common.secondary_indexes.clone(),
         };
 
-        indexer.build_indexes(txn, record, &schema, &secondary_indexes, id)
+        indexer.build_indexes(txn, record, &schema, &secondary_indexes, id)?;
+
+        Ok(id_from_bytes(id))
     }
 }
 

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -79,8 +79,8 @@ pub trait RwCache: RoCache {
     ) -> Result<(), CacheError>;
 
     // Record Operations
-    /// Sets the version of the inserted record and inserts it into the cache.
-    fn insert(&self, record: &mut Record) -> Result<(), CacheError>;
+    /// Sets the version of the inserted record and inserts it into the cache. Returns the id of the newly inserted record.
+    fn insert(&self, record: &mut Record) -> Result<u64, CacheError>;
     /// Returns version of the deleted record.
     fn delete(&self, key: &[u8]) -> Result<u32, CacheError>;
     /// Sets the version of the updated record and updates it in the cache. Returns the version of the record before the update.

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -317,7 +317,7 @@ impl Sink for CacheSink {
     fn process(
         &mut self,
         from_port: PortHandle,
-        mut op: Operation,
+        op: Operation,
         _tx: &SharedTransaction,
         _reader: &HashMap<PortHandle, Box<dyn RecordReader>>,
     ) -> Result<(), ExecutionError> {
@@ -330,8 +330,8 @@ impl Sink for CacheSink {
             .get(&from_port)
             .ok_or(ExecutionError::SchemaNotInitialized)?;
 
-        match &mut op {
-            Operation::Delete { old } => {
+        let mapped_op = match op {
+            Operation::Delete { mut old } => {
                 old.schema_id = schema.identifier;
                 let key = get_primary_key(&schema.primary_index, &old.values);
                 let version = self.cache.delete(&key).map_err(|e| {
@@ -341,36 +341,38 @@ impl Sink for CacheSink {
                     ))
                 })?;
                 old.version = Some(version);
+                types_helper::map_delete_operation(self.api_endpoint.name.clone(), old)
             }
-            Operation::Insert { new } => {
+            Operation::Insert { mut new } => {
                 new.schema_id = schema.identifier;
-                self.cache.insert(new).map_err(|e| {
+                let id = self.cache.insert(&mut new).map_err(|e| {
                     ExecutionError::SinkError(SinkError::CacheInsertFailed(
                         endpoint_name,
                         Box::new(e),
                     ))
                 })?;
+                types_helper::map_insert_operation(self.api_endpoint.name.clone(), new, id)
             }
-            Operation::Update { old, new } => {
+            Operation::Update { mut old, mut new } => {
                 old.schema_id = schema.identifier;
                 new.schema_id = schema.identifier;
                 let key = get_primary_key(&schema.primary_index, &old.values);
-                let old_version = self.cache.update(&key, new).map_err(|e| {
+                let old_version = self.cache.update(&key, &mut new).map_err(|e| {
                     ExecutionError::SinkError(SinkError::CacheUpdateFailed(
                         endpoint_name,
                         Box::new(e),
                     ))
                 })?;
                 old.version = Some(old_version);
+                types_helper::map_update_operation(self.api_endpoint.name.clone(), old, new)
             }
-        }
+        };
 
         if let Some(notifier) = &self.notifier {
-            let op = types_helper::map_operation(self.api_endpoint.name.clone(), &op);
             notifier
                 .try_send(PipelineResponse {
                     endpoint: self.api_endpoint.name.clone(),
-                    api_event: Some(ApiEvent::Op(op)),
+                    api_event: Some(ApiEvent::Op(mapped_op)),
                 })
                 .map_err(|e| ExecutionError::InternalError(Box::new(e)))?;
         }


### PR DESCRIPTION
Currently only `INSERT` operation gets `id`.

typed:

<img width="1066" alt="Screenshot 2023-02-21 at 4 18 45 PM" src="https://user-images.githubusercontent.com/11880732/220287524-1d2dd5fb-e34c-4d07-a71f-1bafbbb139fb.png">

common:

<img width="1066" alt="Screenshot 2023-02-21 at 4 20 54 PM" src="https://user-images.githubusercontent.com/11880732/220287948-2ba3eb21-6261-482d-b848-01e4d575c48c.png">
