### PR TITLE
remove unused dependency

### DIFF
--- a/dozer-core/Cargo.toml
+++ b/dozer-core/Cargo.toml
@@ -11,7 +11,6 @@ dozer-types = {path = "../dozer-types/"}
 dozer-tracing = {path = "../dozer-tracing/"}
 uuid = {version = "1.3.0", features = ["v1", "v4", "fast-rng"]}
 crossbeam = "0.8.2"
-unixstring = "0.2.7"
 dyn-clone = "1.0.10"
 fp_rust = "0.3.5"
 daggy = { git = "https://github.com/getdozer/daggy", branch = "feat/map_owned" }


### PR DESCRIPTION
The unused dependency of unixstring was causing build failure of native windows binary.