### PR TITLE
fix: timestamp diff, add, mul, div

### DIFF
--- a/dozer-ingestion/src/connectors/postgres/tests/client.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/client.rs
@@ -40,10 +40,9 @@ impl TestPostgresClient {
 
     pub fn create_view(&mut self, schema: &str, table_name: &str, view_name: &str) {
         self.execute_query(&format!(
-            "CREATE VIEW {}.{} AS
+            "CREATE VIEW {schema}.{view_name} AS
             SELECT id, name
-            FROM {}.{}",
-            schema, view_name, schema, table_name
+            FROM {schema}.{table_name}"
         ));
     }
 

--- a/dozer-sql/src/pipeline/expression/execution.rs
+++ b/dozer-sql/src/pipeline/expression/execution.rs
@@ -400,6 +400,12 @@ fn get_binary_operator_type(
                     SourceDefinition::Dynamic,
                     false,
                 )),
+                (FieldType::Timestamp, FieldType::Timestamp) => Ok(ExpressionType::new(
+                    FieldType::Int,
+                    false,
+                    SourceDefinition::Dynamic,
+                    false,
+                )),
                 (FieldType::Int, FieldType::Float)
                 | (FieldType::Float, FieldType::Int)
                 | (FieldType::Float, FieldType::Float) => Ok(ExpressionType::new(

--- a/dozer-sql/src/pipeline/expression/mathematical.rs
+++ b/dozer-sql/src/pipeline/expression/mathematical.rs
@@ -27,6 +27,21 @@ macro_rules! define_math_operator {
                             let duration = left_v - right_v;
                             Ok(Field::Int(duration.num_milliseconds()))
                         }
+                        "+" => {
+                            let left_duration = left_v.timestamp_millis();
+                            let right_duration = right_v.timestamp_millis();
+                            Ok(Field::Int(left_duration + right_duration))
+                        }
+                        "*" => {
+                            let left_duration = left_v.timestamp_millis();
+                            let right_duration = right_v.timestamp_millis();
+                            Ok(Field::Int(left_duration * right_duration))
+                        }
+                        "/" => {
+                            let left_duration = left_v.timestamp_millis();
+                            let right_duration = right_v.timestamp_millis();
+                            Ok(Field::Int(left_duration / right_duration))
+                        }
                         _ => Err(PipelineError::InvalidOperandType($op.to_string())),
                     },
                     _ => Err(PipelineError::InvalidOperandType($op.to_string())),

--- a/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
@@ -43,3 +43,38 @@ fn test_timestamp() {
     );
     assert_eq!(f, Field::Int(0));
 }
+
+
+#[test]
+fn test_timestamp_diff() {
+    let f = run_scalar_fct(
+        "SELECT ts1 - ts2 FROM users",
+        Schema::empty()
+            .field(
+                FieldDefinition::new(
+                    String::from("ts1"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .field(
+                FieldDefinition::new(
+                    String::from("ts2"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .clone(),
+        vec![Field::Timestamp(
+            DateTime::parse_from_rfc3339("2023-01-02T00:12:11Z").unwrap(),
+        ),
+         Field::Timestamp(
+             DateTime::parse_from_rfc3339("2023-01-02T00:12:10Z").unwrap(),
+         )],
+    );
+    assert_eq!(f, Field::Int(1000));
+}

--- a/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
@@ -44,7 +44,6 @@ fn test_timestamp() {
     assert_eq!(f, Field::Int(0));
 }
 
-
 #[test]
 fn test_timestamp_diff() {
     let f = run_scalar_fct(
@@ -69,12 +68,10 @@ fn test_timestamp_diff() {
                 false,
             )
             .clone(),
-        vec![Field::Timestamp(
-            DateTime::parse_from_rfc3339("2023-01-02T00:12:11Z").unwrap(),
-        ),
-         Field::Timestamp(
-             DateTime::parse_from_rfc3339("2023-01-02T00:12:10Z").unwrap(),
-         )],
+        vec![
+            Field::Timestamp(DateTime::parse_from_rfc3339("2023-01-02T00:12:11Z").unwrap()),
+            Field::Timestamp(DateTime::parse_from_rfc3339("2023-01-02T00:12:10Z").unwrap()),
+        ],
     );
     assert_eq!(f, Field::Int(1000));
 }

--- a/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
@@ -75,3 +75,67 @@ fn test_timestamp_diff() {
     );
     assert_eq!(f, Field::Int(1000));
 }
+
+#[test]
+fn test_timestamp_add() {
+    let f = run_scalar_fct(
+        "SELECT ts1 + ts2 FROM users",
+        Schema::empty()
+            .field(
+                FieldDefinition::new(
+                    String::from("ts1"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .field(
+                FieldDefinition::new(
+                    String::from("ts2"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .clone(),
+        vec![
+            Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
+            Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
+        ],
+    );
+    assert_eq!(f, Field::Int(20000));
+}
+
+#[test]
+fn test_timestamp_mul() {
+    let f = run_scalar_fct(
+        "SELECT ts1 * ts2 FROM users",
+        Schema::empty()
+            .field(
+                FieldDefinition::new(
+                    String::from("ts1"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .field(
+                FieldDefinition::new(
+                    String::from("ts2"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .clone(),
+        vec![
+            Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
+            Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
+        ],
+    );
+    assert_eq!(f, Field::Int(100000000));
+}


### PR DESCRIPTION
fix: timestamp diff, add, mul, div

- utilizing unix milliseoncds of the timestamp to perform +, -, *, /

todo: support for `Interval`