### PR TITLE
chore: introduce python feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,7 +1940,6 @@ dependencies = [
  "lmdb-rkv",
  "lmdb-rkv-sys",
  "num-traits",
- "pyo3",
  "sqlparser 0.30.0",
  "tempdir",
  "uuid 1.3.0",

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -16,7 +16,9 @@ uuid = {version = "1.3.0", features = ["v1", "v4", "fast-rng"]}
 dozer-types = {path = "../dozer-types"}
 dozer-core = {path = "../dozer-core"}
 dozer-tracing = {path = "../dozer-tracing"}
-pyo3 = {version = "0.18.1", features = ["auto-initialize"]}
 
 [dev-dependencies]
 tempdir = "0.3.7"
+
+[features]
+python = []

--- a/dozer-sql/src/pipeline/errors.rs
+++ b/dozer-sql/src/pipeline/errors.rs
@@ -7,7 +7,6 @@ use dozer_types::errors::types::{DeserializationError, TypeError};
 use dozer_types::thiserror;
 use dozer_types::thiserror::Error;
 use dozer_types::types::{Field, FieldType, Record};
-use pyo3::PyErr;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone)]
@@ -72,8 +71,10 @@ pub enum PipelineError {
     AmbiguousFieldIdentifier(String),
     #[error("The field identifier {0} is invalid. Correct format is: [[connection.]source.]field")]
     IllegalFieldIdentifier(String),
+
+    #[cfg(feature = "python")]
     #[error("Python Error: {0}")]
-    PythonErr(PyErr),
+    PythonErr(dozer_types::pyo3::PyErr),
 
     // Error forwarding
     #[error(transparent)]
@@ -94,9 +95,9 @@ pub enum PipelineError {
     #[error(transparent)]
     SetError(#[from] SetError),
 }
-
-impl From<PyErr> for PipelineError {
-    fn from(py_err: PyErr) -> Self {
+#[cfg(feature = "python")]
+impl From<dozer_types::pyo3::PyErr> for PipelineError {
+    fn from(py_err: dozer_types::pyo3::PyErr) -> Self {
         PipelineError::PythonErr(py_err)
     }
 }

--- a/dozer-sql/src/pipeline/expression.rs
+++ b/dozer-sql/src/pipeline/expression.rs
@@ -8,7 +8,9 @@ pub mod geo;
 pub mod logical;
 pub mod mathematical;
 pub mod operator;
-pub mod python_udf;
 pub mod scalar;
+
+#[cfg(feature = "python")]
+pub mod python_udf;
 #[cfg(test)]
 mod tests;

--- a/dozer-sql/src/pipeline/expression/builder.rs
+++ b/dozer-sql/src/pipeline/expression/builder.rs
@@ -245,6 +245,8 @@ impl ExpressionBuilder {
         schema: &Schema,
     ) -> Result<Box<Expression>, PipelineError> {
         let function_name = sql_function.name.to_string().to_lowercase();
+
+        #[cfg(feature = "python")]
         if function_name.starts_with("py_") {
             // The function is from python udf.
             let udf_name = function_name.strip_prefix("py_").unwrap();
@@ -491,6 +493,7 @@ impl ExpressionBuilder {
         }
     }
 
+    #[cfg(feature = "python")]
     fn parse_python_udf(
         context: &mut ExpressionContext,
         name: &str,

--- a/dozer-sql/src/pipeline/expression/python_udf.rs
+++ b/dozer-sql/src/pipeline/expression/python_udf.rs
@@ -3,9 +3,9 @@ use crate::pipeline::errors::PipelineError::UnsupportedSqlError;
 use crate::pipeline::errors::UnsupportedSqlError::GenericError;
 use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
 use dozer_types::ordered_float::OrderedFloat;
+use dozer_types::pyo3::types::PyTuple;
+use dozer_types::pyo3::Python;
 use dozer_types::types::{Field, FieldType, Record, Schema};
-use pyo3::types::PyTuple;
-use pyo3::Python;
 use std::env;
 use std::path::PathBuf;
 

--- a/dozer-tests/Cargo.toml
+++ b/dozer-tests/Cargo.toml
@@ -37,3 +37,4 @@ tempdir = "0.3.7"
 
 [features]
 mongodb = ["dep:bson", "dep:mongodb", "dep:futures"]
+python=[]

--- a/dozer-tests/src/tests/sql/mod.rs
+++ b/dozer-tests/src/tests/sql/mod.rs
@@ -5,6 +5,7 @@ pub mod simple;
 pub mod join;
 
 pub mod helper;
+#[cfg(feature = "python")]
 pub mod python_udf;
 
 #[derive(Clone, Debug)]

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -26,7 +26,8 @@ fp_rust = "0.3.5"
 prettytable-rs = "0.10.0"
 indicatif = "0.17.3"
 geo = {version = "0.23.1", features = ["use-serde"]}
-pyo3 = "0.18.1"
+pyo3 = {version = "0.18.1", features = ["auto-initialize"],  optional = true}
 
 [features]
+python = ["dep:pyo3"]
 snowflake=[]

--- a/dozer-types/src/lib.rs
+++ b/dozer-types/src/lib.rs
@@ -24,6 +24,8 @@ pub use parking_lot;
 #[macro_use]
 pub extern crate prettytable;
 
+#[cfg(feature = "python")]
+pub use pyo3;
 pub use rust_decimal;
 pub use serde;
 pub use serde_json;

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -1,15 +1,14 @@
 use crate::errors::types::{DeserializationError, TypeError};
+#[allow(unused_imports)]
 use chrono::{DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, TimeZone, Utc};
 use ordered_float::OrderedFloat;
-use pyo3::{PyObject, Python, ToPyObject};
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal::Decimal;
 use serde::{self, Deserialize, Serialize};
 use std::borrow::Cow;
 
-use std::fmt::{Display, Formatter};
-
 use crate::types::DozerPoint;
+use std::fmt::{Display, Formatter};
 
 pub const DATE_FORMAT: &str = "%Y-%m-%d";
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
@@ -27,30 +26,6 @@ pub enum Field {
     Bson(Vec<u8>),
     Point(DozerPoint),
     Null,
-}
-
-impl ToPyObject for Field {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        match self {
-            Field::UInt(val) => val.to_object(py),
-            Field::Int(val) => val.to_object(py),
-            Field::Float(val) => val.0.to_object(py),
-            Field::Boolean(val) => val.to_object(py),
-            Field::String(val) => val.to_object(py),
-            Field::Text(val) => val.to_object(py),
-            Field::Binary(val) => val.to_object(py),
-            Field::Decimal(val) => val.to_f64().unwrap().to_object(py),
-            Field::Timestamp(val) => val.timestamp().to_object(py),
-            Field::Date(val) => {
-                pyo3::types::PyDate::new(py, val.year(), val.month() as u8, val.day() as u8)
-                    .unwrap()
-                    .to_object(py)
-            }
-            Field::Bson(val) => val.to_object(py),
-            Field::Null => unreachable!(),
-            Field::Point(_val) => todo!(),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
@@ -569,411 +544,29 @@ pub fn field_test_cases() -> impl Iterator<Item = Field> {
     .into_iter()
 }
 
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    #[test]
-    fn data_encoding_len_must_agree_with_encode() {
-        for field in field_test_cases() {
-            let bytes = field.encode_data();
-            assert_eq!(bytes.len(), field.data_encoding_len());
+#[cfg(feature = "python")]
+use pyo3::{PyObject, Python, ToPyObject};
+#[cfg(feature = "python")]
+impl ToPyObject for Field {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        match self {
+            Field::UInt(val) => val.to_object(py),
+            Field::Int(val) => val.to_object(py),
+            Field::Float(val) => val.0.to_object(py),
+            Field::Boolean(val) => val.to_object(py),
+            Field::String(val) => val.to_object(py),
+            Field::Text(val) => val.to_object(py),
+            Field::Binary(val) => val.to_object(py),
+            Field::Decimal(val) => val.to_f64().unwrap().to_object(py),
+            Field::Timestamp(val) => val.timestamp().to_object(py),
+            Field::Date(val) => {
+                pyo3::types::PyDate::new(py, val.year(), val.month() as u8, val.day() as u8)
+                    .unwrap()
+                    .to_object(py)
+            }
+            Field::Bson(val) => val.to_object(py),
+            Field::Null => unreachable!(),
+            Field::Point(_val) => todo!(),
         }
-    }
-
-    #[test]
-    fn test_as_conversion() {
-        let field = Field::UInt(1);
-        assert!(field.as_uint().is_some());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Int(1);
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_some());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Float(OrderedFloat::from(1.0));
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_some());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Boolean(true);
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_some());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::String("".to_string());
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_some());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Text("".to_string());
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_some());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Binary(vec![]);
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_some());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Decimal(Decimal::from(1));
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_some());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Timestamp(DateTime::from(Utc.timestamp_millis_opt(0).unwrap()));
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_some());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Date(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_some());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Bson(vec![]);
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_some());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Point(DozerPoint::from((0.0, 0.0)));
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_some());
-        assert!(field.as_null().is_none());
-
-        let field = Field::Null;
-        assert!(field.as_uint().is_none());
-        assert!(field.as_int().is_none());
-        assert!(field.as_float().is_none());
-        assert!(field.as_boolean().is_none());
-        assert!(field.as_string().is_none());
-        assert!(field.as_text().is_none());
-        assert!(field.as_binary().is_none());
-        assert!(field.as_decimal().is_none());
-        assert!(field.as_timestamp().is_none());
-        assert!(field.as_date().is_none());
-        assert!(field.as_bson().is_none());
-        assert!(field.as_point().is_none());
-        assert!(field.as_null().is_some());
-    }
-
-    #[test]
-    fn test_to_conversion() {
-        let field = Field::UInt(1);
-        assert!(field.to_uint().is_some());
-        assert!(field.to_int().is_some());
-        assert!(field.to_float().is_some());
-        assert!(field.to_boolean().is_some());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_some());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Int(1);
-        assert!(field.to_uint().is_some());
-        assert!(field.to_int().is_some());
-        assert!(field.to_float().is_some());
-        assert!(field.to_boolean().is_some());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_some());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Float(OrderedFloat::from(1.0));
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_some());
-        assert!(field.to_boolean().is_some());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_some());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Boolean(true);
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_some());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::String("".to_string());
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_none());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Text("".to_string());
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_none());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Binary(vec![]);
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_none());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_some());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Decimal(Decimal::from(1));
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_some());
-        assert!(field.to_boolean().is_some());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_some());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Timestamp(DateTime::from(Utc.timestamp_millis_opt(0).unwrap()));
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_none());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_some());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Date(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_none());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_some());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Bson(vec![]);
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_none());
-        assert!(field.to_string().is_none());
-        assert!(field.to_text().is_none());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_some());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Point(DozerPoint::from((0.0, 0.0)));
-        assert!(field.to_uint().is_none());
-        assert!(field.to_int().is_none());
-        assert!(field.to_float().is_none());
-        assert!(field.to_boolean().is_none());
-        assert!(field.to_string().is_none());
-        assert!(field.to_text().is_none());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_none());
-        assert!(field.to_timestamp().unwrap().is_none());
-        assert!(field.to_date().unwrap().is_none());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_some());
-        assert!(field.to_null().is_none());
-
-        let field = Field::Null;
-        assert!(field.to_uint().is_some());
-        assert!(field.to_int().is_some());
-        assert!(field.to_float().is_some());
-        assert!(field.to_boolean().is_some());
-        assert!(field.to_string().is_some());
-        assert!(field.to_text().is_some());
-        assert!(field.to_binary().is_none());
-        assert!(field.to_decimal().is_some());
-        assert!(field.to_timestamp().unwrap().is_some());
-        assert!(field.to_date().unwrap().is_some());
-        assert!(field.to_bson().is_none());
-        assert!(field.to_point().is_none());
-        assert!(field.to_null().is_some());
     }
 }

--- a/dozer-types/src/types/tests.rs
+++ b/dozer-types/src/types/tests.rs
@@ -1,0 +1,408 @@
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn data_encoding_len_must_agree_with_encode() {
+        for field in field_test_cases() {
+            let bytes = field.encode_data();
+            assert_eq!(bytes.len(), field.data_encoding_len());
+        }
+    }
+
+    #[test]
+    fn test_as_conversion() {
+        let field = Field::UInt(1);
+        assert!(field.as_uint().is_some());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Int(1);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_some());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Float(OrderedFloat::from(1.0));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_some());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Boolean(true);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_some());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::String("".to_string());
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_some());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Text("".to_string());
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_some());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Binary(vec![]);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_some());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Decimal(Decimal::from(1));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_some());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Timestamp(DateTime::from(Utc.timestamp_millis_opt(0).unwrap()));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_some());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Date(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_some());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Bson(vec![]);
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_some());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Point(DozerPoint::from((0.0, 0.0)));
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_some());
+        assert!(field.as_null().is_none());
+
+        let field = Field::Null;
+        assert!(field.as_uint().is_none());
+        assert!(field.as_int().is_none());
+        assert!(field.as_float().is_none());
+        assert!(field.as_boolean().is_none());
+        assert!(field.as_string().is_none());
+        assert!(field.as_text().is_none());
+        assert!(field.as_binary().is_none());
+        assert!(field.as_decimal().is_none());
+        assert!(field.as_timestamp().is_none());
+        assert!(field.as_date().is_none());
+        assert!(field.as_bson().is_none());
+        assert!(field.as_point().is_none());
+        assert!(field.as_null().is_some());
+    }
+
+    #[test]
+    fn test_to_conversion() {
+        let field = Field::UInt(1);
+        assert!(field.to_uint().is_some());
+        assert!(field.to_int().is_some());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Int(1);
+        assert!(field.to_uint().is_some());
+        assert!(field.to_int().is_some());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Float(OrderedFloat::from(1.0));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Boolean(true);
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::String("".to_string());
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Text("".to_string());
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Binary(vec![]);
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_some());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Decimal(Decimal::from(1));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Timestamp(DateTime::from(Utc.timestamp_millis_opt(0).unwrap()));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_some());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Date(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_some());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Bson(vec![]);
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_some());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Point(DozerPoint::from((0.0, 0.0)));
+        assert!(field.to_uint().is_none());
+        assert!(field.to_int().is_none());
+        assert!(field.to_float().is_none());
+        assert!(field.to_boolean().is_none());
+        assert!(field.to_string().is_none());
+        assert!(field.to_text().is_none());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_none());
+        assert!(field.to_timestamp().unwrap().is_none());
+        assert!(field.to_date().unwrap().is_none());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_some());
+        assert!(field.to_null().is_none());
+
+        let field = Field::Null;
+        assert!(field.to_uint().is_some());
+        assert!(field.to_int().is_some());
+        assert!(field.to_float().is_some());
+        assert!(field.to_boolean().is_some());
+        assert!(field.to_string().is_some());
+        assert!(field.to_text().is_some());
+        assert!(field.to_binary().is_none());
+        assert!(field.to_decimal().is_some());
+        assert!(field.to_timestamp().unwrap().is_some());
+        assert!(field.to_date().unwrap().is_some());
+        assert!(field.to_bson().is_none());
+        assert!(field.to_point().is_none());
+        assert!(field.to_null().is_some());
+    }
+}


### PR DESCRIPTION
Running into issues running because of new dependencies.
```
bs"
  = note: ld: warning: directory not found for option '-L/opt/homebrew/opt/odbc/lib'
          ld: warning: directory not found for option '-L/opt/homebrew/opt/odbc/lib'
          Undefined symbols for architecture arm64:
            "_ERR_get_error_all", referenced from:
                openssl::error::Error::get::h10687d4ca56e2d56 in libopenssl-2efd15f3d78a2746.rlib(openssl-2efd15f3d78a2746.openssl.d451f57b-cgu.5.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Moving python under a feature flag `python`. 

@xudong963 Can you verify ? 