### PR TITLE
chore: Use 16 cores runner for coverage and release, 4 cores runner for lint

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,7 +17,9 @@ jobs:
   # Run coverage
   coverage:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Org Larger Runners
+      labels: ubuntu-latest-16-cores
     services:
       postgres:
         image: debezium/postgres:13
@@ -36,16 +38,6 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: false
-          haskell: false
-          large-packages: false
-          swap-storage: false
-
       - uses: actions/checkout@v3
 
       - name: Install stable with llvm-tools-preview

--- a/.github/workflows/dozer.yaml
+++ b/.github/workflows/dozer.yaml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   lint:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Org Larger Runners
+      labels: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,14 +63,16 @@ jobs:
           fi
   release:
     name: Release
-    runs-on: ${{ matrix.os }}
+    runs-on: 
+      group: Default Larger Runners
+      labels: ${{ matrix.os }}
     needs: prepare
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20-16-cores]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-20-16-cores
             file_name: dozer
             asset_name: dozer-linux-amd64
           # - os: macos-12


### PR DESCRIPTION
Fixes #1065 