### PR TITLE
fix: Remove non-existent proto include, which made cargo always rerun

### DIFF
--- a/dozer-types/build.rs
+++ b/dozer-types/build.rs
@@ -93,9 +93,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join("generated_films.bin"))
-        .compile(
-            &["protos/films.proto"],
-            &["protos", "google/protobuf/timestamp.proto"],
-        )?;
+        .compile(&["protos/films.proto"], &["protos"])?;
     Ok(())
 }


### PR DESCRIPTION
Closes #1062 