### PR TITLE
fix: Fix snowflake schema helper import

### DIFF
--- a/dozer-ingestion/src/connectors/snowflake/connector.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connector.rs
@@ -14,7 +14,9 @@ use crate::connectors::snowflake::stream_consumer::StreamConsumer;
 #[cfg(feature = "snowflake")]
 use dozer_types::log::{debug, info};
 
+#[cfg(feature = "snowflake")]
 use crate::connectors::snowflake::schema_helper::SchemaHelper;
+
 use dozer_types::types::SourceSchema;
 use tokio::runtime::Runtime;
 #[cfg(feature = "snowflake")]
@@ -40,6 +42,12 @@ impl Connector for SnowflakeConnector {
         Ok(())
     }
 
+    #[cfg(not(feature = "snowflake"))]
+    fn validate_schemas(&self, _tables: &[TableInfo]) -> Result<ValidationResults, ConnectorError> {
+        todo!()
+    }
+
+    #[cfg(feature = "snowflake")]
     fn validate_schemas(&self, tables: &[TableInfo]) -> Result<ValidationResults, ConnectorError> {
         SchemaHelper::validate_schemas(&self.config, tables)
     }


### PR DESCRIPTION
Fixes build error 
```
error[E0432]: unresolved import `crate::connectors::snowflake::schema_helper`
  --> dozer-ingestion/src/connectors/snowflake/connector.rs:17:35
   |
17 | use crate::connectors::snowflake::schema_helper::SchemaHelper;
   |                                   ^^^^^^^^^^^^^ could not find `schema_helper` in `snowflake`
   ```