### PR TITLE
feat: implement date extract

### DIFF
--- a/dozer-sql/src/pipeline/aggregation/avg.rs
+++ b/dozer-sql/src/pipeline/aggregation/avg.rs
@@ -123,15 +123,11 @@ fn get_average(
                 Ok(Field::Decimal(sum / count))
             }
         }
-        Some(not_supported_return_type) => {
-            Err(PipelineError::InternalExecutionError(InvalidType(format!(
-                "Not supported return type {} for {}",
-                not_supported_return_type, Avg
-            ))))
-        }
+        Some(not_supported_return_type) => Err(PipelineError::InternalExecutionError(InvalidType(
+            format!("Not supported return type {not_supported_return_type} for {Avg}"),
+        ))),
         None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
-            "Not supported None return type for {}",
-            Avg
+            "Not supported None return type for {Avg}"
         )))),
     }
 }

--- a/dozer-sql/src/pipeline/aggregation/count.rs
+++ b/dozer-sql/src/pipeline/aggregation/count.rs
@@ -54,15 +54,11 @@ fn get_count(count: u64, return_type: Option<FieldType>) -> Result<Field, Pipeli
             Count,
             FieldType::Decimal
         ))),
-        Some(not_supported_return_type) => {
-            Err(PipelineError::InternalExecutionError(InvalidType(format!(
-                "Not supported return type {} for {}",
-                not_supported_return_type, Count
-            ))))
-        }
+        Some(not_supported_return_type) => Err(PipelineError::InternalExecutionError(InvalidType(
+            format!("Not supported return type {not_supported_return_type} for {Count}"),
+        ))),
         None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
-            "Not supported None return type for {}",
-            Count
+            "Not supported None return type for {Count}"
         )))),
     }
 }

--- a/dozer-sql/src/pipeline/aggregation/max.rs
+++ b/dozer-sql/src/pipeline/aggregation/max.rs
@@ -75,13 +75,11 @@ fn get_max(
             }
             Some(not_supported_return_type) => {
                 Err(PipelineError::InternalExecutionError(InvalidType(format!(
-                    "Not supported return type {} for {}",
-                    not_supported_return_type, Max
+                    "Not supported return type {not_supported_return_type} for {Max}"
                 ))))
             }
             None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
-                "Not supported None return type for {}",
-                Max
+                "Not supported None return type for {Max}"
             )))),
         }
     }

--- a/dozer-sql/src/pipeline/aggregation/min.rs
+++ b/dozer-sql/src/pipeline/aggregation/min.rs
@@ -74,13 +74,11 @@ fn get_min(
             }
             Some(not_supported_return_type) => {
                 Err(PipelineError::InternalExecutionError(InvalidType(format!(
-                    "Not supported return type {} for {}",
-                    not_supported_return_type, Min
+                    "Not supported return type {not_supported_return_type} for {Min}"
                 ))))
             }
             None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
-                "Not supported None return type for {}",
-                Min
+                "Not supported None return type for {Min}"
             )))),
         }
     }

--- a/dozer-sql/src/pipeline/aggregation/sum.rs
+++ b/dozer-sql/src/pipeline/aggregation/sum.rs
@@ -118,15 +118,11 @@ fn get_sum(
             }
             Ok(Field::Decimal(current_state.decimal_state))
         }
-        Some(not_supported_return_type) => {
-            Err(PipelineError::InternalExecutionError(InvalidType(format!(
-                "Not supported return type {} for {}",
-                not_supported_return_type, Sum
-            ))))
-        }
+        Some(not_supported_return_type) => Err(PipelineError::InternalExecutionError(InvalidType(
+            format!("Not supported return type {not_supported_return_type} for {Sum}"),
+        ))),
         None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
-            "Not supported None return type for {}",
-            Sum
+            "Not supported None return type for {Sum}"
         )))),
     }
 }

--- a/dozer-sql/src/pipeline/expression/builder.rs
+++ b/dozer-sql/src/pipeline/expression/builder.rs
@@ -430,9 +430,7 @@ impl ExpressionBuilder {
     ) -> Result<Expression, PipelineError> {
         let right = self.parse_sql_expression(parse_aggregations, expr, schema)?;
         Ok(Expression::DateTimeFunction {
-            fun: DateTimeFunctionType::Extract {
-                field: field.clone(),
-            },
+            fun: DateTimeFunctionType::Extract { field: *field },
             arg: Box::new(right),
         })
     }

--- a/dozer-sql/src/pipeline/expression/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/datetime.rs
@@ -22,7 +22,7 @@ impl Display for DateTimeFunctionType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             DateTimeFunctionType::Extract { field } => {
-                f.write_str(format!("EXTRACT {}", field).as_str())
+                f.write_str(format!("EXTRACT {field}").as_str())
             }
         }
     }

--- a/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
@@ -31,7 +31,7 @@ fn test_extract_date() {
         let mut results = vec![];
         for i in inputs.clone() {
             let f = run_scalar_fct(
-                &format!("select extract({} from date) from users", part),
+                &format!("select extract({part} from date) from users"),
                 Schema::empty()
                     .field(
                         FieldDefinition::new(

--- a/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs
@@ -3,45 +3,53 @@ use dozer_types::chrono::{DateTime, NaiveDate};
 use dozer_types::types::{Field, FieldDefinition, FieldType, Schema, SourceDefinition};
 
 #[test]
-fn test_date() {
-    let f = run_scalar_fct(
-        "SELECT DAY_OF_WEEK(date) FROM users",
-        Schema::empty()
-            .field(
-                FieldDefinition::new(
-                    String::from("date"),
-                    FieldType::Date,
-                    false,
-                    SourceDefinition::Dynamic,
-                ),
-                false,
-            )
-            .clone(),
-        vec![Field::Date(NaiveDate::from_ymd_opt(2023, 1, 1).unwrap())],
-    );
-    assert_eq!(f, Field::Int(6));
-}
+fn test_extract_date() {
+    let date_fns: Vec<(&str, i64, i64)> = vec![
+        ("dow", 6, 0),
+        ("day", 1, 2),
+        ("month", 1, 1),
+        ("year", 2023, 2023),
+        ("hour", 0, 0),
+        ("minute", 0, 12),
+        ("second", 0, 10),
+        ("millisecond", 1672531200000, 1672618330000),
+        ("microsecond", 1672531200000000, 1672618330000000),
+        ("nanoseconds", 1672531200000000000, 1672618330000000000),
+        ("quarter", 1, 1),
+        ("epoch", 1672531200, 1672618330),
+        ("week", 52, 1),
+        ("century", 21, 21),
+        ("decade", 203, 203),
+        ("doy", 1, 2),
+    ];
+    let inputs = vec![
+        Field::Date(NaiveDate::from_ymd_opt(2023, 1, 1).unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2023-01-02T00:12:10Z").unwrap()),
+    ];
 
-#[test]
-fn test_timestamp() {
-    let f = run_scalar_fct(
-        "SELECT DAY_OF_WEEK(ts) FROM users",
-        Schema::empty()
-            .field(
-                FieldDefinition::new(
-                    String::from("ts"),
-                    FieldType::Timestamp,
-                    false,
-                    SourceDefinition::Dynamic,
-                ),
-                false,
-            )
-            .clone(),
-        vec![Field::Timestamp(
-            DateTime::parse_from_rfc3339("2023-01-02T00:12:10Z").unwrap(),
-        )],
-    );
-    assert_eq!(f, Field::Int(0));
+    for (part, val1, val2) in date_fns {
+        let mut results = vec![];
+        for i in inputs.clone() {
+            let f = run_scalar_fct(
+                &format!("select extract({} from date) from users", part),
+                Schema::empty()
+                    .field(
+                        FieldDefinition::new(
+                            String::from("date"),
+                            FieldType::Date,
+                            false,
+                            SourceDefinition::Dynamic,
+                        ),
+                        false,
+                    )
+                    .clone(),
+                vec![i.clone()],
+            );
+            results.push(f.to_int().unwrap());
+        }
+        assert_eq!(val1, results[0]);
+        assert_eq!(val2, results[1]);
+    }
 }
 
 #[test]


### PR DESCRIPTION
https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-extract/

- Implement `extract(day from date)` syntax which is natively supported in SQL. 
- This can replace day_of_week function

Sample queries
```
select extract(timezone from last_update) from actor;
select extract(year from last_update) from actor;
select extract(hour from last_update) from actor;
select extract(month from last_update) from actor;
```
```
 DateTimeField::Dow => ts.weekday().num_days_from_monday().to_i64(),
        DateTimeField::Day => ts.day().to_i64(),
        DateTimeField::Month => ts.month().to_i64(),
        DateTimeField::Year => ts.year().to_i64(),
        DateTimeField::Hour => ts.hour().to_i64(),
        DateTimeField::Minute => ts.minute().to_i64(),
        DateTimeField::Second => ts.second().to_i64(),
        DateTimeField::Millisecond | DateTimeField::Milliseconds => ts.timestamp_millis().to_i64(),
        DateTimeField::Microsecond | DateTimeField::Microseconds => ts.timestamp_micros().to_i64(),
        DateTimeField::Nanoseconds | DateTimeField::Nanosecond => ts.timestamp_nanos().to_i64(),
        DateTimeField::Quarter => ts.month0().to_i64().map(|m| m / 3 + 1),
        DateTimeField::Epoch => ts.timestamp().to_i64(),
        DateTimeField::Week => ts.iso_week().week().to_i64(),
        DateTimeField::Century => ts.year().to_i64().map(|y| (y as f64 / 100.0).ceil() as i64),
        DateTimeField::Decade => ts.year().to_i64().map(|y| (y as f64 / 10.0).ceil() as i64),
        DateTimeField::Doy => ts.ordinal().to_i64(),
```

