### PR TITLE
fix: Don't create default connector config

### DIFF
--- a/dozer-ingestion/src/connectors/kafka/tests.rs
+++ b/dozer-ingestion/src/connectors/kafka/tests.rs
@@ -130,7 +130,7 @@ fn connector_disabled_test_e2e_connect_debezium_json_and_get_schema() {
         .unwrap()
         .clone()
         .config
-        .unwrap_or_default()
+        .unwrap()
     {
         broker
     } else {
@@ -187,7 +187,7 @@ fn connector_disabled_test_e2e_connect_debezium_avro_and_get_schema() {
             .unwrap()
             .clone()
             .config
-            .unwrap_or_default()
+            .unwrap()
         {
             (broker, schema_registry_url)
         } else {

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -93,7 +93,9 @@ pub struct ColumnInfo {
 }
 
 pub fn get_connector(connection: Connection) -> Result<Box<dyn Connector>, ConnectorError> {
-    let config = connection.config.unwrap_or_default();
+    let config = connection
+        .config
+        .ok_or_else(|| ConnectorError::MissingConfiguration(connection.name.clone()))?;
     match config {
         ConnectionConfig::Postgres(_) => {
             let config = map_connection_config(&config)?;

--- a/dozer-ingestion/src/connectors/postgres/tests/e2e.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/e2e.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 fn connector_disabled_test_e2e_connect_postgres_stream() {
     let config = serde_yaml::from_str::<Config>(load_config("test.postgres.yaml")).unwrap();
     let connection = config.connections.get(0).unwrap().clone();
-    let mut client = TestPostgresClient::new(&connection.config.to_owned().unwrap_or_default());
+    let mut client = TestPostgresClient::new(&connection.config.to_owned().unwrap());
 
     let mut rng = rand::thread_rng();
     let table_name = format!("products_test_{}", rng.gen::<u32>());

--- a/dozer-ingestion/src/connectors/snowflake/test_utils.rs
+++ b/dozer-ingestion/src/connectors/snowflake/test_utils.rs
@@ -5,12 +5,11 @@ use dozer_types::models::connection::{Connection, ConnectionConfig};
 use odbc::create_environment_v3;
 
 pub fn get_client(connection: &Connection) -> Client {
-    let config = match connection.config.to_owned().unwrap_or_default() {
-        ConnectionConfig::Snowflake(snowflake_config) => Some(snowflake_config),
-        _ => None,
+    let ConnectionConfig::Snowflake(config) = connection.config.as_ref().expect("Expecting connection config") else {
+        panic!("Expecting Snowflake connection config")
     };
 
-    Client::new(&config.unwrap())
+    Client::new(config)
 }
 
 pub fn remove_streams(connection: Connection, table_name: &str) -> Result<bool, SnowflakeError> {

--- a/dozer-ingestion/src/errors.rs
+++ b/dozer-ingestion/src/errors.rs
@@ -21,6 +21,9 @@ use schema_registry_converter::error::SRCError;
 
 #[derive(Error, Debug)]
 pub enum ConnectorError {
+    #[error("Missing `config` for connector {0}")]
+    MissingConfiguration(String),
+
     #[error("Table not found: {0}")]
     TableNotFound(String),
 

--- a/dozer-tests/src/e2e_tests/runner/running_env.rs
+++ b/dozer-tests/src/e2e_tests/runner/running_env.rs
@@ -329,13 +329,15 @@ fn write_dozer_config_for_running_in_docker_compose(
     };
 
     for connection in &mut config.connections {
-        let mut config = connection.config.clone().unwrap_or_default();
+        let config = connection
+            .config
+            .as_mut()
+            .expect("Connection should always have config");
 
         match config {
-            ConnectionConfig::Postgres(mut postgres) => {
+            ConnectionConfig::Postgres(postgres) => {
                 postgres.host = connection.name.clone();
                 postgres.port = map_port(postgres.port as u16) as u32;
-                config = ConnectionConfig::Postgres(postgres);
             }
             ConnectionConfig::Ethereum(_) => (),
             ConnectionConfig::Grpc(_) => (),
@@ -348,8 +350,6 @@ fn write_dozer_config_for_running_in_docker_compose(
             ConnectionConfig::S3Storage(_) => {}
             ConnectionConfig::LocalStorage(_) => {}
         }
-
-        connection.config = Some(config);
     }
 
     let config_path = dir.join("dozer-config.yaml");

--- a/dozer-types/src/models/connection.rs
+++ b/dozer-types/src/models/connection.rs
@@ -64,9 +64,3 @@ pub enum ConnectionConfig {
     /// In yaml, present as tag: `!ObjectStore`
     LocalStorage(LocalStorage),
 }
-
-impl Default for ConnectionConfig {
-    fn default() -> Self {
-        ConnectionConfig::Postgres(PostgresConfig::default())
-    }
-}


### PR DESCRIPTION
Fixes #954 

Now the error message is:

```text
2023-02-21T08:37:19.596601Z ERROR [eth_logs] X Connection validation error: Missing `config` for connector eth_logs    
2023-02-21T08:37:19.597035Z ERROR Source validation failed   
```