### PR TITLE
chore: Don't fail discord notification when PR has no comment

### DIFF
--- a/.github/workflows/pulls.yaml
+++ b/.github/workflows/pulls.yaml
@@ -26,7 +26,7 @@ jobs:
           "fields": [
             { "name": "Pull Request", "value": "[${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})" },
             { "name": "Repository", "value": "[getdozer/dozer](https://github.com/getdozer/dozer)" },
-            { "name": "Message", "value": ${{ toJSON(github.event.pull_request.body) }}}
+            { "name": "Message", "value": ${{ toJSON(github.event.pull_request.body || github.event.pull_request.title) }}}
           ],
           "color": 990099
           }]'


### PR DESCRIPTION
Example PR: #1025

I have to put title in the message if body is null because Github Action doesn't allow string literal in the expression