### PR TITLE
chore: Remove `cargo test connector_e2e_` because there's no test.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -68,15 +68,6 @@ jobs:
           source ./dozer-tests/python_udf/virtualenv.sh
           cargo test --all-features --no-fail-fast
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: connector_e2e_ --all-features -- --ignored
-        env:
-          CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Cinstrument-coverage"
-          LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
-
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"


### PR DESCRIPTION
This saves CI compilation time.