### PR TITLE
chore: Move `SnapshottingDone` out of `Operation` so processors don't have to know it.

### DIFF
--- a/dozer-core/src/channels.rs
+++ b/dozer-core/src/channels.rs
@@ -2,16 +2,11 @@ use crate::errors::ExecutionError;
 use crate::node::PortHandle;
 use core::marker::{Send, Sync};
 use core::result::Result;
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::types::Operation;
 
 pub trait SourceChannelForwarder: Send + Sync {
-    fn send(
-        &mut self,
-        txid: u64,
-        seq_in_tx: u64,
-        op: Operation,
-        port: PortHandle,
-    ) -> Result<(), ExecutionError>;
+    fn send(&mut self, message: IngestionMessage, port: PortHandle) -> Result<(), ExecutionError>;
 }
 
 pub trait ProcessorChannelForwarder {

--- a/dozer-core/src/executor.rs
+++ b/dozer-core/src/executor.rs
@@ -51,6 +51,7 @@ pub enum ExecutorOperation {
     Op { op: Operation },
     Commit { epoch: Epoch },
     Terminate,
+    SnapshottingDone {},
 }
 
 mod execution_dag;

--- a/dozer-core/src/executor/processor_node.rs
+++ b/dozer-core/src/executor/processor_node.rs
@@ -113,4 +113,8 @@ impl ReceiverLoop for ProcessorNode {
     fn on_terminate(&mut self) -> Result<(), ExecutionError> {
         self.channel_manager.send_terminate()
     }
+
+    fn on_snapshotting_done(&mut self) -> Result<(), ExecutionError> {
+        self.channel_manager.send_snapshotting_done()
+    }
 }

--- a/dozer-core/src/executor/sink_node.rs
+++ b/dozer-core/src/executor/sink_node.rs
@@ -109,4 +109,8 @@ impl ReceiverLoop for SinkNode {
     fn on_terminate(&mut self) -> Result<(), ExecutionError> {
         Ok(())
     }
+
+    fn on_snapshotting_done(&mut self) -> Result<(), ExecutionError> {
+        self.sink.on_source_snapshotting_done()
+    }
 }

--- a/dozer-core/src/executor/source_node.rs
+++ b/dozer-core/src/executor/source_node.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crossbeam::channel::{bounded, Receiver, RecvTimeoutError, Sender};
-use dozer_types::types::Operation;
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::{
     log::debug,
     node::{NodeHandle, OpIdentifier},
@@ -24,14 +24,8 @@ use crate::{
 use super::{execution_dag::ExecutionDag, node::Node, ExecutorOptions};
 
 impl SourceChannelForwarder for InternalChannelSourceForwarder {
-    fn send(
-        &mut self,
-        txid: u64,
-        seq_in_tx: u64,
-        op: Operation,
-        port: PortHandle,
-    ) -> Result<(), ExecutionError> {
-        Ok(self.sender.send((port, txid, seq_in_tx, op))?)
+    fn send(&mut self, message: IngestionMessage, port: PortHandle) -> Result<(), ExecutionError> {
+        Ok(self.sender.send((port, message))?)
     }
 }
 
@@ -72,7 +66,7 @@ pub struct SourceListenerNode {
     /// Node handle in description DAG.
     node_handle: NodeHandle,
     /// Output from corresponding source sender.
-    receiver: Receiver<(PortHandle, u64, u64, Operation)>,
+    receiver: Receiver<(PortHandle, IngestionMessage)>,
     /// Receiving timeout.
     timeout: Duration,
     /// If the execution DAG should be running. Used for determining if a `terminate` message should be sent.
@@ -83,7 +77,7 @@ pub struct SourceListenerNode {
 
 #[derive(Debug, Clone, PartialEq)]
 enum DataKind {
-    Data((PortHandle, u64, u64, Operation)),
+    Data((PortHandle, IngestionMessage)),
     NoDataBecauseOfTimeout,
     NoDataBecauseOfChannelDisconnection,
 }
@@ -99,9 +93,9 @@ impl SourceListenerNode {
             || !self.running.load(Ordering::SeqCst);
         // If this commit was not requested with termination at the start, we shouldn't terminate either.
         let terminating = match data {
-            DataKind::Data((port, txid, seq_in_tx, op)) => self
+            DataKind::Data((port, message)) => self
                 .channel_manager
-                .send_and_trigger_commit_if_needed(txid, seq_in_tx, op, port, terminating)?,
+                .send_and_trigger_commit_if_needed(message, port, terminating)?,
             DataKind::NoDataBecauseOfTimeout | DataKind::NoDataBecauseOfChannelDisconnection => {
                 self.channel_manager.trigger_commit_if_needed(terminating)?
             }
@@ -135,11 +129,11 @@ impl Node for SourceListenerNode {
 
 #[derive(Debug)]
 struct InternalChannelSourceForwarder {
-    sender: Sender<(PortHandle, u64, u64, Operation)>,
+    sender: Sender<(PortHandle, IngestionMessage)>,
 }
 
 impl InternalChannelSourceForwarder {
-    pub fn new(sender: Sender<(PortHandle, u64, u64, Operation)>) -> Self {
+    pub fn new(sender: Sender<(PortHandle, IngestionMessage)>) -> Self {
         Self { sender }
     }
 }

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -119,4 +119,6 @@ pub trait Sink: Send + Sync + Debug {
         state: &SharedTransaction,
         reader: &HashMap<PortHandle, Box<dyn RecordReader>>,
     ) -> Result<(), ExecutionError>;
+
+    fn on_source_snapshotting_done(&mut self) -> Result<(), ExecutionError>;
 }

--- a/dozer-core/src/record_store.rs
+++ b/dozer-core/src/record_store.rs
@@ -290,7 +290,6 @@ impl RecordWriter for PrimaryKeyLookupRecordWriter {
                 new.version = Some(curr_version + 1);
                 Ok(Operation::Update { old, new })
             }
-            Operation::SnapshottingDone { .. } => Ok(op),
         }
     }
 }
@@ -427,7 +426,6 @@ impl RecordWriter for AutogenRowKeyLookupRecordWriter {
             Operation::Delete { .. } => Err(UnsupportedDeleteOperation(
                 "AutogenRowsIdLookupRecordWriter does not support delete operations".to_string(),
             )),
-            Operation::SnapshottingDone { .. } => Ok(op),
         }
     }
 }

--- a/dozer-core/src/tests/dag_recordreader_update.rs
+++ b/dozer-core/src/tests/dag_recordreader_update.rs
@@ -11,6 +11,7 @@ use crate::tests::app::NoneContext;
 use crate::tests::sinks::{CountingSinkFactory, COUNTING_SINK_INPUT_PORT};
 use crate::{Dag, Endpoint};
 use dozer_storage::lmdb_storage::{LmdbExclusiveTransaction, SharedTransaction};
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
@@ -116,18 +117,20 @@ impl Source for GeneratorSource {
 
         for n in 0..self.count {
             fw.send(
-                txid,
-                0,
-                Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    txid,
+                    0,
+                    Operation::Insert {
+                        new: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 GENERATOR_SOURCE_OUTPUT_PORT,
             )?;
             txid += 1;
@@ -135,26 +138,28 @@ impl Source for GeneratorSource {
 
         for n in 0..self.count {
             fw.send(
-                txid,
-                0,
-                Operation::Update {
-                    old: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    txid,
+                    0,
+                    Operation::Update {
+                        old: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                        new: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 GENERATOR_SOURCE_OUTPUT_PORT,
             )?;
             txid += 1;
@@ -162,18 +167,20 @@ impl Source for GeneratorSource {
 
         for n in 0..self.count {
             fw.send(
-                txid,
-                0,
-                Operation::Delete {
-                    old: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    txid,
+                    0,
+                    Operation::Delete {
+                        old: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 GENERATOR_SOURCE_OUTPUT_PORT,
             )?;
             txid += 1;

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -95,6 +95,10 @@ impl Sink for CountingSink {
         }
         Ok(())
     }
+
+    fn on_source_snapshotting_done(&mut self) -> Result<(), ExecutionError> {
+        Ok(())
+    }
 }
 
 #[derive(Debug)]

--- a/dozer-core/src/tests/sources.rs
+++ b/dozer-core/src/tests/sources.rs
@@ -2,6 +2,7 @@ use crate::channels::SourceChannelForwarder;
 use crate::errors::ExecutionError;
 use crate::node::{OutputPortDef, OutputPortType, PortHandle, Source, SourceFactory};
 use crate::DEFAULT_PORT_HANDLE;
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
 };
@@ -108,18 +109,20 @@ impl Source for GeneratorSource {
 
         for n in start + 1..(start + self.count + 1) {
             fw.send(
-                n,
-                0,
-                Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    n,
+                    0,
+                    Operation::Insert {
+                        new: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 GENERATOR_SOURCE_OUTPUT_PORT,
             )?;
         }
@@ -241,33 +244,37 @@ impl Source for DualPortGeneratorSource {
     ) -> Result<(), ExecutionError> {
         for n in 1..(self.count + 1) {
             fw.send(
-                n,
-                0,
-                Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    n,
+                    0,
+                    Operation::Insert {
+                        new: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 DUAL_PORT_GENERATOR_SOURCE_OUTPUT_PORT_1,
             )?;
             fw.send(
-                n,
-                0,
-                Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    n,
+                    0,
+                    Operation::Insert {
+                        new: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 DUAL_PORT_GENERATOR_SOURCE_OUTPUT_PORT_2,
             )?;
         }
@@ -370,18 +377,20 @@ impl Source for NoPkGeneratorSource {
 
         for n in start + 1..(start + self.count + 1) {
             fw.send(
-                n,
-                0,
-                Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String(format!("key_{n}")),
-                            Field::String(format!("value_{n}")),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    n,
+                    0,
+                    Operation::Insert {
+                        new: Record::new(
+                            None,
+                            vec![
+                                Field::String(format!("key_{n}")),
+                                Field::String(format!("value_{n}")),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 GENERATOR_SOURCE_OUTPUT_PORT,
             )?;
         }

--- a/dozer-ingestion/src/connectors/ethereum/log/sender.rs
+++ b/dozer-ingestion/src/connectors/ethereum/log/sender.rs
@@ -241,12 +241,10 @@ fn process_log(details: Arc<EthDetails>, msg: Log) -> Result<(), ConnectorError>
             // Write eth_log record
             details
                 .ingestor
-                .handle_message((
-                    (
-                        msg.block_number.expect("expected for non pending").as_u64(),
-                        0,
-                    ),
-                    IngestionMessage::OperationEvent(op),
+                .handle_message(IngestionMessage::new_op(
+                    msg.block_number.expect("expected for non pending").as_u64(),
+                    0,
+                    op,
                 ))
                 .map_err(ConnectorError::IngestorError)?;
         } else {
@@ -265,7 +263,7 @@ fn process_log(details: Arc<EthDetails>, msg: Log) -> Result<(), ConnectorError>
             trace!("Writing event : {:?}", op);
             details
                 .ingestor
-                .handle_message(((0, 0), IngestionMessage::OperationEvent(op)))
+                .handle_message(IngestionMessage::new_op(0, 0, op))
                 .map_err(ConnectorError::IngestorError)?;
         } else {
             trace!("Writing event : {:?}", op);

--- a/dozer-ingestion/src/connectors/ethereum/trace/connector.rs
+++ b/dozer-ingestion/src/connectors/ethereum/trace/connector.rs
@@ -105,10 +105,6 @@ pub async fn run(
     );
     let batch_iter = BatchIterator::new(config.from_block, config.to_block, config.batch_size);
 
-    ingestor
-        .handle_message(((config.from_block, 0), IngestionMessage::Begin()))
-        .map_err(ConnectorError::IngestorError)?;
-
     let mut errors: Vec<ConnectorError> = vec![];
     for batch in batch_iter {
         for retry in 0..RETRIES {
@@ -124,9 +120,8 @@ pub async fn run(
                         let ops = map_trace_to_ops(&result.result);
 
                         for op in ops {
-                            let message = IngestionMessage::OperationEvent(op);
                             ingestor
-                                .handle_message(((batch.0, 0), message))
+                                .handle_message(IngestionMessage::new_op(batch.0, 0, op))
                                 .map_err(ConnectorError::IngestorError)?;
                         }
                     }

--- a/dozer-ingestion/src/connectors/ethereum/trace/tests.rs
+++ b/dozer-ingestion/src/connectors/ethereum/trace/tests.rs
@@ -1,7 +1,7 @@
 use std::{env, thread, time::Duration};
 
 use dozer_types::{
-    ingestion_types::EthTraceConfig,
+    ingestion_types::{EthTraceConfig, IngestionMessage, IngestionMessageKind},
     log::info,
     types::{Field, Operation},
 };
@@ -72,7 +72,11 @@ fn test_trace_iterator() {
         connector.start(None, &ingestor, vec![]).unwrap();
     });
 
-    if let Some((_, op)) = iterator.next_timeout(Duration::from_millis(1000)) {
+    if let Some(IngestionMessage {
+        kind: IngestionMessageKind::OperationEvent(op),
+        ..
+    }) = iterator.next_timeout(Duration::from_millis(1000))
+    {
         assert!(matches!(op, Operation::Insert { .. }));
         if let Operation::Insert { new } = op {
             assert!(matches!(new.values[0], Field::String(_)));

--- a/dozer-ingestion/src/connectors/grpc/connector.rs
+++ b/dozer-ingestion/src/connectors/grpc/connector.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use dozer_types::ingestion_types::{GrpcConfig, IngestionMessage};
+use dozer_types::ingestion_types::GrpcConfig;
 use dozer_types::log::info;
 use dozer_types::serde_json;
 use dozer_types::types::{Schema, SchemaIdentifier, SourceSchema};
@@ -27,16 +27,6 @@ pub struct GrpcConnector {
 impl GrpcConnector {
     pub fn new(id: u64, name: String, config: GrpcConfig) -> Self {
         Self { id, name, config }
-    }
-
-    pub fn push(
-        &mut self,
-        ingestor: Ingestor,
-        msg: IngestionMessage,
-    ) -> Result<(), ConnectorError> {
-        ingestor
-            .handle_message(((0, 0), msg))
-            .map_err(ConnectorError::IngestorError)
     }
 
     pub fn parse_schemas(config: &GrpcConfig) -> Result<Vec<SourceSchema>, ConnectorError> {

--- a/dozer-ingestion/src/connectors/grpc/ingest.rs
+++ b/dozer-ingestion/src/connectors/grpc/ingest.rs
@@ -51,7 +51,7 @@ impl IngestorServiceImpl {
             },
         };
         ingestor
-            .handle_message(((0, req.seq_no as u64), IngestionMessage::OperationEvent(op)))
+            .handle_message(IngestionMessage::new_op(0, req.seq_no as u64, op))
             .map_err(|e| tonic::Status::internal(format!("ingestion error: {e}")))?;
         Ok(tonic::Response::new(IngestResponse { seq_no: req.seq_no }))
     }

--- a/dozer-ingestion/src/connectors/kafka/debezium/stream_consumer.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/stream_consumer.rs
@@ -136,9 +136,10 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                 })?;
 
                                 ingestor
-                                    .handle_message((
-                                        (0, 0),
-                                        IngestionMessage::OperationEvent(Operation::Update {
+                                    .handle_message(IngestionMessage::new_op(
+                                        0,
+                                        0,
+                                        Operation::Update {
                                             old: Record {
                                                 schema_id: Some(SchemaIdentifier {
                                                     id: 1,
@@ -155,7 +156,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                                 values: new,
                                                 version: None,
                                             },
-                                        }),
+                                        },
                                     ))
                                     .map_err(ConnectorError::IngestorError)?;
                             }
@@ -168,9 +169,10 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                     })?;
 
                                 ingestor
-                                    .handle_message((
-                                        (0, 0),
-                                        IngestionMessage::OperationEvent(Operation::Delete {
+                                    .handle_message(IngestionMessage::new_op(
+                                        0,
+                                        0,
+                                        Operation::Delete {
                                             old: Record {
                                                 schema_id: Some(SchemaIdentifier {
                                                     id: 1,
@@ -179,7 +181,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                                 values: old,
                                                 version: None,
                                             },
-                                        }),
+                                        },
                                     ))
                                     .map_err(ConnectorError::IngestorError)?;
                             }
@@ -196,9 +198,10 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                 })?;
 
                                 ingestor
-                                    .handle_message((
-                                        (0, 0),
-                                        IngestionMessage::OperationEvent(Operation::Insert {
+                                    .handle_message(IngestionMessage::new_op(
+                                        0,
+                                        0,
+                                        Operation::Insert {
                                             new: Record {
                                                 schema_id: Some(SchemaIdentifier {
                                                     id: 1,
@@ -207,7 +210,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                                 values: new,
                                                 version: None,
                                             },
-                                        }),
+                                        },
                                     ))
                                     .map_err(ConnectorError::IngestorError)?;
                             }

--- a/dozer-ingestion/src/connectors/kafka/tests.rs
+++ b/dozer-ingestion/src/connectors/kafka/tests.rs
@@ -3,6 +3,7 @@ use crate::connectors::kafka::test_utils::{
     get_client_and_create_table, get_debezium_config, get_iterator_and_client,
 };
 use crate::connectors::{Connector, TableInfo};
+use dozer_types::ingestion_types::{IngestionMessage, IngestionMessageKind};
 use dozer_types::models::connection::ConnectionConfig;
 use dozer_types::{ingestion_types::KafkaConfig, rust_decimal::Decimal, types::Operation};
 use postgres::Client;
@@ -81,7 +82,11 @@ fn connector_disabled_test_e2e_connect_debezium_and_use_kafka_stream() {
     while i < 30 {
         let op = iterator.next();
 
-        if let Some((_, op)) = op {
+        if let Some(IngestionMessage {
+            kind: IngestionMessageKind::OperationEvent(op),
+            ..
+        }) = op
+        {
             i += 1;
             match op {
                 Operation::Insert { .. } => {
@@ -99,7 +104,6 @@ fn connector_disabled_test_e2e_connect_debezium_and_use_kafka_stream() {
                         panic!("Unexpected operation");
                     }
                 }
-                Operation::SnapshottingDone {} => (),
             }
         }
     }

--- a/dozer-ingestion/src/connectors/object_store/table_reader.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_reader.rs
@@ -88,15 +88,16 @@ impl<T: Clone + Send + Sync> TableReader<T> {
                     .collect::<Result<Vec<_>, _>>()?;
 
                 ingestor
-                    .handle_message((
-                        (0_u64, idx),
-                        IngestionMessage::OperationEvent(Operation::Insert {
+                    .handle_message(IngestionMessage::new_op(
+                        0_u64,
+                        idx,
+                        Operation::Insert {
                             new: Record {
                                 schema_id: Some(SchemaIdentifier { id, version: 0 }),
                                 values: fields,
                                 version: None,
                             },
-                        }),
+                        },
                     ))
                     .unwrap();
 

--- a/dozer-ingestion/src/connectors/postgres/iterator.rs
+++ b/dozer-ingestion/src/connectors/postgres/iterator.rs
@@ -2,6 +2,7 @@ use crate::connectors::TableInfo;
 
 use crate::errors::{ConnectorError, PostgresConnectorError};
 use crate::ingestion::Ingestor;
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::log::debug;
 
 use std::cell::RefCell;
@@ -16,7 +17,6 @@ use crate::connectors::postgres::snapshotter::PostgresSnapshotter;
 use crate::errors::PostgresConnectorError::{
     InvalidQueryError, LSNNotStoredError, LsnNotReturnedFromReplicationSlot, LsnParseError,
 };
-use dozer_types::ingestion_types::IngestionMessage::SnapshottingDone;
 use postgres_types::PgLsn;
 use tokio::runtime::Runtime;
 
@@ -170,7 +170,7 @@ impl<'a> PostgresIteratorHandler<'a> {
 
             let lsn = self.lsn.borrow().map_or(0, |(lsn, _)| u64::from(lsn));
             self.ingestor
-                .handle_message(((lsn, 0), SnapshottingDone))
+                .handle_message(IngestionMessage::new_snapshotting_done(lsn, 0))
                 .map_err(ConnectorError::IngestorError)?;
 
             debug!("\nInitialized with tables: {:?}", tables);

--- a/dozer-ingestion/src/connectors/postgres/snapshotter.rs
+++ b/dozer-ingestion/src/connectors/postgres/snapshotter.rs
@@ -50,7 +50,7 @@ impl<'a> PostgresSnapshotter<'a> {
             .collect();
 
         let column_str = column_str.join(",");
-        let query = format!("select {} from {}", column_str, name);
+        let query = format!("select {column_str} from {name}");
         let stmt = client_plain
             .prepare(&query)
             .map_err(|e| PostgresConnectorError(InvalidQueryError(e)))?;
@@ -118,7 +118,7 @@ impl<'a> PostgresSnapshotter<'a> {
                 }
                 Some(evt) => {
                     self.ingestor
-                        .handle_message(((0, idx), IngestionMessage::OperationEvent(evt)))
+                        .handle_message(IngestionMessage::new_op(0, idx, evt))
                         .map_err(ConnectorError::IngestorError)?;
                     idx += 1;
                 }

--- a/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
@@ -10,6 +10,8 @@ mod tests {
     use crate::ingestion::{IngestionConfig, Ingestor};
     use crate::test_util::run_connector_test;
     use core::cell::RefCell;
+    use dozer_types::ingestion_types::IngestionMessage;
+    use dozer_types::node::OpIdentifier;
     use rand::Rng;
     use serial_test::serial;
     use std::sync::Arc;
@@ -131,8 +133,12 @@ mod tests {
             let mut i = last_parsed_position;
             while i < 4 {
                 i += 1;
-                if let Some(((_, seq_no), _)) = iterator.next() {
-                    assert_eq!(i, seq_no);
+                if let Some(IngestionMessage {
+                    identifier: OpIdentifier { seq_in_tx, .. },
+                    ..
+                }) = iterator.next()
+                {
+                    assert_eq!(i, seq_in_tx);
                 } else {
                     panic!("Unexpected operation");
                 }
@@ -142,8 +148,12 @@ mod tests {
             let mut i = 0;
             while i < 3 {
                 i += 1;
-                if let Some(((_, seq_no), _)) = iterator.next() {
-                    assert_eq!(i, seq_no);
+                if let Some(IngestionMessage {
+                    identifier: OpIdentifier { seq_in_tx, .. },
+                    ..
+                }) = iterator.next()
+                {
+                    assert_eq!(i, seq_in_tx);
                 } else {
                     panic!("Unexpected operation");
                 }

--- a/dozer-ingestion/src/connectors/postgres/tests/e2e.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/e2e.rs
@@ -1,5 +1,6 @@
 use crate::connectors::postgres::tests::client::TestPostgresClient;
 use crate::test_util::load_config;
+use dozer_types::ingestion_types::{IngestionMessage, IngestionMessageKind};
 use dozer_types::models::app_config::Config;
 
 use crate::connectors::postgres::test_utils::get_iterator;
@@ -27,7 +28,11 @@ fn connector_disabled_test_e2e_connect_postgres_stream() {
     let mut i = 1;
     while i < 10 {
         let op = iterator.next();
-        if let Some((_, Operation::Insert { new })) = op {
+        if let Some(IngestionMessage {
+            kind: IngestionMessageKind::OperationEvent(Operation::Insert { new }),
+            ..
+        }) = op
+        {
             assert_eq!(new.values.get(0).unwrap(), &Field::Int(i));
             i += 1;
         }
@@ -37,7 +42,11 @@ fn connector_disabled_test_e2e_connect_postgres_stream() {
     while i < 20 {
         let op = iterator.next();
 
-        if let Some((_, Operation::Insert { new })) = op {
+        if let Some(IngestionMessage {
+            kind: IngestionMessageKind::OperationEvent(Operation::Insert { new }),
+            ..
+        }) = op
+        {
             assert_eq!(new.values.get(0).unwrap(), &Field::Int(i));
             i += 1;
         }

--- a/dozer-ingestion/src/connectors/snowflake/tests.rs
+++ b/dozer-ingestion/src/connectors/snowflake/tests.rs
@@ -6,6 +6,7 @@ use dozer_types::types::FieldType::{
     Binary, Boolean, Date, Decimal, Float, Int, String, Timestamp,
 };
 
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::models::connection::ConnectionConfig;
 use odbc::create_environment_v3;
 use rand::Rng;
@@ -70,9 +71,9 @@ fn test_connector_and_read_from_stream() {
             let op = iterator.next();
             match op {
                 None => {}
-                Some(((lsn, seq_no), _operation)) => {
-                    assert_eq!(lsn, 0);
-                    assert_eq!(seq_no, i);
+                Some(IngestionMessage { identifier, .. }) => {
+                    assert_eq!(identifier.txid, 0);
+                    assert_eq!(identifier.seq_in_tx, i);
                 }
             }
             i += 1;
@@ -87,9 +88,9 @@ fn test_connector_and_read_from_stream() {
             let op = iterator.next();
             match op {
                 None => {}
-                Some(((lsn, seq_no), _operation)) => {
-                    assert_eq!(lsn, 1);
-                    assert_eq!(seq_no, i);
+                Some(IngestionMessage { identifier, .. }) => {
+                    assert_eq!(identifier.txid, 1);
+                    assert_eq!(identifier.seq_in_tx, i);
                 }
             }
             i += 1;

--- a/dozer-orchestrator/src/cli/repl/sql.rs
+++ b/dozer-orchestrator/src/cli/repl/sql.rs
@@ -175,7 +175,6 @@ pub fn query(
                                     updates_map.insert(pkey.clone(), (0, instant.elapsed()));
                                 }
                             }
-                            Operation::SnapshottingDone { .. } => (),
                         }
                         idx += 1;
                     }

--- a/dozer-orchestrator/src/pipeline/sinks.rs
+++ b/dozer-orchestrator/src/pipeline/sinks.rs
@@ -411,20 +411,23 @@ impl Sink for CacheSink {
                     try_send(&notifier.1, op)?;
                 }
             }
-            // FIXME: Maybe we should only switch cache when all source nodes snapshotting are done? (by chubei 2023-02-24)
-            Operation::SnapshottingDone {} => {
-                let real_name = self.cache.name();
-                create_alias(&*self.cache_manager, real_name, &self.api_endpoint.name)?;
-
-                if let Some(notifier) = &self.notifier {
-                    let alias_redirected = AliasRedirected {
-                        real_name: real_name.to_string(),
-                        alias: self.api_endpoint.name.clone(),
-                    };
-                    try_send(&notifier.0, alias_redirected)?;
-                }
-            }
         };
+
+        Ok(())
+    }
+
+    // FIXME: Maybe we should only switch cache when all source nodes snapshotting are done? (by chubei 2023-02-24)
+    fn on_source_snapshotting_done(&mut self) -> Result<(), ExecutionError> {
+        let real_name = self.cache.name();
+        create_alias(&*self.cache_manager, real_name, &self.api_endpoint.name)?;
+
+        if let Some(notifier) = &self.notifier {
+            let alias_redirected = AliasRedirected {
+                real_name: real_name.to_string(),
+                alias: self.api_endpoint.name.clone(),
+            };
+            try_send(&notifier.0, alias_redirected)?;
+        }
 
         Ok(())
     }

--- a/dozer-orchestrator/src/pipeline/streaming_sink.rs
+++ b/dozer-orchestrator/src/pipeline/streaming_sink.rs
@@ -75,4 +75,8 @@ impl Sink for StreamingSink {
     fn commit(&mut self, _epoch: &Epoch, _tx: &SharedTransaction) -> Result<(), ExecutionError> {
         Ok(())
     }
+
+    fn on_source_snapshotting_done(&mut self) -> Result<(), ExecutionError> {
+        Ok(())
+    }
 }

--- a/dozer-sql/src/pipeline/aggregation/processor.rs
+++ b/dozer-sql/src/pipeline/aggregation/processor.rs
@@ -489,7 +489,6 @@ impl AggregationProcessor {
                     ])
                 }
             }
-            Operation::SnapshottingDone { .. } => Ok(vec![op]),
         }
     }
 }

--- a/dozer-sql/src/pipeline/product/processor.rs
+++ b/dozer-sql/src/pipeline/product/processor.rs
@@ -213,9 +213,6 @@ impl Processor for FromProcessor {
                     }
                 }
             }
-            Operation::SnapshottingDone { .. } => {
-                let _ = fw.send(op, DEFAULT_PORT_HANDLE);
-            }
         }
         Ok(())
     }

--- a/dozer-sql/src/pipeline/product/set_processor.rs
+++ b/dozer-sql/src/pipeline/product/set_processor.rs
@@ -159,9 +159,6 @@ impl Processor for SetProcessor {
                     }
                 }
             }
-            Operation::SnapshottingDone { .. } => {
-                let _ = fw.send(op, DEFAULT_PORT_HANDLE);
-            }
         }
         Ok(())
     }

--- a/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
@@ -10,6 +10,7 @@ use dozer_core::node::{
 use dozer_core::record_store::RecordReader;
 use dozer_core::storage::lmdb_storage::SharedTransaction;
 use dozer_core::DEFAULT_PORT_HANDLE;
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::node::SourceStates;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::tracing::{debug, info};
@@ -405,7 +406,7 @@ impl Source for TestSource {
             // ),
         ];
 
-        for operation in operations.iter().enumerate() {
+        for (index, (op, port)) in operations.into_iter().enumerate() {
             // match operation.1.clone().0 {
             //     Operation::Delete { old } => {
             //         info!("s{}: - {:?}", operation.1.clone().1, old.values)
@@ -422,13 +423,8 @@ impl Source for TestSource {
             //         )
             //     }
             // }
-            fw.send(
-                operation.0.try_into().unwrap(),
-                0,
-                operation.1.clone().0,
-                operation.1.clone().1,
-            )
-            .unwrap();
+            fw.send(IngestionMessage::new_op(index as u64, 0, op), port)
+                .unwrap();
         }
 
         loop {
@@ -502,9 +498,6 @@ impl Sink for TestSink {
             Operation::Update { old, new } => {
                 info!("o0:-> - {:?}, + {:?}", old.values, new.values)
             }
-            Operation::SnapshottingDone {} => {
-                info!("o0:-> SnapshottingDone")
-            }
         }
 
         self.current += 1;
@@ -519,6 +512,10 @@ impl Sink for TestSink {
     }
 
     fn commit(&mut self, _epoch: &Epoch, _tx: &SharedTransaction) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn on_source_snapshotting_done(&mut self) -> Result<(), ExecutionError> {
         Ok(())
     }
 }

--- a/dozer-sql/src/pipeline/projection/processor.rs
+++ b/dozer-sql/src/pipeline/projection/processor.rs
@@ -90,7 +90,6 @@ impl Processor for ProjectionProcessor {
             Operation::Update { ref old, ref new } => {
                 fw.send(self.update(old, new)?, DEFAULT_PORT_HANDLE)
             }
-            Operation::SnapshottingDone { .. } => fw.send(op, DEFAULT_PORT_HANDLE),
         };
         Ok(())
     }

--- a/dozer-sql/src/pipeline/selection/processor.rs
+++ b/dozer-sql/src/pipeline/selection/processor.rs
@@ -100,9 +100,6 @@ impl Processor for SelectionProcessor {
                     }
                 }
             }
-            Operation::SnapshottingDone { .. } => {
-                let _ = fw.send(op, DEFAULT_PORT_HANDLE);
-            }
         }
         Ok(())
     }

--- a/dozer-sql/src/pipeline/tests/builder_test.rs
+++ b/dozer-sql/src/pipeline/tests/builder_test.rs
@@ -9,6 +9,7 @@ use dozer_core::node::{
 use dozer_core::record_store::RecordReader;
 use dozer_core::storage::lmdb_storage::SharedTransaction;
 use dozer_core::DEFAULT_PORT_HANDLE;
+use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::log::debug;
 use dozer_types::node::SourceStates;
 use dozer_types::ordered_float::OrderedFloat;
@@ -109,19 +110,21 @@ impl Source for TestSource {
     ) -> Result<(), ExecutionError> {
         for n in 0..10000 {
             fw.send(
-                n,
-                0,
-                Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::Int(0),
-                            Field::String("Italy".to_string()),
-                            Field::Float(OrderedFloat(5.5)),
-                        ],
-                        None,
-                    ),
-                },
+                IngestionMessage::new_op(
+                    n,
+                    0,
+                    Operation::Insert {
+                        new: Record::new(
+                            None,
+                            vec![
+                                Field::Int(0),
+                                Field::String("Italy".to_string()),
+                                Field::Float(OrderedFloat(5.5)),
+                            ],
+                            None,
+                        ),
+                    },
+                ),
                 DEFAULT_PORT_HANDLE,
             )
             .unwrap();
@@ -177,6 +180,10 @@ impl Sink for TestSink {
     }
 
     fn commit(&mut self, _epoch: &Epoch, _tx: &SharedTransaction) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn on_source_snapshotting_done(&mut self) -> Result<(), ExecutionError> {
         Ok(())
     }
 }

--- a/dozer-tests/src/sql_tests/mapper.rs
+++ b/dozer-tests/src/sql_tests/mapper.rs
@@ -231,7 +231,6 @@ impl SqlMapper {
                     map_field_to_string(&pkey_value)
                 ))
             }
-            Operation::SnapshottingDone {} => Ok(String::new()),
         }
     }
 

--- a/dozer-types/src/ingestion_types.rs
+++ b/dozer-types/src/ingestion_types.rs
@@ -4,16 +4,33 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{
-    errors::internal::BoxedError,
-    types::{Commit, Operation},
-};
+use crate::{errors::internal::BoxedError, node::OpIdentifier, types::Operation};
 
-#[derive(Clone, Debug)]
-pub enum IngestionMessage {
-    Begin(),
+#[derive(Debug, Clone, PartialEq)]
+pub struct IngestionMessage {
+    pub identifier: OpIdentifier,
+    pub kind: IngestionMessageKind,
+}
+
+impl IngestionMessage {
+    pub fn new_op(txn: u64, seq_no: u64, op: Operation) -> Self {
+        Self {
+            identifier: OpIdentifier::new(txn, seq_no),
+            kind: IngestionMessageKind::OperationEvent(op),
+        }
+    }
+
+    pub fn new_snapshotting_done(txn: u64, seq_no: u64) -> Self {
+        Self {
+            identifier: OpIdentifier::new(txn, seq_no),
+            kind: IngestionMessageKind::SnapshottingDone,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum IngestionMessageKind {
     OperationEvent(Operation),
-    Commit(Commit),
     SnapshottingDone,
 }
 
@@ -24,7 +41,7 @@ pub enum IngestorError {
 }
 
 pub trait IngestorForwarder: Send + Sync + Debug {
-    fn forward(&self, msg: ((u64, u64), Operation)) -> Result<(), IngestorError>;
+    fn forward(&self, msg: IngestionMessage) -> Result<(), IngestorError>;
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Message, Hash)]

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -323,24 +323,11 @@ impl Display for Record {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Copy)]
-pub struct Commit {
-    pub seq_no: u64,
-    pub lsn: u64,
-}
-
-impl Commit {
-    pub fn new(seq_no: u64, lsn: u64) -> Self {
-        Self { seq_no, lsn }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Operation {
     Delete { old: Record },
     Insert { new: Record },
     Update { old: Record, new: Record },
-    SnapshottingDone {},
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
Also removed unused variants of `IngestionMessage`