### PR TITLE
chore: Remove `TableInfo::table_name` and `TableInfo::id`. Remove parameter of `Connector::get_tables`.

### DIFF
--- a/dozer-admin/src/services/connection_service.rs
+++ b/dozer-admin/src/services/connection_service.rs
@@ -34,7 +34,7 @@ impl ConnectionService {
     ) -> Result<Vec<dozer_orchestrator::TableInfo>, ErrorResponse> {
         let res = thread::spawn(|| {
             let connector = get_connector(connection).map_err(|err| err.to_string())?;
-            connector.get_tables(None).map_err(|err| err.to_string())
+            connector.get_tables().map_err(|err| err.to_string())
         })
         .join()
         .unwrap();

--- a/dozer-admin/src/services/converter.rs
+++ b/dozer-admin/src/services/converter.rs
@@ -15,7 +15,7 @@ impl From<dozer_orchestrator::TableInfo> for dozer_admin_grpc::TableInfo {
         }
 
         dozer_admin_grpc::TableInfo {
-            table_name: t.table_name,
+            table_name: t.name,
             columns,
         }
     }

--- a/dozer-admin/src/services/converter.rs
+++ b/dozer-admin/src/services/converter.rs
@@ -15,7 +15,7 @@ impl From<dozer_orchestrator::TableInfo> for dozer_admin_grpc::TableInfo {
         }
 
         dozer_admin_grpc::TableInfo {
-            table_name: t.name,
+            table_name: t.table_name,
             columns,
         }
     }

--- a/dozer-core/src/dag_impl.rs
+++ b/dozer-core/src/dag_impl.rs
@@ -392,7 +392,7 @@ fn contains_port<T>(
         }
         NodeKind::Source(s) => {
             if direction == PortDirection::Output {
-                s.get_output_ports()?.iter().any(|e| e.handle == port)
+                s.get_output_ports().iter().any(|e| e.handle == port)
             } else {
                 false
             }

--- a/dozer-core/src/dag_schemas.rs
+++ b/dozer-core/src/dag_schemas.rs
@@ -203,7 +203,7 @@ fn populate_schemas<T: Clone>(
 
         match &node.kind {
             NodeKind::Source(source) => {
-                let ports = source.get_output_ports()?;
+                let ports = source.get_output_ports();
 
                 for edge in dag.graph().edges(node_index) {
                     let port = find_output_port_def(&ports, edge);

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -28,10 +28,6 @@ pub enum ExecutionError {
     InvalidDatabase,
     #[error("Field not found at position {0}")]
     FieldNotFound(String),
-    #[error("Port not found in source for schema_id: {0}.")]
-    PortNotFound(String),
-    #[error("Replication type not found")]
-    ReplicationTypeNotFound,
     #[error("Record not found")]
     RecordNotFound(),
     #[error("Node {node} has incompatible {typ:?} schemas: {source}")]

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -47,7 +47,7 @@ impl OutputPortDef {
 
 pub trait SourceFactory<T>: Send + Sync + Debug {
     fn get_output_schema(&self, port: &PortHandle) -> Result<(Schema, T), ExecutionError>;
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError>;
+    fn get_output_ports(&self) -> Vec<OutputPortDef>;
     fn build(
         &self,
         output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-core/src/tests/app.rs
+++ b/dozer-core/src/tests/app.rs
@@ -36,7 +36,7 @@ impl SourceFactory<NoneContext> for NoneSourceFactory {
         todo!()
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
         todo!()
     }
 

--- a/dozer-core/src/tests/dag_base_create_errors.rs
+++ b/dozer-core/src/tests/dag_base_create_errors.rs
@@ -54,11 +54,11 @@ impl SourceFactory<NoneContext> for CreateErrSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             DEFAULT_PORT_HANDLE,
             OutputPortType::Stateless,
-        )])
+        )]
     }
 
     fn build(

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -320,11 +320,11 @@ impl SourceFactory<NoneContext> for ErrGeneratorSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             GENERATOR_SOURCE_OUTPUT_PORT,
             OutputPortType::Stateless,
-        )])
+        )]
     }
 
     fn build(

--- a/dozer-core/src/tests/dag_ports.rs
+++ b/dozer-core/src/tests/dag_ports.rs
@@ -28,12 +28,11 @@ impl SourceFactory<NoneContext> for DynPortsSourceFactory {
         todo!()
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(self
-            .output_ports
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        self.output_ports
             .iter()
             .map(|p| OutputPortDef::new(*p, OutputPortType::Stateless))
-            .collect())
+            .collect()
     }
 
     fn build(

--- a/dozer-core/src/tests/dag_recordreader_update.rs
+++ b/dozer-core/src/tests/dag_recordreader_update.rs
@@ -72,8 +72,8 @@ impl SourceFactory<NoneContext> for GeneratorSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             GENERATOR_SOURCE_OUTPUT_PORT,
             if self.stateful {
                 OutputPortType::StatefulWithPrimaryKeyLookup {
@@ -83,7 +83,7 @@ impl SourceFactory<NoneContext> for GeneratorSourceFactory {
             } else {
                 OutputPortType::Stateless
             },
-        )])
+        )]
     }
 
     fn build(

--- a/dozer-core/src/tests/dag_schemas.rs
+++ b/dozer-core/src/tests/dag_schemas.rs
@@ -62,11 +62,11 @@ impl SourceFactory<NoneContext> for TestUsersSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             DEFAULT_PORT_HANDLE,
             OutputPortType::Stateless,
-        )])
+        )]
     }
 
     fn build(
@@ -110,11 +110,11 @@ impl SourceFactory<NoneContext> for TestCountriesSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             DEFAULT_PORT_HANDLE,
             OutputPortType::Stateless,
-        )])
+        )]
     }
 
     fn build(

--- a/dozer-core/src/tests/sources.rs
+++ b/dozer-core/src/tests/sources.rs
@@ -64,8 +64,8 @@ impl SourceFactory<NoneContext> for GeneratorSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             GENERATOR_SOURCE_OUTPUT_PORT,
             if self.stateful {
                 OutputPortType::StatefulWithPrimaryKeyLookup {
@@ -75,7 +75,7 @@ impl SourceFactory<NoneContext> for GeneratorSourceFactory {
             } else {
                 OutputPortType::Stateless
             },
-        )])
+        )]
     }
 
     fn build(
@@ -188,8 +188,8 @@ impl SourceFactory<NoneContext> for DualPortGeneratorSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![
             OutputPortDef::new(
                 DUAL_PORT_GENERATOR_SOURCE_OUTPUT_PORT_1,
                 if self.stateful {
@@ -212,7 +212,7 @@ impl SourceFactory<NoneContext> for DualPortGeneratorSourceFactory {
                     OutputPortType::Stateless
                 },
             ),
-        ])
+        ]
     }
 
     fn build(
@@ -335,15 +335,15 @@ impl SourceFactory<NoneContext> for NoPkGeneratorSourceFactory {
         ))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             GENERATOR_SOURCE_OUTPUT_PORT,
             if self.stateful {
                 OutputPortType::AutogenRowKeyLookup
             } else {
                 OutputPortType::Stateless
             },
-        )])
+        )]
     }
 
     fn build(
@@ -417,11 +417,11 @@ impl SourceFactory<NoneContext> for ConnectivityTestSourceFactory {
         unimplemented!("This struct is for connectivity test, only output ports are defined")
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![OutputPortDef::new(
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![OutputPortDef::new(
             DEFAULT_PORT_HANDLE,
             OutputPortType::Stateless,
-        )])
+        )]
     }
 
     fn build(

--- a/dozer-ingestion/benches/helper.rs
+++ b/dozer-ingestion/benches/helper.rs
@@ -44,7 +44,7 @@ pub async fn get_connection_iterator(config: TestConfig) -> IngestionIterator {
 
         let mut tables = grpc_connector.get_tables().unwrap();
         if let Some(tables_filter) = config.tables_filter {
-            tables.retain(|t| tables_filter.contains(&t.table_name));
+            tables.retain(|t| tables_filter.contains(&t.name));
         }
 
         let res = grpc_connector.start(None, &ingestor, tables);

--- a/dozer-ingestion/benches/helper.rs
+++ b/dozer-ingestion/benches/helper.rs
@@ -42,7 +42,7 @@ pub async fn get_connection_iterator(config: TestConfig) -> IngestionIterator {
     std::thread::spawn(move || {
         let grpc_connector = dozer_ingestion::connectors::get_connector(config.connection).unwrap();
 
-        let mut tables = grpc_connector.get_tables(None).unwrap();
+        let mut tables = grpc_connector.get_tables().unwrap();
         if let Some(tables_filter) = config.tables_filter {
             tables.retain(|t| tables_filter.contains(&t.table_name));
         }

--- a/dozer-ingestion/benches/helper.rs
+++ b/dozer-ingestion/benches/helper.rs
@@ -44,7 +44,7 @@ pub async fn get_connection_iterator(config: TestConfig) -> IngestionIterator {
 
         let mut tables = grpc_connector.get_tables(None).unwrap();
         if let Some(tables_filter) = config.tables_filter {
-            tables.retain(|t| tables_filter.contains(&t.name));
+            tables.retain(|t| tables_filter.contains(&t.table_name));
         }
 
         let res = grpc_connector.start(None, &ingestor, tables);

--- a/dozer-ingestion/examples/postgres/main.rs
+++ b/dozer-ingestion/examples/postgres/main.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let (ingestor, mut iterator) = Ingestor::initialize_channel(IngestionConfig::default());
     let tables = vec![TableInfo {
-        table_name: "users".to_string(),
+        name: "users".to_string(),
         columns: None,
     }];
     let postgres_config = PostgresConfig {

--- a/dozer-ingestion/examples/postgres/main.rs
+++ b/dozer-ingestion/examples/postgres/main.rs
@@ -12,7 +12,6 @@ fn main() {
 
     let (ingestor, mut iterator) = Ingestor::initialize_channel(IngestionConfig::default());
     let tables = vec![TableInfo {
-        name: "users".to_string(),
         table_name: "users".to_string(),
         id: 0,
         columns: None,

--- a/dozer-ingestion/examples/postgres/main.rs
+++ b/dozer-ingestion/examples/postgres/main.rs
@@ -13,7 +13,6 @@ fn main() {
     let (ingestor, mut iterator) = Ingestor::initialize_channel(IngestionConfig::default());
     let tables = vec![TableInfo {
         table_name: "users".to_string(),
-        id: 0,
         columns: None,
     }];
     let postgres_config = PostgresConfig {

--- a/dozer-ingestion/src/connectors/ethereum/log/connector.rs
+++ b/dozer-ingestion/src/connectors/ethereum/log/connector.rs
@@ -141,7 +141,7 @@ impl Connector for EthLogConnector {
         let schemas = if let Some(tables) = tables {
             schemas
                 .iter()
-                .filter(|s| tables.iter().any(|t| t.table_name == s.name))
+                .filter(|s| tables.iter().any(|t| t.name == s.name))
                 .cloned()
                 .collect()
         } else {

--- a/dozer-ingestion/src/connectors/ethereum/log/connector.rs
+++ b/dozer-ingestion/src/connectors/ethereum/log/connector.rs
@@ -191,8 +191,8 @@ impl Connector for EthLogConnector {
         Ok(HashMap::new())
     }
 
-    fn get_tables(&self, tables: Option<&[TableInfo]>) -> Result<Vec<TableInfo>, ConnectorError> {
-        self.get_tables_default(tables)
+    fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError> {
+        self.get_tables_default()
     }
 
     fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ConnectorError> {

--- a/dozer-ingestion/src/connectors/ethereum/log/helper.rs
+++ b/dozer-ingestion/src/connectors/ethereum/log/helper.rs
@@ -105,7 +105,7 @@ pub fn decode_event(
                 .to_owned();
 
             let table_name = get_table_name(contract_tuple, &event.name);
-            let is_table_required = tables.iter().any(|t| t.table_name == table_name);
+            let is_table_required = tables.iter().any(|t| t.name == table_name);
             if is_table_required {
                 let parsed_event = event.parse_log(RawLog {
                     topics: log.topics,
@@ -172,10 +172,7 @@ pub fn map_abitype_to_field(f: web3::ethabi::Token) -> Field {
 }
 pub fn map_log_to_event(log: Log, details: Arc<EthDetails>) -> Option<Operation> {
     // Check if table is requested
-    let is_table_required = details
-        .tables
-        .iter()
-        .any(|t| t.table_name == ETH_LOGS_TABLE);
+    let is_table_required = details.tables.iter().any(|t| t.name == ETH_LOGS_TABLE);
 
     if !is_table_required {
         None

--- a/dozer-ingestion/src/connectors/ethereum/trace/connector.rs
+++ b/dozer-ingestion/src/connectors/ethereum/trace/connector.rs
@@ -69,8 +69,8 @@ impl Connector for EthTraceConnector {
         Ok(HashMap::new())
     }
 
-    fn get_tables(&self, tables: Option<&[TableInfo]>) -> Result<Vec<TableInfo>, ConnectorError> {
-        self.get_tables_default(tables)
+    fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError> {
+        self.get_tables_default()
     }
 
     fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ConnectorError> {

--- a/dozer-ingestion/src/connectors/grpc/adapter/arrow.rs
+++ b/dozer-ingestion/src/connectors/grpc/adapter/arrow.rs
@@ -44,7 +44,7 @@ impl IngestAdapter for ArrowAdapter {
             serde_json::from_str(schemas_str).map_err(ConnectorError::map_serialization_error)?;
         let mut schemas = vec![];
 
-        for (id, grpc_schema) in grpc_schemas.iter().enumerate() {
+        for (id, grpc_schema) in grpc_schemas.into_iter().enumerate() {
             let mut schema = arrow_types::from_arrow::map_schema_to_dozer(&grpc_schema.schema)
                 .map_err(|e| ConnectorError::InternalError(Box::new(e)))?;
             schema.identifier = Some(SchemaIdentifier {
@@ -53,7 +53,7 @@ impl IngestAdapter for ArrowAdapter {
             });
 
             schemas.push(SourceSchema {
-                name: grpc_schema.name.clone(),
+                name: grpc_schema.name,
                 schema,
                 replication_type: grpc_schema.replication_type.clone(),
             });

--- a/dozer-ingestion/src/connectors/grpc/connector.rs
+++ b/dozer-ingestion/src/connectors/grpc/connector.rs
@@ -135,7 +135,7 @@ where
         let schemas = table_names.map_or(schemas.clone(), |names| {
             schemas
                 .into_iter()
-                .filter(|s| names.iter().any(|n| n.table_name == s.name))
+                .filter(|s| names.iter().any(|n| n.name == s.name))
                 .collect()
         });
         Ok(schemas)
@@ -161,15 +161,15 @@ where
         let adapter = GrpcIngestor::<T>::new(schemas_str)?;
         let schema_map = adapter.schema_map;
         for table in tables {
-            let r = schema_map.get(&table.table_name).map_or(
+            let r = schema_map.get(&table.name).map_or(
                 Err(ConnectorError::InitializationError(format!(
                     "Schema not found for table {}",
-                    table.table_name
+                    table.name
                 ))),
                 |_| Ok(()),
             );
 
-            results.insert(table.table_name.clone(), vec![(None, r)]);
+            results.insert(table.name.clone(), vec![(None, r)]);
         }
         Ok(results)
     }

--- a/dozer-ingestion/src/connectors/grpc/connector.rs
+++ b/dozer-ingestion/src/connectors/grpc/connector.rs
@@ -174,8 +174,8 @@ where
         Ok(results)
     }
 
-    fn get_tables(&self, tables: Option<&[TableInfo]>) -> Result<Vec<TableInfo>, ConnectorError> {
-        self.get_tables_default(tables)
+    fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError> {
+        self.get_tables_default()
     }
 
     fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ConnectorError> {

--- a/dozer-ingestion/src/connectors/grpc/connector.rs
+++ b/dozer-ingestion/src/connectors/grpc/connector.rs
@@ -135,7 +135,7 @@ where
         let schemas = table_names.map_or(schemas.clone(), |names| {
             schemas
                 .into_iter()
-                .filter(|s| names.iter().any(|n| n.name == s.name))
+                .filter(|s| names.iter().any(|n| n.table_name == s.name))
                 .collect()
         });
         Ok(schemas)
@@ -161,15 +161,15 @@ where
         let adapter = GrpcIngestor::<T>::new(schemas_str)?;
         let schema_map = adapter.schema_map;
         for table in tables {
-            let r = schema_map.get(&table.name).map_or(
+            let r = schema_map.get(&table.table_name).map_or(
                 Err(ConnectorError::InitializationError(format!(
                     "Schema not found for table {}",
-                    table.name
+                    table.table_name
                 ))),
                 |_| Ok(()),
             );
 
-            results.insert(table.name.clone(), vec![(None, r)]);
+            results.insert(table.table_name.clone(), vec![(None, r)]);
         }
         Ok(results)
     }

--- a/dozer-ingestion/src/connectors/grpc/tests.rs
+++ b/dozer-ingestion/src/connectors/grpc/tests.rs
@@ -43,7 +43,7 @@ async fn ingest_grpc(
         })
         .unwrap();
 
-        let tables = grpc_connector.get_tables(None).unwrap();
+        let tables = grpc_connector.get_tables().unwrap();
         grpc_connector.start(None, &ingestor, tables).unwrap();
     });
 

--- a/dozer-ingestion/src/connectors/kafka/connector.rs
+++ b/dozer-ingestion/src/connectors/kafka/connector.rs
@@ -60,8 +60,8 @@ impl Connector for KafkaConnector {
         todo!()
     }
 
-    fn get_tables(&self, tables: Option<&[TableInfo]>) -> Result<Vec<TableInfo>, ConnectorError> {
-        self.get_tables_default(tables)
+    fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError> {
+        self.get_tables_default()
     }
 
     fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ConnectorError> {

--- a/dozer-ingestion/src/connectors/kafka/connector.rs
+++ b/dozer-ingestion/src/connectors/kafka/connector.rs
@@ -44,7 +44,7 @@ impl Connector for KafkaConnector {
     ) -> Result<(), ConnectorError> {
         let topic = tables
             .get(0)
-            .map_or(Err(TopicNotDefined), |table| Ok(&table.table_name))?;
+            .map_or(Err(TopicNotDefined), |table| Ok(&table.name))?;
 
         let broker = self.config.broker.to_owned();
         Runtime::new()

--- a/dozer-ingestion/src/connectors/kafka/debezium/no_schema_registry.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/no_schema_registry.rs
@@ -20,7 +20,7 @@ impl NoSchemaRegistry {
         table_names.map_or(Ok(vec![]), |tables| {
             tables.get(0).map_or(Ok(vec![]), |table| {
                 let mut con = Consumer::from_hosts(vec![config.broker.clone()])
-                    .with_topic(table.table_name.clone())
+                    .with_topic(table.name.clone())
                     .with_fallback_offset(FetchOffset::Earliest)
                     .with_offset_storage(GroupOffsetStorage::Kafka)
                     .create()
@@ -52,7 +52,7 @@ impl NoSchemaRegistry {
                             })?;
 
                             schemas.push(SourceSchema::new(
-                                table.table_name.clone(),
+                                table.name.clone(),
                                 mapped_schema,
                                 ReplicationChangesTrackingType::FullChanges,
                             ));

--- a/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
@@ -86,10 +86,8 @@ impl SchemaRegistry {
         let sr_settings = SrSettings::new(config.schema_registry_url.unwrap());
         table_names.map_or(Ok(vec![]), |tables| {
             tables.get(0).map_or(Ok(vec![]), |table| {
-                let key_result =
-                    SchemaRegistry::fetch_struct(&sr_settings, &table.table_name, true)?;
-                let schema_result =
-                    SchemaRegistry::fetch_struct(&sr_settings, &table.table_name, false)?;
+                let key_result = SchemaRegistry::fetch_struct(&sr_settings, &table.name, true)?;
+                let schema_result = SchemaRegistry::fetch_struct(&sr_settings, &table.name, false)?;
 
                 let pk_fields = key_result.fields.map_or(vec![], |fields| {
                     fields
@@ -142,7 +140,7 @@ impl SchemaRegistry {
                                 };
 
                                 schema_data = Some(Ok(vec![SourceSchema::new(
-                                    table.table_name.clone(),
+                                    table.name.clone(),
                                     schema,
                                     ReplicationChangesTrackingType::FullChanges,
                                 )]));

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -54,12 +54,11 @@ pub trait Connector: Send + Sync + Debug {
         Ok(self
             .get_schemas(None)?
             .into_iter()
-            .enumerate()
-            .map(|(id, s)| TableInfo {
-                table_name: s.name,
-                id: id as u32,
+            .map(|source_schema| TableInfo {
+                table_name: source_schema.name,
                 columns: Some(
-                    s.schema
+                    source_schema
+                        .schema
                         .fields
                         .into_iter()
                         .map(|f| ColumnInfo {
@@ -77,7 +76,6 @@ pub trait Connector: Send + Sync + Debug {
 #[serde(crate = "self::serde")]
 pub struct TableInfo {
     pub table_name: String,
-    pub id: u32,
     pub columns: Option<Vec<ColumnInfo>>,
 }
 

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -56,18 +56,17 @@ pub trait Connector: Send + Sync + Debug {
     ) -> Result<Vec<TableInfo>, ConnectorError> {
         Ok(self
             .get_schemas(tables.map(|t| t.to_vec()))?
-            .iter()
+            .into_iter()
             .enumerate()
             .map(|(id, s)| TableInfo {
-                name: s.name.to_string(),
-                table_name: s.name.to_string(),
+                table_name: s.name,
                 id: id as u32,
                 columns: Some(
                     s.schema
                         .fields
-                        .iter()
+                        .into_iter()
                         .map(|f| ColumnInfo {
-                            name: f.name.to_string(),
+                            name: f.name,
                             data_type: Some(f.typ.to_string()),
                         })
                         .collect(),
@@ -80,7 +79,6 @@ pub trait Connector: Send + Sync + Debug {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(crate = "self::serde")]
 pub struct TableInfo {
-    pub name: String,
     pub table_name: String,
     pub id: u32,
     pub columns: Option<Vec<ColumnInfo>>,

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -47,15 +47,12 @@ pub trait Connector: Send + Sync + Debug {
         ingestor: &Ingestor,
         tables: Vec<TableInfo>,
     ) -> Result<(), ConnectorError>;
-    fn get_tables(&self, tables: Option<&[TableInfo]>) -> Result<Vec<TableInfo>, ConnectorError>;
+    fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError>;
 
     // This is a default table mapping from schemas. It will result in errors if connector has unsupported data types.
-    fn get_tables_default(
-        &self,
-        tables: Option<&[TableInfo]>,
-    ) -> Result<Vec<TableInfo>, ConnectorError> {
+    fn get_tables_default(&self) -> Result<Vec<TableInfo>, ConnectorError> {
         Ok(self
-            .get_schemas(tables.map(|t| t.to_vec()))?
+            .get_schemas(None)?
             .into_iter()
             .enumerate()
             .map(|(id, s)| TableInfo {

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -55,7 +55,7 @@ pub trait Connector: Send + Sync + Debug {
             .get_schemas(None)?
             .into_iter()
             .map(|source_schema| TableInfo {
-                table_name: source_schema.name,
+                name: source_schema.name,
                 columns: Some(
                     source_schema
                         .schema
@@ -75,7 +75,7 @@ pub trait Connector: Send + Sync + Debug {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(crate = "self::serde")]
 pub struct TableInfo {
-    pub table_name: String,
+    pub name: String,
     pub columns: Option<Vec<ColumnInfo>>,
 }
 

--- a/dozer-ingestion/src/connectors/object_store/connector.rs
+++ b/dozer-ingestion/src/connectors/object_store/connector.rs
@@ -53,7 +53,7 @@ impl<T: DozerObjectStore> Connector for ObjectStoreConnector<T> {
         TableReader::new(self.config.clone()).read_tables(&tables, ingestor)
     }
 
-    fn get_tables(&self, tables: Option<&[TableInfo]>) -> ConnectorResult<Vec<TableInfo>> {
-        self.get_tables_default(tables)
+    fn get_tables(&self) -> ConnectorResult<Vec<TableInfo>> {
+        self.get_tables_default()
     }
 }

--- a/dozer-ingestion/src/connectors/object_store/schema_mapper.rs
+++ b/dozer-ingestion/src/connectors/object_store/schema_mapper.rs
@@ -67,7 +67,6 @@ impl<T: DozerObjectStore> Mapper<T> for SchemaMapper<T> {
                 .tables()
                 .iter()
                 .map(|t| TableInfo {
-                    name: t.name.clone(),
                     table_name: t.name.clone(),
                     id: 0,
                     columns: None,

--- a/dozer-ingestion/src/connectors/object_store/schema_mapper.rs
+++ b/dozer-ingestion/src/connectors/object_store/schema_mapper.rs
@@ -68,7 +68,6 @@ impl<T: DozerObjectStore> Mapper<T> for SchemaMapper<T> {
                 .iter()
                 .map(|t| TableInfo {
                     table_name: t.name.clone(),
-                    id: 0,
                     columns: None,
                 })
                 .collect()

--- a/dozer-ingestion/src/connectors/object_store/schema_mapper.rs
+++ b/dozer-ingestion/src/connectors/object_store/schema_mapper.rs
@@ -67,7 +67,7 @@ impl<T: DozerObjectStore> Mapper<T> for SchemaMapper<T> {
                 .tables()
                 .iter()
                 .map(|t| TableInfo {
-                    table_name: t.name.clone(),
+                    name: t.name.clone(),
                     columns: None,
                 })
                 .collect()
@@ -77,7 +77,7 @@ impl<T: DozerObjectStore> Mapper<T> for SchemaMapper<T> {
             .iter()
             .enumerate()
             .map(|(id, table)| {
-                let table_name = table.table_name.clone();
+                let table_name = table.name.clone();
 
                 let params = self.config.table_params(&table_name)?;
 

--- a/dozer-ingestion/src/connectors/object_store/table_reader.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_reader.rs
@@ -116,7 +116,7 @@ pub trait Reader<T> {
 impl<T: DozerObjectStore> Reader<T> for TableReader<T> {
     fn read_tables(&self, tables: &[TableInfo], ingestor: &Ingestor) -> Result<(), ConnectorError> {
         for (id, table) in tables.iter().enumerate() {
-            let params = self.config.table_params(&table.name)?;
+            let params = self.config.table_params(&table.table_name)?;
 
             let table_path = ListingTableUrl::parse(params.table_path).map_err(|e| {
                 ObjectStoreConnectorError::DataFusionStorageObjectError(ListingPathParsingError(e))

--- a/dozer-ingestion/src/connectors/object_store/table_reader.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_reader.rs
@@ -116,7 +116,7 @@ pub trait Reader<T> {
 impl<T: DozerObjectStore> Reader<T> for TableReader<T> {
     fn read_tables(&self, tables: &[TableInfo], ingestor: &Ingestor) -> Result<(), ConnectorError> {
         for (id, table) in tables.iter().enumerate() {
-            let params = self.config.table_params(&table.table_name)?;
+            let params = self.config.table_params(&table.name)?;
 
             let table_path = ListingTableUrl::parse(params.table_path).map_err(|e| {
                 ObjectStoreConnectorError::DataFusionStorageObjectError(ListingPathParsingError(e))

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -74,7 +74,7 @@ fn test_read_parquet_file() {
     let (ingestor, mut iterator) = Ingestor::initialize_channel(config);
 
     let table = TableInfo {
-        table_name: "all_types_parquet".to_string(),
+        name: "all_types_parquet".to_string(),
         columns: None,
     };
     thread::spawn(move || {
@@ -124,7 +124,7 @@ fn test_csv_read() {
     let (ingestor, mut iterator) = Ingestor::initialize_channel(config);
 
     let table = TableInfo {
-        table_name: "all_types_csv".to_string(),
+        name: "all_types_csv".to_string(),
         columns: None,
     };
 
@@ -199,7 +199,7 @@ fn test_missing_directory() {
         None,
         &ingestor,
         vec![TableInfo {
-            table_name: table.name,
+            name: table.name,
             columns: None,
         }],
     );

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -75,7 +75,6 @@ fn test_read_parquet_file() {
 
     let table = TableInfo {
         table_name: "all_types_parquet".to_string(),
-        id: 0,
         columns: None,
     };
     thread::spawn(move || {
@@ -126,7 +125,6 @@ fn test_csv_read() {
 
     let table = TableInfo {
         table_name: "all_types_csv".to_string(),
-        id: 0,
         columns: None,
     };
 
@@ -202,7 +200,6 @@ fn test_missing_directory() {
         &ingestor,
         vec![TableInfo {
             table_name: table.name,
-            id: 0,
             columns: None,
         }],
     );

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -74,7 +74,6 @@ fn test_read_parquet_file() {
     let (ingestor, mut iterator) = Ingestor::initialize_channel(config);
 
     let table = TableInfo {
-        name: "all_types_parquet".to_string(),
         table_name: "all_types_parquet".to_string(),
         id: 0,
         columns: None,
@@ -126,7 +125,6 @@ fn test_csv_read() {
     let (ingestor, mut iterator) = Ingestor::initialize_channel(config);
 
     let table = TableInfo {
-        name: "all_types_csv".to_string(),
         table_name: "all_types_csv".to_string(),
         id: 0,
         columns: None,
@@ -203,7 +201,6 @@ fn test_missing_directory() {
         None,
         &ingestor,
         vec![TableInfo {
-            name: table.name.clone(),
             table_name: table.name,
             id: 0,
             columns: None,

--- a/dozer-ingestion/src/connectors/postgres/connection/validator.rs
+++ b/dozer-ingestion/src/connectors/postgres/connection/validator.rs
@@ -135,8 +135,8 @@ fn validate_wal_level(client: &mut Client) -> Result<(), PostgresConnectorError>
 fn validate_tables_names(table_info: &Vec<TableInfo>) -> Result<(), PostgresConnectorError> {
     let table_regex = Regex::new(r"^([[:lower:]_][[:alnum:]_]*)$").unwrap();
     for t in table_info {
-        if !table_regex.is_match(&t.table_name) {
-            return Err(TableNameNotValid(t.table_name.clone()));
+        if !table_regex.is_match(&t.name) {
+            return Err(TableNameNotValid(t.name.clone()));
         }
     }
 
@@ -164,7 +164,7 @@ fn validate_tables(
 ) -> Result<(), PostgresConnectorError> {
     let mut tables_names: HashMap<String, bool> = HashMap::new();
     table_info.iter().for_each(|t| {
-        tables_names.insert(t.table_name.clone(), true);
+        tables_names.insert(t.name.clone(), true);
     });
 
     validate_tables_names(table_info)?;
@@ -209,7 +209,7 @@ fn validate_tables(
 
         let columns = table_info
             .iter()
-            .find(|x| x.table_name == table_name)
+            .find(|x| x.name == table_name)
             .unwrap()
             .clone()
             .columns;
@@ -295,8 +295,8 @@ pub fn validate_slot(
         }
 
         for t in tables_list {
-            if !publication_tables.contains(&t.table_name) {
-                return Err(MissingTableInReplicationSlot(t.table_name.clone()));
+            if !publication_tables.contains(&t.name) {
+                return Err(MissingTableInReplicationSlot(t.name.clone()));
             }
         }
     }
@@ -427,7 +427,7 @@ mod tests {
                 .expect("User creation failed");
 
             let tables = vec![TableInfo {
-                table_name: "not_existing".to_string(),
+                name: "not_existing".to_string(),
                 columns: None,
             }];
             let result = validate_connection("pg_test_conn", config, Some(&tables), None);
@@ -475,7 +475,7 @@ mod tests {
             ];
 
             let tables = vec![TableInfo {
-                table_name: "existing".to_string(),
+                name: "existing".to_string(),
                 columns: Some(columns),
             }];
 
@@ -653,7 +653,7 @@ mod tests {
 
         for (table_name, expected_result) in tables_with_result {
             let res = validate_tables_names(&vec![TableInfo {
-                table_name: table_name.to_string(),
+                name: table_name.to_string(),
                 columns: None,
             }]);
 
@@ -672,7 +672,7 @@ mod tests {
 
         for (column_name, expected_result) in columns_names_with_result {
             let res = validate_columns_names(&vec![TableInfo {
-                table_name: "column_test_table".to_string(),
+                name: "column_test_table".to_string(),
                 columns: Some(vec![ColumnInfo {
                     name: column_name.to_string(),
                     data_type: None,
@@ -706,7 +706,7 @@ mod tests {
             let result = validate_tables(
                 &mut pg_client,
                 &vec![TableInfo {
-                    table_name,
+                    name: table_name,
                     columns: None,
                 }],
             );
@@ -716,7 +716,7 @@ mod tests {
             let result = validate_tables(
                 &mut pg_client,
                 &vec![TableInfo {
-                    table_name: view_name,
+                    name: view_name,
                     columns: None,
                 }],
             );

--- a/dozer-ingestion/src/connectors/postgres/connection/validator.rs
+++ b/dozer-ingestion/src/connectors/postgres/connection/validator.rs
@@ -427,7 +427,6 @@ mod tests {
                 .expect("User creation failed");
 
             let tables = vec![TableInfo {
-                name: "not_existing".to_string(),
                 table_name: "not_existing".to_string(),
                 id: 0,
                 columns: None,
@@ -477,7 +476,6 @@ mod tests {
             ];
 
             let tables = vec![TableInfo {
-                name: "existing".to_string(),
                 table_name: "existing".to_string(),
                 id: 0,
                 columns: Some(columns),
@@ -657,7 +655,6 @@ mod tests {
 
         for (table_name, expected_result) in tables_with_result {
             let res = validate_tables_names(&vec![TableInfo {
-                name: table_name.to_string(),
                 table_name: table_name.to_string(),
                 id: 0,
                 columns: None,
@@ -678,7 +675,6 @@ mod tests {
 
         for (column_name, expected_result) in columns_names_with_result {
             let res = validate_columns_names(&vec![TableInfo {
-                name: "column_test_table".to_string(),
                 table_name: "column_test_table".to_string(),
                 id: 0,
                 columns: Some(vec![ColumnInfo {
@@ -714,7 +710,6 @@ mod tests {
             let result = validate_tables(
                 &mut pg_client,
                 &vec![TableInfo {
-                    name: table_name.clone(),
                     table_name,
                     id: 0,
                     columns: None,
@@ -726,7 +721,6 @@ mod tests {
             let result = validate_tables(
                 &mut pg_client,
                 &vec![TableInfo {
-                    name: view_name.clone(),
                     table_name: view_name,
                     id: 0,
                     columns: None,

--- a/dozer-ingestion/src/connectors/postgres/connection/validator.rs
+++ b/dozer-ingestion/src/connectors/postgres/connection/validator.rs
@@ -428,7 +428,6 @@ mod tests {
 
             let tables = vec![TableInfo {
                 table_name: "not_existing".to_string(),
-                id: 0,
                 columns: None,
             }];
             let result = validate_connection("pg_test_conn", config, Some(&tables), None);
@@ -477,7 +476,6 @@ mod tests {
 
             let tables = vec![TableInfo {
                 table_name: "existing".to_string(),
-                id: 0,
                 columns: Some(columns),
             }];
 
@@ -656,7 +654,6 @@ mod tests {
         for (table_name, expected_result) in tables_with_result {
             let res = validate_tables_names(&vec![TableInfo {
                 table_name: table_name.to_string(),
-                id: 0,
                 columns: None,
             }]);
 
@@ -676,7 +673,6 @@ mod tests {
         for (column_name, expected_result) in columns_names_with_result {
             let res = validate_columns_names(&vec![TableInfo {
                 table_name: "column_test_table".to_string(),
-                id: 0,
                 columns: Some(vec![ColumnInfo {
                     name: column_name.to_string(),
                     data_type: None,
@@ -711,7 +707,6 @@ mod tests {
                 &mut pg_client,
                 &vec![TableInfo {
                     table_name,
-                    id: 0,
                     columns: None,
                 }],
             );
@@ -722,7 +717,6 @@ mod tests {
                 &mut pg_client,
                 &vec![TableInfo {
                     table_name: view_name,
-                    id: 0,
                     columns: None,
                 }],
             );

--- a/dozer-ingestion/src/connectors/postgres/connector.rs
+++ b/dozer-ingestion/src/connectors/postgres/connector.rs
@@ -135,7 +135,7 @@ impl Connector for PostgresConnector {
         Ok(tables
             .into_iter()
             .map(|table_info| TableInfo {
-                table_name: table_info.name,
+                name: table_info.name,
                 columns: Some(table_info.columns),
             })
             .collect())
@@ -169,7 +169,7 @@ impl PostgresConnector {
         let table_str: String = match self.tables.as_ref() {
             None => "ALL TABLES".to_string(),
             Some(arr) => {
-                let table_names: Vec<String> = arr.iter().map(|t| t.table_name.clone()).collect();
+                let table_names: Vec<String> = arr.iter().map(|t| t.name.clone()).collect();
                 format!("TABLE {}", table_names.join(" , "))
             }
         };

--- a/dozer-ingestion/src/connectors/postgres/connector.rs
+++ b/dozer-ingestion/src/connectors/postgres/connector.rs
@@ -85,7 +85,7 @@ impl Connector for PostgresConnector {
         table_names: Option<Vec<TableInfo>>,
     ) -> Result<Vec<SourceSchema>, ConnectorError> {
         self.schema_helper
-            .get_schemas(table_names)
+            .get_schemas(table_names.as_deref())
             .map_err(PostgresConnectorError)
     }
 
@@ -106,7 +106,7 @@ impl Connector for PostgresConnector {
             self.name.clone(),
             self.get_publication_name(),
             self.get_slot_name(),
-            tables,
+            self.schema_helper.get_tables(Some(&tables))?,
             self.replication_conn_config.clone(),
             ingestor,
             self.conn_config.clone(),
@@ -131,7 +131,14 @@ impl Connector for PostgresConnector {
     }
 
     fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError> {
-        self.schema_helper.get_tables(None)
+        let tables = self.schema_helper.get_tables(None)?;
+        Ok(tables
+            .into_iter()
+            .map(|table_info| TableInfo {
+                table_name: table_info.name,
+                columns: Some(table_info.columns),
+            })
+            .collect())
     }
 
     fn can_start_from(&self, (lsn, _): (u64, u64)) -> Result<bool, ConnectorError> {

--- a/dozer-ingestion/src/connectors/postgres/connector.rs
+++ b/dozer-ingestion/src/connectors/postgres/connector.rs
@@ -130,7 +130,7 @@ impl Connector for PostgresConnector {
         SchemaHelper::validate(&self.schema_helper, tables).map_err(PostgresConnectorError)
     }
 
-    fn get_tables(&self, _tables: Option<&[TableInfo]>) -> Result<Vec<TableInfo>, ConnectorError> {
+    fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError> {
         self.schema_helper.get_tables(None)
     }
 

--- a/dozer-ingestion/src/connectors/postgres/iterator.rs
+++ b/dozer-ingestion/src/connectors/postgres/iterator.rs
@@ -169,7 +169,7 @@ impl<'a> PostgresIteratorHandler<'a> {
                 .tables
                 .iter()
                 .map(|table_info| TableInfo {
-                    table_name: table_info.name.clone(),
+                    name: table_info.name.clone(),
                     columns: Some(table_info.columns.clone()),
                 })
                 .collect::<Vec<_>>();

--- a/dozer-ingestion/src/connectors/postgres/schema/helper.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/helper.rs
@@ -138,7 +138,6 @@ impl SchemaHelper {
         Ok(columns_map
             .iter()
             .map(|(table_name, columns)| TableInfo {
-                name: table_name.clone(),
                 table_name: table_name.clone(),
                 id: *tables_id.get(&table_name.clone()).unwrap(),
                 columns: Some(columns.clone()),

--- a/dozer-ingestion/src/connectors/postgres/schema/helper.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/helper.rs
@@ -172,12 +172,12 @@ impl SchemaHelper {
             tables.iter().for_each(|t| {
                 if let Some(columns) = t.columns.clone() {
                     tables_columns_map.insert(
-                        t.table_name.clone(),
+                        t.name.clone(),
                         columns.iter().map(|c| c.name.clone()).collect(),
                     );
                 }
             });
-            let table_names: Vec<String> = tables.iter().map(|t| t.table_name.clone()).collect();
+            let table_names: Vec<String> = tables.iter().map(|t| t.name.clone()).collect();
             let sql = str::replace(SQL, ":tables_name_condition", "t.table_name = ANY($2)");
             client.query(&sql, &[&schema, &table_names])
         } else {
@@ -317,7 +317,7 @@ impl SchemaHelper {
         for table in tables {
             if let Some(columns) = &table.columns {
                 let mut existing_columns = HashMap::new();
-                if let Some(res) = validation_result.get(&table.table_name) {
+                if let Some(res) = validation_result.get(&table.name) {
                     for (col_name, _) in res {
                         if let Some(name) = col_name {
                             existing_columns.insert(name.clone(), ());
@@ -328,14 +328,14 @@ impl SchemaHelper {
                 for ColumnInfo { name, .. } in columns {
                     if existing_columns.get(name).is_none() {
                         validation_result
-                            .entry(table.table_name.clone())
+                            .entry(table.name.clone())
                             .and_modify(|r| {
                                 r.push((
                                     None,
                                     Err(ConnectorError::PostgresConnectorError(
                                         PostgresConnectorError::ColumnNotFound(
                                             name.to_string(),
-                                            table.table_name.clone(),
+                                            table.name.clone(),
                                         ),
                                     )),
                                 ))

--- a/dozer-ingestion/src/connectors/postgres/schema/sorter.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/sorter.rs
@@ -152,7 +152,6 @@ mod tests {
 
         let expected_table_order = &[TableInfo {
             table_name: "sort_test".to_string(),
-            id: 0,
             columns: None,
         }];
 
@@ -196,7 +195,6 @@ mod tests {
         }];
         let expected_table_order = &[TableInfo {
             table_name: "sort_test".to_string(),
-            id: 0,
             columns: Some(columns_order.clone()),
         }];
 
@@ -230,7 +228,6 @@ mod tests {
         ];
         let expected_table_order = &[TableInfo {
             table_name: "sort_test".to_string(),
-            id: 0,
             columns: Some(columns_order.clone()),
         }];
 
@@ -289,12 +286,10 @@ mod tests {
         let expected_table_order = &[
             TableInfo {
                 table_name: "sort_test_first".to_string(),
-                id: 0,
                 columns: Some(columns_order_1.clone()),
             },
             TableInfo {
                 table_name: "sort_test_second".to_string(),
-                id: 0,
                 columns: Some(columns_order_2.clone()),
             },
         ];

--- a/dozer-ingestion/src/connectors/postgres/schema/sorter.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/sorter.rs
@@ -19,7 +19,7 @@ pub fn sort_schemas(
         |tables| {
             let mut sorted_tables: Vec<(String, PostgresTable)> = Vec::new();
             for table in tables.iter() {
-                let postgres_table = mapped_tables.get(&table.table_name).ok_or(ColumnNotFound)?;
+                let postgres_table = mapped_tables.get(&table.name).ok_or(ColumnNotFound)?;
 
                 let sorted_table = table.columns.as_ref().map_or_else(
                     || Ok(postgres_table.clone()),
@@ -40,7 +40,7 @@ pub fn sort_schemas(
                     },
                 )?;
 
-                sorted_tables.push((table.table_name.clone(), sorted_table));
+                sorted_tables.push((table.name.clone(), sorted_table));
             }
 
             Ok(sorted_tables)
@@ -151,7 +151,7 @@ mod tests {
         mapped_tables.insert("sort_test".to_string(), postgres_table.clone());
 
         let expected_table_order = &[TableInfo {
-            table_name: "sort_test".to_string(),
+            name: "sort_test".to_string(),
             columns: None,
         }];
 
@@ -194,7 +194,7 @@ mod tests {
             data_type: None,
         }];
         let expected_table_order = &[TableInfo {
-            table_name: "sort_test".to_string(),
+            name: "sort_test".to_string(),
             columns: Some(columns_order.clone()),
         }];
 
@@ -227,7 +227,7 @@ mod tests {
             },
         ];
         let expected_table_order = &[TableInfo {
-            table_name: "sort_test".to_string(),
+            name: "sort_test".to_string(),
             columns: Some(columns_order.clone()),
         }];
 
@@ -285,11 +285,11 @@ mod tests {
         ];
         let expected_table_order = &[
             TableInfo {
-                table_name: "sort_test_first".to_string(),
+                name: "sort_test_first".to_string(),
                 columns: Some(columns_order_1.clone()),
             },
             TableInfo {
-                table_name: "sort_test_second".to_string(),
+                name: "sort_test_second".to_string(),
                 columns: Some(columns_order_2.clone()),
             },
         ];
@@ -300,11 +300,11 @@ mod tests {
 
         assert_eq!(
             first_table_after_sort.0,
-            expected_table_order.get(0).unwrap().table_name
+            expected_table_order.get(0).unwrap().name
         );
         assert_eq!(
             second_table_after_sort.0,
-            expected_table_order.get(1).unwrap().table_name
+            expected_table_order.get(1).unwrap().name
         );
         assert_eq!(
             first_table_after_sort.1.fields().get(0).unwrap().name,

--- a/dozer-ingestion/src/connectors/postgres/schema/sorter.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/sorter.rs
@@ -151,7 +151,6 @@ mod tests {
         mapped_tables.insert("sort_test".to_string(), postgres_table.clone());
 
         let expected_table_order = &[TableInfo {
-            name: "sort_test".to_string(),
             table_name: "sort_test".to_string(),
             id: 0,
             columns: None,
@@ -196,7 +195,6 @@ mod tests {
             data_type: None,
         }];
         let expected_table_order = &[TableInfo {
-            name: "sort_test".to_string(),
             table_name: "sort_test".to_string(),
             id: 0,
             columns: Some(columns_order.clone()),
@@ -231,7 +229,6 @@ mod tests {
             },
         ];
         let expected_table_order = &[TableInfo {
-            name: "sort_test".to_string(),
             table_name: "sort_test".to_string(),
             id: 0,
             columns: Some(columns_order.clone()),
@@ -291,13 +288,11 @@ mod tests {
         ];
         let expected_table_order = &[
             TableInfo {
-                name: "sort_test_first".to_string(),
                 table_name: "sort_test_first".to_string(),
                 id: 0,
                 columns: Some(columns_order_1.clone()),
             },
             TableInfo {
-                name: "sort_test_second".to_string(),
                 table_name: "sort_test_second".to_string(),
                 id: 0,
                 columns: Some(columns_order_2.clone()),
@@ -310,11 +305,11 @@ mod tests {
 
         assert_eq!(
             first_table_after_sort.0,
-            expected_table_order.get(0).unwrap().name
+            expected_table_order.get(0).unwrap().table_name
         );
         assert_eq!(
             second_table_after_sort.0,
-            expected_table_order.get(1).unwrap().name
+            expected_table_order.get(1).unwrap().table_name
         );
         assert_eq!(
             first_table_after_sort.1.fields().get(0).unwrap().name,

--- a/dozer-ingestion/src/connectors/postgres/schema/tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/tests.rs
@@ -71,7 +71,7 @@ fn test_connector_get_schema_with_selected_columns() {
 
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
-            table_name: table_name.clone(),
+            name: table_name.clone(),
             columns: Some(vec![
                 ColumnInfo::new("name".to_string(), None),
                 ColumnInfo::new("id".to_string(), None),
@@ -110,7 +110,7 @@ fn test_connector_get_schema_without_selected_columns() {
 
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
-            table_name: table_name.clone(),
+            name: table_name.clone(),
             columns: Some(vec![]),
         };
         let result = schema_helper.get_tables(Some(&[table_info])).unwrap();
@@ -150,7 +150,7 @@ fn test_connector_view_cannot_be_used() {
 
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
-            table_name: view_name,
+            name: view_name,
             columns: Some(vec![]),
         };
 
@@ -162,7 +162,7 @@ fn test_connector_view_cannot_be_used() {
         ));
 
         let table_info = TableInfo {
-            table_name,
+            name: table_name,
             columns: Some(vec![]),
         };
         let result = schema_helper.get_schemas(Some(&[table_info]));

--- a/dozer-ingestion/src/connectors/postgres/schema/tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/tests.rs
@@ -10,7 +10,7 @@ use serial_test::serial;
 use std::collections::HashSet;
 use std::hash::Hash;
 
-fn assert_vec_eq<T>(a: Vec<T>, b: Vec<T>) -> bool
+fn assert_vec_eq<T>(a: &[T], b: &[T]) -> bool
 where
     T: Eq + Hash,
 {
@@ -39,15 +39,15 @@ fn test_connector_get_tables() {
         let result = schema_helper.get_tables(None).unwrap();
 
         let table = result.get(0).unwrap();
-        assert_eq!(table_name, table.table_name.clone());
+        assert_eq!(table_name, table.name);
         assert!(assert_vec_eq(
-            vec![
+            &[
                 ColumnInfo::new("name".to_string(), None),
                 ColumnInfo::new("description".to_string(), None),
                 ColumnInfo::new("weight".to_string(), None),
                 ColumnInfo::new("id".to_string(), None),
             ],
-            table.columns.clone().unwrap()
+            &table.columns
         ));
 
         client.drop_schema(&schema);
@@ -72,7 +72,6 @@ fn test_connector_get_schema_with_selected_columns() {
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
             table_name: table_name.clone(),
-            id: 0,
             columns: Some(vec![
                 ColumnInfo::new("name".to_string(), None),
                 ColumnInfo::new("id".to_string(), None),
@@ -81,13 +80,13 @@ fn test_connector_get_schema_with_selected_columns() {
         let result = schema_helper.get_tables(Some(&[table_info])).unwrap();
 
         let table = result.get(0).unwrap();
-        assert_eq!(table_name, table.table_name.clone());
+        assert_eq!(table_name, table.name);
         assert!(assert_vec_eq(
-            vec![
+            &[
                 ColumnInfo::new("name".to_string(), None),
                 ColumnInfo::new("id".to_string(), None)
             ],
-            table.columns.clone().unwrap()
+            &table.columns
         ));
 
         client.drop_schema(&schema);
@@ -112,21 +111,20 @@ fn test_connector_get_schema_without_selected_columns() {
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
             table_name: table_name.clone(),
-            id: 0,
             columns: Some(vec![]),
         };
         let result = schema_helper.get_tables(Some(&[table_info])).unwrap();
 
         let table = result.get(0).unwrap();
-        assert_eq!(table_name, table.table_name.clone());
+        assert_eq!(table_name, table.name.clone());
         assert!(assert_vec_eq(
-            vec![
+            &[
                 ColumnInfo::new("id".to_string(), None),
                 ColumnInfo::new("name".to_string(), None),
                 ColumnInfo::new("description".to_string(), None),
                 ColumnInfo::new("weight".to_string(), None),
             ],
-            table.columns.clone().unwrap()
+            &table.columns
         ));
 
         client.drop_schema(&schema);
@@ -153,11 +151,10 @@ fn test_connector_view_cannot_be_used() {
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
             table_name: view_name,
-            id: 0,
             columns: Some(vec![]),
         };
 
-        let result = schema_helper.get_schemas(Some(vec![table_info]));
+        let result = schema_helper.get_schemas(Some(&[table_info]));
         assert!(result.is_err());
         assert!(matches!(
             result,
@@ -166,10 +163,9 @@ fn test_connector_view_cannot_be_used() {
 
         let table_info = TableInfo {
             table_name,
-            id: 0,
             columns: Some(vec![]),
         };
-        let result = schema_helper.get_schemas(Some(vec![table_info]));
+        let result = schema_helper.get_schemas(Some(&[table_info]));
         assert!(result.is_ok());
 
         client.drop_schema(&schema);

--- a/dozer-ingestion/src/connectors/postgres/schema/tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/tests.rs
@@ -71,7 +71,6 @@ fn test_connector_get_schema_with_selected_columns() {
 
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
-            name: table_name.clone(),
             table_name: table_name.clone(),
             id: 0,
             columns: Some(vec![
@@ -112,7 +111,6 @@ fn test_connector_get_schema_without_selected_columns() {
 
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
-            name: table_name.clone(),
             table_name: table_name.clone(),
             id: 0,
             columns: Some(vec![]),
@@ -154,8 +152,7 @@ fn test_connector_view_cannot_be_used() {
 
         let schema_helper = SchemaHelper::new(client.postgres_config.clone(), Some(schema.clone()));
         let table_info = TableInfo {
-            name: view_name.clone(),
-            table_name: view_name.clone(),
+            table_name: view_name,
             id: 0,
             columns: Some(vec![]),
         };
@@ -168,8 +165,7 @@ fn test_connector_view_cannot_be_used() {
         ));
 
         let table_info = TableInfo {
-            name: table_name.clone(),
-            table_name: table_name.clone(),
+            table_name,
             id: 0,
             columns: Some(vec![]),
         };

--- a/dozer-ingestion/src/connectors/postgres/snapshotter.rs
+++ b/dozer-ingestion/src/connectors/postgres/snapshotter.rs
@@ -20,14 +20,13 @@ use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::types::Operation;
 
 pub struct PostgresSnapshotter<'a> {
-    pub tables: Vec<TableInfo>,
     pub conn_config: tokio_postgres::Config,
     pub ingestor: &'a Ingestor,
     pub connector_id: u64,
 }
 
 impl<'a> PostgresSnapshotter<'a> {
-    pub fn get_tables(&self, tables: Vec<TableInfo>) -> Result<Vec<SourceSchema>, ConnectorError> {
+    pub fn get_tables(&self, tables: &[TableInfo]) -> Result<Vec<SourceSchema>, ConnectorError> {
         let helper = SchemaHelper::new(self.conn_config.clone(), None);
         helper
             .get_schemas(Some(tables))
@@ -85,7 +84,7 @@ impl<'a> PostgresSnapshotter<'a> {
         Ok(())
     }
 
-    pub fn sync_tables(&self, tables: Vec<TableInfo>) -> Result<(), ConnectorError> {
+    pub fn sync_tables(&self, tables: &[TableInfo]) -> Result<(), ConnectorError> {
         let tables = self.get_tables(tables)?;
 
         let mut left_tables_count = tables.len();
@@ -175,7 +174,6 @@ mod tests {
 
             let tables = vec![TableInfo {
                 table_name: table_name.clone(),
-                id: 0,
                 columns: None,
             }];
 
@@ -191,7 +189,6 @@ mod tests {
 
             let input_tables = vec![TableInfo {
                 table_name,
-                id: 0,
                 columns: None,
             }];
 
@@ -199,13 +196,12 @@ mod tests {
             let (ingestor, mut iterator) = Ingestor::initialize_channel(ingestion_config);
 
             let snapshotter = PostgresSnapshotter {
-                tables,
                 conn_config,
                 ingestor: &ingestor,
                 connector_id: connector.id,
             };
 
-            let actual = snapshotter.sync_tables(input_tables);
+            let actual = snapshotter.sync_tables(&input_tables);
 
             assert!(actual.is_ok());
 
@@ -249,7 +245,6 @@ mod tests {
 
             let tables = vec![TableInfo {
                 table_name,
-                id: 0,
                 columns: None,
             }];
 
@@ -266,7 +261,6 @@ mod tests {
             let input_table_name = String::from("not_existing_table");
             let input_tables = vec![TableInfo {
                 table_name: input_table_name,
-                id: 0,
                 columns: None,
             }];
 
@@ -274,13 +268,12 @@ mod tests {
             let (ingestor, mut _iterator) = Ingestor::initialize_channel(ingestion_config);
 
             let snapshotter = PostgresSnapshotter {
-                tables,
                 conn_config,
                 ingestor: &ingestor,
                 connector_id: connector.id,
             };
 
-            let actual = snapshotter.sync_tables(input_tables);
+            let actual = snapshotter.sync_tables(&input_tables);
 
             assert!(actual.is_err());
 
@@ -312,7 +305,6 @@ mod tests {
 
             let tables = vec![TableInfo {
                 table_name: table_name.clone(),
-                id: 0,
                 columns: None,
             }];
 
@@ -328,7 +320,6 @@ mod tests {
 
             let input_tables = vec![TableInfo {
                 table_name,
-                id: 0,
                 columns: None,
             }];
 
@@ -336,13 +327,12 @@ mod tests {
             let (ingestor, mut _iterator) = Ingestor::initialize_channel(ingestion_config);
 
             let snapshotter = PostgresSnapshotter {
-                tables,
                 conn_config,
                 ingestor: &ingestor,
                 connector_id: connector.id,
             };
 
-            let actual = snapshotter.sync_tables(input_tables);
+            let actual = snapshotter.sync_tables(&input_tables);
 
             assert!(actual.is_err());
 

--- a/dozer-ingestion/src/connectors/postgres/snapshotter.rs
+++ b/dozer-ingestion/src/connectors/postgres/snapshotter.rs
@@ -174,7 +174,6 @@ mod tests {
             test_client.insert_rows(&table_name, 2, None);
 
             let tables = vec![TableInfo {
-                name: table_name.clone(),
                 table_name: table_name.clone(),
                 id: 0,
                 columns: None,
@@ -191,8 +190,7 @@ mod tests {
             let connector = PostgresConnector::new(1, postgres_config);
 
             let input_tables = vec![TableInfo {
-                name: table_name.clone(),
-                table_name: table_name.clone(),
+                table_name,
                 id: 0,
                 columns: None,
             }];
@@ -250,8 +248,7 @@ mod tests {
             test_client.insert_rows(&table_name, 2, None);
 
             let tables = vec![TableInfo {
-                name: table_name.clone(),
-                table_name: table_name.clone(),
+                table_name,
                 id: 0,
                 columns: None,
             }];
@@ -268,7 +265,6 @@ mod tests {
 
             let input_table_name = String::from("not_existing_table");
             let input_tables = vec![TableInfo {
-                name: input_table_name.clone(),
                 table_name: input_table_name,
                 id: 0,
                 columns: None,
@@ -315,7 +311,6 @@ mod tests {
             let connector_name = format!("pg_connector_{}", rng.gen::<u32>());
 
             let tables = vec![TableInfo {
-                name: table_name.clone(),
                 table_name: table_name.clone(),
                 id: 0,
                 columns: None,
@@ -332,7 +327,6 @@ mod tests {
             let connector = PostgresConnector::new(1, postgres_config);
 
             let input_tables = vec![TableInfo {
-                name: table_name.clone(),
                 table_name,
                 id: 0,
                 columns: None,

--- a/dozer-ingestion/src/connectors/postgres/snapshotter.rs
+++ b/dozer-ingestion/src/connectors/postgres/snapshotter.rs
@@ -173,7 +173,7 @@ mod tests {
             test_client.insert_rows(&table_name, 2, None);
 
             let tables = vec![TableInfo {
-                table_name: table_name.clone(),
+                name: table_name.clone(),
                 columns: None,
             }];
 
@@ -188,7 +188,7 @@ mod tests {
             let connector = PostgresConnector::new(1, postgres_config);
 
             let input_tables = vec![TableInfo {
-                table_name,
+                name: table_name,
                 columns: None,
             }];
 
@@ -244,7 +244,7 @@ mod tests {
             test_client.insert_rows(&table_name, 2, None);
 
             let tables = vec![TableInfo {
-                table_name,
+                name: table_name,
                 columns: None,
             }];
 
@@ -260,7 +260,7 @@ mod tests {
 
             let input_table_name = String::from("not_existing_table");
             let input_tables = vec![TableInfo {
-                table_name: input_table_name,
+                name: input_table_name,
                 columns: None,
             }];
 
@@ -304,7 +304,7 @@ mod tests {
             let connector_name = format!("pg_connector_{}", rng.gen::<u32>());
 
             let tables = vec![TableInfo {
-                table_name: table_name.clone(),
+                name: table_name.clone(),
                 columns: None,
             }];
 
@@ -319,7 +319,7 @@ mod tests {
             let connector = PostgresConnector::new(1, postgres_config);
 
             let input_tables = vec![TableInfo {
-                table_name,
+                name: table_name,
                 columns: None,
             }];
 

--- a/dozer-ingestion/src/connectors/postgres/test_utils.rs
+++ b/dozer-ingestion/src/connectors/postgres/test_utils.rs
@@ -33,7 +33,6 @@ pub fn get_iterator(config: Connection, table_name: String) -> IngestionIterator
     thread::spawn(move || {
         let tables: Vec<TableInfo> = vec![TableInfo {
             table_name,
-            id: 0,
             columns: None,
         }];
 

--- a/dozer-ingestion/src/connectors/postgres/test_utils.rs
+++ b/dozer-ingestion/src/connectors/postgres/test_utils.rs
@@ -32,8 +32,7 @@ pub fn get_iterator(config: Connection, table_name: String) -> IngestionIterator
 
     thread::spawn(move || {
         let tables: Vec<TableInfo> = vec![TableInfo {
-            name: table_name.clone(),
-            table_name: table_name.clone(),
+            table_name,
             id: 0,
             columns: None,
         }];

--- a/dozer-ingestion/src/connectors/postgres/test_utils.rs
+++ b/dozer-ingestion/src/connectors/postgres/test_utils.rs
@@ -32,7 +32,7 @@ pub fn get_iterator(config: Connection, table_name: String) -> IngestionIterator
 
     thread::spawn(move || {
         let tables: Vec<TableInfo> = vec![TableInfo {
-            table_name,
+            name: table_name,
             columns: None,
         }];
 

--- a/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
@@ -88,7 +88,7 @@ mod tests {
             test_client.create_simple_table("public", &table_name);
 
             let tables = vec![TableInfo {
-                table_name: table_name.clone(),
+                name: table_name.clone(),
                 columns: None,
             }];
 

--- a/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
@@ -89,7 +89,6 @@ mod tests {
 
             let tables = vec![TableInfo {
                 table_name: table_name.clone(),
-                id: 0,
                 columns: None,
             }];
 

--- a/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
@@ -88,7 +88,6 @@ mod tests {
             test_client.create_simple_table("public", &table_name);
 
             let tables = vec![TableInfo {
-                name: table_name.clone(),
                 table_name: table_name.clone(),
                 id: 0,
                 columns: None,

--- a/dozer-ingestion/src/connectors/snowflake/connection/client.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connection/client.rs
@@ -399,8 +399,7 @@ impl Client {
                 if idx > 0 {
                     buf.write_char(',').unwrap();
                 }
-                buf.write_str(&format!("\'{}\'", table_info.table_name))
-                    .unwrap();
+                buf.write_str(&format!("\'{}\'", table_info.name)).unwrap();
             }
             buf.write_char(')').unwrap();
             buf

--- a/dozer-ingestion/src/connectors/snowflake/connector.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connector.rs
@@ -117,19 +117,17 @@ async fn run(
             if iteration == 0 {
                 match from_seq {
                     None | Some((0, _)) => {
-                        info!("[{}][{}] Creating new stream", name, table.table_name);
-                        StreamConsumer::drop_stream(&client, &table.table_name)?;
-                        StreamConsumer::create_stream(&client, &table.table_name)?;
+                        info!("[{}][{}] Creating new stream", name, table.name);
+                        StreamConsumer::drop_stream(&client, &table.name)?;
+                        StreamConsumer::create_stream(&client, &table.name)?;
                     }
                     Some((lsn, seq)) => {
                         info!(
                             "[{}][{}] Continuing ingestion from {}/{}",
-                            name, table.table_name, lsn, seq
+                            name, table.name, lsn, seq
                         );
                         iteration = lsn;
-                        if let Ok(false) =
-                            StreamConsumer::is_stream_created(&client, &table.table_name)
-                        {
+                        if let Ok(false) = StreamConsumer::is_stream_created(&client, &table.name) {
                             return Err(ConnectorError::SnowflakeError(
                                 SnowflakeError::SnowflakeStreamError(
                                     SnowflakeStreamError::StreamNotFound,
@@ -140,12 +138,9 @@ async fn run(
                 }
             }
 
-            debug!(
-                "[{}][{}] Reading from changes stream",
-                name, table.table_name
-            );
+            debug!("[{}][{}] Reading from changes stream", name, table.name);
 
-            consumer.consume_stream(&stream_client, &table.table_name, ingestor, idx, iteration)?;
+            consumer.consume_stream(&stream_client, &table.name, ingestor, idx, iteration)?;
 
             interval.tick().await;
         }

--- a/dozer-ingestion/src/connectors/snowflake/connector.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connector.rs
@@ -86,8 +86,8 @@ impl Connector for SnowflakeConnector {
         })
     }
 
-    fn get_tables(&self, tables: Option<&[TableInfo]>) -> Result<Vec<TableInfo>, ConnectorError> {
-        self.get_tables_default(tables)
+    fn get_tables(&self) -> Result<Vec<TableInfo>, ConnectorError> {
+        self.get_tables_default()
     }
 
     fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ConnectorError> {

--- a/dozer-ingestion/src/connectors/snowflake/schema_helper.rs
+++ b/dozer-ingestion/src/connectors/snowflake/schema_helper.rs
@@ -29,7 +29,7 @@ impl SchemaHelper {
         let tables_indexes = table_names.clone().map_or(HashMap::new(), |tables| {
             let mut result = HashMap::new();
             for (idx, table) in tables.iter().enumerate() {
-                result.insert(table.table_name.clone(), idx);
+                result.insert(table.name.clone(), idx);
             }
 
             result
@@ -74,8 +74,8 @@ impl SchemaHelper {
         let existing_schemas_names: Vec<String> = schemas.iter().map(|s| s.name.clone()).collect();
         for table in tables {
             let mut result = vec![];
-            if !existing_schemas_names.contains(&table.table_name) {
-                result.push((None, Err(TableNotFound(table.table_name.clone()))));
+            if !existing_schemas_names.contains(&table.name) {
+                result.push((None, Err(TableNotFound(table.name.clone()))));
             }
 
             validation_result.insert(table.name.clone(), result);

--- a/dozer-ingestion/src/connectors/snowflake/tests.rs
+++ b/dozer-ingestion/src/connectors/snowflake/tests.rs
@@ -55,8 +55,6 @@ fn test_disabled_connector_and_read_from_stream() {
         let connection_config = connection.clone();
         let table = TableInfo {
             name: table_name.clone(),
-            table_name: table_name.clone(),
-            id: 0,
             columns: None,
         };
         thread::spawn(move || {
@@ -141,9 +139,7 @@ fn test_disabled_connector_get_schemas_test() {
         let schemas = connector
             .as_ref()
             .get_schemas(Some(vec![TableInfo {
-                name: table_name.to_string(),
-                table_name: table_name.to_string(),
-                id: 0,
+                name: table_name.clone(),
                 columns: None,
             }]))
             .unwrap();
@@ -185,9 +181,7 @@ fn test_disabled_connector_missing_table_validator() {
         let not_existing_table = "not_existing_table".to_string();
         let result = connector
             .validate_schemas(&[TableInfo {
-                name: not_existing_table.clone(),
-                table_name: not_existing_table,
-                id: 0,
+                name: not_existing_table,
                 columns: None,
             }])
             .unwrap();
@@ -201,8 +195,6 @@ fn test_disabled_connector_missing_table_validator() {
         let result = connector
             .validate_schemas(&[TableInfo {
                 name: existing_table.clone(),
-                table_name: existing_table.clone(),
-                id: 0,
                 columns: None,
             }])
             .unwrap();

--- a/dozer-orchestrator/src/pipeline/connector_source.rs
+++ b/dozer-orchestrator/src/pipeline/connector_source.rs
@@ -40,7 +40,7 @@ fn attach_progress(multi_pb: Option<MultiProgress>) -> ProgressBar {
 
 #[derive(Debug)]
 struct Table {
-    table_name: String,
+    name: String,
     columns: Option<Vec<ColumnInfo>>,
     schema: Schema,
     replication_type: ReplicationChangesTrackingType,
@@ -96,13 +96,13 @@ impl ConnectorSourceFactory {
         for ((table, port), source_schema) in
             table_and_ports.into_iter().zip(source_schemas.into_iter())
         {
-            let table_name = table.table_name;
+            let name = table.name;
             let columns = table.columns;
             let schema = source_schema.schema;
             let replication_type = source_schema.replication_type;
 
             let table = Table {
-                table_name,
+                name,
                 columns,
                 schema,
                 replication_type,
@@ -132,7 +132,7 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
             .find(|table| table.port == *port)
             .ok_or(ExecutionError::PortNotFoundInSource(*port))?;
         let mut schema = table.schema.clone();
-        let table_name = &table.table_name;
+        let table_name = &table.name;
 
         // Add source information to the schema.
         for field in &mut schema.fields {
@@ -175,7 +175,7 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
             .tables
             .iter()
             .map(|table| TableInfo {
-                table_name: table.table_name.clone(),
+                name: table.name.clone(),
                 columns: table.columns.clone(),
             })
             .collect();
@@ -189,7 +189,7 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
         let mut bars = HashMap::new();
         for table in &self.tables {
             let pb = attach_progress(self.progress.clone());
-            pb.set_message(table.table_name.clone());
+            pb.set_message(table.name.clone());
             bars.insert(table.port, pb);
         }
 

--- a/dozer-orchestrator/src/pipeline/connector_source.rs
+++ b/dozer-orchestrator/src/pipeline/connector_source.rs
@@ -176,7 +176,6 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
             .iter()
             .map(|table| TableInfo {
                 table_name: table.table_name.clone(),
-                id: 0,
                 columns: table.columns.clone(),
             })
             .collect();

--- a/dozer-orchestrator/src/pipeline/connector_source.rs
+++ b/dozer-orchestrator/src/pipeline/connector_source.rs
@@ -1,8 +1,8 @@
 use dozer_core::channels::SourceChannelForwarder;
-use dozer_core::errors::ExecutionError::{InternalError, ReplicationTypeNotFound};
+use dozer_core::errors::ExecutionError::InternalError;
 use dozer_core::errors::{ExecutionError, SourceError};
 use dozer_core::node::{OutputPortDef, OutputPortType, PortHandle, Source, SourceFactory};
-use dozer_ingestion::connectors::{get_connector, Connector, TableInfo};
+use dozer_ingestion::connectors::{get_connector, ColumnInfo, Connector, TableInfo};
 use dozer_ingestion::errors::ConnectorError;
 use dozer_ingestion::ingestion::{IngestionConfig, IngestionIterator, Ingestor};
 use dozer_sql::pipeline::builder::SchemaSQLContext;
@@ -13,7 +13,6 @@ use dozer_types::models::connection::Connection;
 use dozer_types::parking_lot::Mutex;
 use dozer_types::types::{
     Operation, ReplicationChangesTrackingType, Schema, SchemaIdentifier, SourceDefinition,
-    SourceSchema,
 };
 use std::collections::HashMap;
 use std::thread;
@@ -40,14 +39,21 @@ fn attach_progress(multi_pb: Option<MultiProgress>) -> ProgressBar {
 }
 
 #[derive(Debug)]
+struct Table {
+    table_name: String,
+    columns: Option<Vec<ColumnInfo>>,
+    schema: Schema,
+    replication_type: ReplicationChangesTrackingType,
+    port: PortHandle,
+}
+
+#[derive(Debug)]
 pub struct ConnectorSourceFactory {
-    pub ports: HashMap<String, u16>,
-    pub schema_port_map: HashMap<u32, u16>,
-    pub schema_map: HashMap<u16, Schema>,
-    pub replication_changes_type_map: HashMap<u16, ReplicationChangesTrackingType>,
-    pub tables: Vec<TableInfo>,
-    pub connection: Connection,
-    pub progress: Option<MultiProgress>,
+    connection_name: String,
+    tables: Vec<Table>,
+    /// Will be moved to `ConnectorSource` in `build`.
+    connector: Mutex<Option<Box<dyn Connector>>>,
+    progress: Option<MultiProgress>,
 }
 
 fn map_replication_type_to_output_port_type(
@@ -70,70 +76,48 @@ fn map_replication_type_to_output_port_type(
 
 impl ConnectorSourceFactory {
     pub fn new(
-        ports: HashMap<String, u16>,
-        tables: Vec<TableInfo>,
+        table_and_ports: Vec<(TableInfo, PortHandle)>,
         connection: Connection,
         progress: Option<MultiProgress>,
     ) -> Result<Self, ExecutionError> {
-        let (schema_map, schema_port_map, replication_changes_type_map) =
-            Self::get_schema_map(connection.clone(), tables.clone(), ports.clone())?;
-        Ok(Self {
-            ports,
-            schema_port_map,
-            schema_map,
-            replication_changes_type_map,
-            tables,
-            connection,
-            progress,
-        })
-    }
-
-    #[allow(clippy::type_complexity)]
-    fn get_schema_map(
-        connection: Connection,
-        tables: Vec<TableInfo>,
-        ports: HashMap<String, u16>,
-    ) -> Result<
-        (
-            HashMap<u16, Schema>,
-            HashMap<u32, u16>,
-            HashMap<u16, ReplicationChangesTrackingType>,
-        ),
-        ExecutionError,
-    > {
-        let tables_map = tables
-            .iter()
-            .map(|table| (table.table_name.clone(), table.name.clone()))
-            .collect::<HashMap<_, _>>();
+        let connection_name = connection.name.clone();
 
         let connector = get_connector(connection).map_err(|e| InternalError(Box::new(e)))?;
-        let schema_tuples = connector
-            .get_schemas(Some(tables))
+        let source_schemas = connector
+            .get_schemas(Some(
+                table_and_ports
+                    .iter()
+                    .map(|(table, _)| table.clone())
+                    .collect(),
+            ))
             .map_err(|e| InternalError(Box::new(e)))?;
 
-        let mut schema_map = HashMap::new();
-        let mut schema_port_map: HashMap<u32, u16> = HashMap::new();
-        let mut replication_changes_type_map: HashMap<u16, ReplicationChangesTrackingType> =
-            HashMap::new();
-
-        for SourceSchema {
-            name,
-            schema,
-            replication_type,
-        } in schema_tuples
+        let mut tables = vec![];
+        for ((table, port), source_schema) in
+            table_and_ports.into_iter().zip(source_schemas.into_iter())
         {
-            let source_name = tables_map.get(&name).unwrap();
-            let port: u16 = *ports
-                .get(source_name)
-                .ok_or(ExecutionError::PortNotFound(name))?;
-            let schema_id = get_schema_id(schema.identifier)?;
+            let table_name = table.table_name;
+            let columns = table.columns;
+            let schema = source_schema.schema;
+            let replication_type = source_schema.replication_type;
 
-            schema_port_map.insert(schema_id, port);
-            schema_map.insert(port, schema);
-            replication_changes_type_map.insert(port, replication_type);
+            let table = Table {
+                table_name,
+                columns,
+                schema,
+                replication_type,
+                port,
+            };
+
+            tables.push(table);
         }
 
-        Ok((schema_map, schema_port_map, replication_changes_type_map))
+        Ok(Self {
+            connection_name,
+            tables,
+            connector: Mutex::new(Some(connector)),
+            progress,
+        })
     }
 }
 
@@ -142,25 +126,21 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
         &self,
         port: &PortHandle,
     ) -> Result<(Schema, SchemaSQLContext), ExecutionError> {
-        let mut schema = self
-            .schema_map
-            .get(port)
-            .map_or(Err(ExecutionError::PortNotFoundInSource(*port)), |s| {
-                Ok(s.clone())
-            })?;
+        let table = self
+            .tables
+            .iter()
+            .find(|table| table.port == *port)
+            .ok_or(ExecutionError::PortNotFoundInSource(*port))?;
+        let mut schema = table.schema.clone();
+        let table_name = &table.table_name;
 
-        let table_name = self.ports.iter().find(|(_, p)| **p == *port).unwrap().0;
         // Add source information to the schema.
-        let mut fields = vec![];
-        for field in schema.fields {
-            let mut f = field.clone();
-            f.source = SourceDefinition::Table {
-                connection: self.connection.name.clone(),
+        for field in &mut schema.fields {
+            field.source = SourceDefinition::Table {
+                connection: self.connection_name.clone(),
                 name: table_name.clone(),
             };
-            fields.push(f);
         }
-        schema.fields = fields;
 
         use std::println as info;
         info!("Source: Initializing input schema: {table_name}");
@@ -169,19 +149,12 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
         Ok((schema, SchemaSQLContext::default()))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        self.ports
-            .values()
-            .map(|e| {
-                self.replication_changes_type_map.get(e).map_or(
-                    Err(ReplicationTypeNotFound),
-                    |typ| {
-                        Ok(OutputPortDef::new(
-                            *e,
-                            map_replication_type_to_output_port_type(typ),
-                        ))
-                    },
-                )
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        self.tables
+            .iter()
+            .map(|table| {
+                let typ = map_replication_type_to_output_port_type(&table.replication_type);
+                OutputPortDef::new(table.port, typ)
             })
             .collect()
     }
@@ -191,21 +164,41 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
         _output_schemas: HashMap<PortHandle, Schema>,
     ) -> Result<Box<dyn Source>, ExecutionError> {
         let (ingestor, iterator) = Ingestor::initialize_channel(IngestionConfig::default());
-        let connector = get_connector(self.connection.clone())
-            .map_err(|e| ExecutionError::ConnectorError(Box::new(e)))?;
+
+        let mut schema_port_map = HashMap::new();
+        for table in &self.tables {
+            let schema_id = get_schema_id(table.schema.identifier)?;
+            schema_port_map.insert(schema_id, table.port);
+        }
+
+        let tables = self
+            .tables
+            .iter()
+            .map(|table| TableInfo {
+                table_name: table.table_name.clone(),
+                id: 0,
+                columns: table.columns.clone(),
+            })
+            .collect();
+
+        let connector = self
+            .connector
+            .lock()
+            .take()
+            .expect("ConnectorSource was already built");
 
         let mut bars = HashMap::new();
-        for (name, port) in self.ports.iter() {
+        for table in &self.tables {
             let pb = attach_progress(self.progress.clone());
-            pb.set_message(name.clone());
-            bars.insert(*port, pb);
+            pb.set_message(table.table_name.clone());
+            bars.insert(table.port, pb);
         }
 
         Ok(Box::new(ConnectorSource {
             ingestor,
             iterator: Mutex::new(iterator),
-            schema_port_map: self.schema_port_map.clone(),
-            tables: self.tables.clone(),
+            schema_port_map,
+            tables,
             connector,
             bars,
         }))
@@ -216,10 +209,10 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
 pub struct ConnectorSource {
     ingestor: Ingestor,
     iterator: Mutex<IngestionIterator>,
-    schema_port_map: HashMap<u32, u16>,
+    schema_port_map: HashMap<u32, PortHandle>,
     tables: Vec<TableInfo>,
     connector: Box<dyn Connector>,
-    bars: HashMap<u16, ProgressBar>,
+    bars: HashMap<PortHandle, ProgressBar>,
 }
 
 impl Source for ConnectorSource {

--- a/dozer-orchestrator/src/pipeline/source_builder.rs
+++ b/dozer-orchestrator/src/pipeline/source_builder.rs
@@ -56,34 +56,35 @@ impl<'a> SourceBuilder<'a> {
 
             if let Some(connection) = &first_source.connection {
                 let mut ports = HashMap::new();
-                let mut tables = vec![];
+                let mut table_and_ports = vec![];
                 for source in &sources_group {
                     if self.used_sources.contains(&source.name) {
                         ports.insert(source.name.clone(), port);
 
-                        tables.push(TableInfo {
-                            name: source.name.clone(),
-                            table_name: source.table_name.clone(),
-                            id: port as u32,
-                            columns: Some(
-                                source
-                                    .columns
-                                    .iter()
-                                    .map(|c| ColumnInfo {
-                                        name: c.clone(),
-                                        data_type: None,
-                                    })
-                                    .collect(),
-                            ),
-                        });
+                        table_and_ports.push((
+                            TableInfo {
+                                table_name: source.table_name.clone(),
+                                id: port as u32,
+                                columns: Some(
+                                    source
+                                        .columns
+                                        .iter()
+                                        .map(|c| ColumnInfo {
+                                            name: c.clone(),
+                                            data_type: None,
+                                        })
+                                        .collect(),
+                                ),
+                            },
+                            port,
+                        ));
 
                         port += 1;
                     }
                 }
 
                 let source_factory = ConnectorSourceFactory::new(
-                    ports.clone(),
-                    tables,
+                    table_and_ports,
                     connection.clone(),
                     self.progress.cloned(),
                 )?;

--- a/dozer-orchestrator/src/pipeline/source_builder.rs
+++ b/dozer-orchestrator/src/pipeline/source_builder.rs
@@ -64,7 +64,6 @@ impl<'a> SourceBuilder<'a> {
                         table_and_ports.push((
                             TableInfo {
                                 table_name: source.table_name.clone(),
-                                id: port as u32,
                                 columns: Some(
                                     source
                                         .columns

--- a/dozer-orchestrator/src/pipeline/source_builder.rs
+++ b/dozer-orchestrator/src/pipeline/source_builder.rs
@@ -63,7 +63,7 @@ impl<'a> SourceBuilder<'a> {
 
                         table_and_ports.push((
                             TableInfo {
-                                table_name: source.table_name.clone(),
+                                name: source.table_name.clone(),
                                 columns: Some(
                                     source
                                         .columns

--- a/dozer-orchestrator/src/pipeline/validate.rs
+++ b/dozer-orchestrator/src/pipeline/validate.rs
@@ -23,7 +23,7 @@ pub fn validate_grouped_connections(
             let tables: Vec<TableInfo> = sources_group
                 .iter()
                 .map(|source| TableInfo {
-                    table_name: source.table_name.clone(),
+                    name: source.table_name.clone(),
                     columns: Some(
                         source
                             .columns

--- a/dozer-orchestrator/src/pipeline/validate.rs
+++ b/dozer-orchestrator/src/pipeline/validate.rs
@@ -23,7 +23,6 @@ pub fn validate_grouped_connections(
             let tables: Vec<TableInfo> = sources_group
                 .iter()
                 .map(|source| TableInfo {
-                    name: source.name.clone(),
                     table_name: source.table_name.clone(),
                     id: 0,
                     columns: Some(

--- a/dozer-orchestrator/src/pipeline/validate.rs
+++ b/dozer-orchestrator/src/pipeline/validate.rs
@@ -24,7 +24,6 @@ pub fn validate_grouped_connections(
                 .iter()
                 .map(|source| TableInfo {
                     table_name: source.table_name.clone(),
-                    id: 0,
                     columns: Some(
                         source
                             .columns

--- a/dozer-sql/src/pipeline/product/tests/left_join_test.rs
+++ b/dozer-sql/src/pipeline/product/tests/left_join_test.rs
@@ -41,8 +41,8 @@ impl TestSourceFactory {
 }
 
 impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![
             OutputPortDef::new(
                 USER_PORT,
                 OutputPortType::StatefulWithPrimaryKeyLookup {
@@ -64,7 +64,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                     retr_old_records_for_deletes: true,
                 },
             ),
-        ])
+        ]
     }
 
     fn get_output_schema(

--- a/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
@@ -41,8 +41,8 @@ impl TestSourceFactory {
 }
 
 impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![
             OutputPortDef::new(
                 USER_PORT,
                 OutputPortType::StatefulWithPrimaryKeyLookup {
@@ -58,7 +58,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                     retr_old_records_for_deletes: true,
                 },
             ),
-        ])
+        ]
     }
 
     fn get_output_schema(

--- a/dozer-sql/src/pipeline/product/tests/set_operator_test.rs
+++ b/dozer-sql/src/pipeline/product/tests/set_operator_test.rs
@@ -192,8 +192,8 @@ impl TestSourceFactory {
 }
 
 impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(vec![
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        vec![
             OutputPortDef::new(
                 SUPPLIERS_PORT,
                 OutputPortType::StatefulWithPrimaryKeyLookup {
@@ -208,7 +208,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                     retr_old_records_for_deletes: true,
                 },
             ),
-        ])
+        ]
     }
 
     fn get_output_schema(

--- a/dozer-sql/src/pipeline/tests/builder_test.rs
+++ b/dozer-sql/src/pipeline/tests/builder_test.rs
@@ -41,12 +41,11 @@ impl TestSourceFactory {
 }
 
 impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(self
-            .output_ports
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        self.output_ports
             .iter()
             .map(|e| OutputPortDef::new(*e, OutputPortType::Stateless))
-            .collect())
+            .collect()
     }
 
     fn get_output_schema(

--- a/dozer-tests/src/sql_tests/pipeline.rs
+++ b/dozer-tests/src/sql_tests/pipeline.rs
@@ -91,9 +91,8 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
         Ok((schema, SchemaSQLContext::default()))
     }
 
-    fn get_output_ports(&self) -> Result<Vec<OutputPortDef>, ExecutionError> {
-        Ok(self
-            .schemas
+    fn get_output_ports(&self) -> Vec<OutputPortDef> {
+        self.schemas
             .iter()
             .enumerate()
             .map(|(idx, _)| {
@@ -105,7 +104,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                     },
                 )
             })
-            .collect())
+            .collect()
     }
 
     fn build(


### PR DESCRIPTION
1. Remove `TableInfo::table_name`

Now `TableInfo::name` is old `TableInfo::table_name`. Old `TableInfo::name` is the connection name and is not used.

2. Remove `TableInfo::id`

`TableInfo::id` is an implementation detail of postgres connector.

3. Remove parameter of `Connector::get_tables`

That parameter is never used.

4. Remove `Err` variant from `SourceFactory::get_output_ports` return type

Only `ConnectorSourceFactory` used to fail this method. We check the error early now, in construction.