### PR TITLE
fix: Use same progress bar style (expect for color) for source and sink

### DIFF
--- a/dozer-orchestrator/src/pipeline/connector_source.rs
+++ b/dozer-orchestrator/src/pipeline/connector_source.rs
@@ -22,7 +22,7 @@ fn attach_progress(multi_pb: Option<MultiProgress>) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
     multi_pb.as_ref().map(|m| m.add(pb.clone()));
     pb.set_style(
-        ProgressStyle::with_template("{msg}: {spinner:.red} {pos} : {per_sec}")
+        ProgressStyle::with_template("{spinner:.red} {msg}: {pos}: {per_sec}")
             .unwrap()
             // For more spinners check out the cli-spinners project:
             // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -29,7 +29,7 @@ fn attach_progress(multi_pb: Option<MultiProgress>) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
     multi_pb.as_ref().map(|m| m.add(pb.clone()));
     pb.set_style(
-        ProgressStyle::with_template("{spinner:.blue} {msg} {pos} : {per_sec}")
+        ProgressStyle::with_template("{spinner:.blue} {msg}: {pos}: {per_sec}")
             .unwrap()
             // For more spinners check out the cli-spinners project:
             // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json


### PR DESCRIPTION
# Before

```text
stocks_meta: ▹▸▹▹▹ 8000 : 15,717.4372/s
stocks: ▸▹▹▹▹ 19000 : 102,344.652/s
stocks_meta: ▹▸▹▹▹ 8000 : 15,717.4372/s
stocks: ▹▸▹▹▹ 20000 : 103,526.3387/s
stocks_meta: ▹▸▹▹▹ 8000 : 15,717.4372/s
stocks: ▹▸▹▹▹ 20000 : 103,526.3387/s
▸▹▹▹▹ stocks 20049 : 19,054.2494/s
▸▹▹▹▹ stocks_meta 8050 : 1,269.6193/s                                   
```

# After

```text
▹▹▹▸▹ stocks: 16000: 26,675.5882/s
▹▸▹▹▹ stocks_meta: 8000: 14,558.2636/s
▹▸▹▹▹ stocks: 20000: 103,293.2523/s
▹▸▹▹▹ stocks_meta: 8000: 14,558.2636/s
▹▸▹▹▹ stocks: 20000: 103,293.2523/s
▹▸▹▹▹ stocks_meta: 8000: 14,558.2636/s
▹▸▹▹▹ stocks: 20049: 1,214.6517/s
▹▸▹▹▹ stocks_meta: 8050: 919.5672/s      
```