### PR TITLE
fix: Don't panic if operation cannot be read from indexing thread.

### DIFF
--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/mod.rs
@@ -152,12 +152,11 @@ impl OperationLog {
         &self,
         txn: &T,
         operation_id: u64,
-    ) -> Result<Operation, StorageError> {
+    ) -> Result<Option<Operation>, StorageError> {
         Ok(self
             .operation_id_to_operation
             .get(txn, &operation_id)?
-            .unwrap_or_else(|| panic!("Operation id {} out of range", operation_id))
-            .into_owned())
+            .map(IntoOwned::into_owned))
     }
 
     /// Inserts the record and sets the record version. Returns the record id.
@@ -331,7 +330,7 @@ mod tests {
                 RecordWithId::new(record_id, record.clone())
             );
             assert_eq!(
-                log.get_operation(&txn, index as _).unwrap(),
+                log.get_operation(&txn, index as _).unwrap().unwrap(),
                 Operation::Insert {
                     record_id,
                     record: record.clone(),
@@ -379,7 +378,7 @@ mod tests {
             RecordWithId::new(record_id, record.clone())
         );
         assert_eq!(
-            log.get_operation(&txn, 0).unwrap(),
+            log.get_operation(&txn, 0).unwrap().unwrap(),
             Operation::Insert {
                 record_id,
                 record: record.clone(),
@@ -412,7 +411,7 @@ mod tests {
             false
         );
         assert_eq!(
-            log.get_operation(&txn, 1).unwrap(),
+            log.get_operation(&txn, 1).unwrap().unwrap(),
             Operation::Delete { operation_id: 0 }
         );
 
@@ -455,7 +454,7 @@ mod tests {
             RecordWithId::new(record_id, record.clone())
         );
         assert_eq!(
-            log.get_operation(&txn, 2).unwrap(),
+            log.get_operation(&txn, 2).unwrap().unwrap(),
             Operation::Insert {
                 record_id,
                 record: record.clone(),

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
@@ -4,7 +4,7 @@ use dozer_storage::{
     lmdb_storage::{LmdbEnvironmentManager, SharedTransaction},
     BeginTransaction, LmdbCounter, LmdbMultimap, LmdbOption, ReadTransaction,
 };
-use dozer_types::{borrow::IntoOwned, types::IndexDefinition};
+use dozer_types::{borrow::IntoOwned, log::debug, types::IndexDefinition};
 
 use crate::{cache::lmdb::utils::init_env, errors::CacheError};
 
@@ -113,7 +113,11 @@ impl RwSecondaryEnvironment {
                 return Ok(());
             }
             // Get operation by operation id.
-            let operation = operation_log.get_operation(log_txn, operation_id)?;
+            let Some(operation) = operation_log.get_operation(log_txn, operation_id)? else {
+                // We're not able to read this operation yet, try again later.
+                debug!("Operation {} not found", operation_id);
+                return Ok(());
+            };
             match operation {
                 Operation::Insert { record, .. } => {
                     // Build secondary index.
@@ -126,8 +130,13 @@ impl RwSecondaryEnvironment {
                     )?;
                 }
                 Operation::Delete { operation_id } => {
-                    // If the operation is a `Delete`, find the deleted record, which must exist.
-                    let Operation::Insert { record, .. } = operation_log.get_operation(log_txn, operation_id)? else {
+                    // If the operation is a `Delete`, find the deleted record.
+                    let Some(operation) = operation_log.get_operation(log_txn, operation_id)? else {
+                        // We're not able to read this operation yet, try again later.
+                        debug!("Operation {} not found", operation_id);
+                        return Ok(())
+                    };
+                    let Operation::Insert { record, .. } = operation else {
                         panic!("Insert operation {} not found", operation_id);
                     };
                     // Delete secondary index.

--- a/dozer-cache/src/cache/lmdb/indexing.rs
+++ b/dozer-cache/src/cache/lmdb/indexing.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use dozer_storage::BeginTransaction;
-use dozer_types::log::error;
+use dozer_types::log::debug;
 
 use crate::errors::CacheError;
 
@@ -121,7 +121,7 @@ fn index_and_log_error(
     loop {
         // Run `index` for at least once before quitting.
         if let Err(e) = index(&main_env, &secondary_env) {
-            error!("Error while indexing {}: {e}", main_env.name());
+            debug!("Error while indexing {}: {e}", main_env.name());
         }
 
         if !running.load(Ordering::SeqCst) {


### PR DESCRIPTION
This problem happens once in a while, but seems to be recoverable, so we just ignore the error when an operation cannot be found and retry later. Example log:

```
2023-03-16T15:03:02.358474Z DEBUG Operation 27999 not found    
2023-03-16T15:03:02.358482Z DEBUG Operation 28002 not found    
2023-03-16T15:03:02.358480Z DEBUG Operation 28530 not found    
2023-03-16T15:03:02.358480Z DEBUG Operation 28473 not found    
2023-03-16T15:03:02.463046Z DEBUG Operation 33893 not found    
2023-03-16T15:03:02.463046Z DEBUG Operation 33246 not found    
2023-03-16T15:03:02.463092Z DEBUG Operation 33303 not found    
2023-03-16T15:03:02.463046Z DEBUG Operation 33891 not found    
2023-03-16T15:03:02.567920Z DEBUG Operation 38659 not found    
2023-03-16T15:03:02.567925Z DEBUG Operation 38589 not found    
2023-03-16T15:03:02.567920Z DEBUG Operation 39268 not found    
2023-03-16T15:03:02.567920Z DEBUG Operation 39259 not found    
2023-03-16T15:03:02.677373Z DEBUG Operation 44172 not found    
2023-03-16T15:03:02.677371Z DEBUG Operation 44891 not found    
2023-03-16T15:03:02.677373Z DEBUG Operation 44894 not found    
2023-03-16T15:03:02.677373Z DEBUG Operation 44155 not found    
2023-03-16T15:03:02.787082Z DEBUG Operation 49730 not found    
2023-03-16T15:03:02.787081Z DEBUG Operation 49206 not found    
2023-03-16T15:03:02.787081Z DEBUG Operation 50037 not found    
2023-03-16T15:03:02.787081Z DEBUG Operation 49219 not found    
2023-03-16T15:03:02.889352Z DEBUG Operation 55175 not found    
2023-03-16T15:03:02.889356Z DEBUG Operation 54223 not found    
2023-03-16T15:03:02.889359Z DEBUG Operation 54894 not found    
2023-03-16T15:03:02.889359Z DEBUG Operation 54261 not found    
2023-03-16T15:03:02.992956Z DEBUG Operation 59491 not found    
2023-03-16T15:03:02.992995Z DEBUG Operation 59480 not found    
2023-03-16T15:03:02.993074Z DEBUG Operation 60263 not found    
2023-03-16T15:03:02.996562Z DEBUG Error while indexing 65f023b9-2edb-4557-9678-decaee0afe3d: Storage error: Lmdb error: MDB_PAGE_NOTFOUND: Requested page not found    
2023-03-16T15:03:03.090686Z DEBUG Operation 64379 not found    
2023-03-16T15:03:03.090719Z DEBUG Operation 64448 not found    
2023-03-16T15:03:03.090686Z DEBUG Operation 65530 not found    
2023-03-16T15:03:03.090686Z DEBUG Operation 65299 not found    
2023-03-16T15:03:03.202255Z DEBUG Operation 71236 not found    
2023-03-16T15:03:03.202255Z DEBUG Operation 71054 not found    
2023-03-16T15:03:03.202255Z DEBUG Operation 70061 not found    
2023-03-16T15:03:03.202255Z DEBUG Operation 70160 not found    
2023-03-16T15:03:03.308846Z DEBUG Operation 76578 not found    
2023-03-16T15:03:03.308850Z DEBUG Operation 75547 not found    
2023-03-16T15:03:03.308852Z DEBUG Operation 75459 not found    
2023-03-16T15:03:03.413249Z DEBUG Operation 80828 not found    
2023-03-16T15:03:03.413257Z DEBUG Operation 81929 not found    
2023-03-16T15:03:03.413249Z DEBUG Operation 80726 not found    
2023-03-16T15:03:03.463893Z DEBUG Operation 84613 not found    
2023-03-16T15:03:03.516626Z DEBUG Operation 85946 not found    
2023-03-16T15:03:03.516626Z DEBUG Operation 87175 not found    
2023-03-16T15:03:03.574915Z DEBUG Operation 90258 not found    
2023-03-16T15:03:03.629081Z DEBUG Operation 91566 not found    
2023-03-16T15:03:03.681924Z DEBUG Operation 94282 not found    
2023-03-16T15:03:03.736918Z DEBUG Operation 96966 not found    
2023-03-16T15:03:03.843681Z DEBUG Operation 102353 not found    
2023-03-16T15:03:03.951482Z DEBUG Operation 107812 not found    
2023-03-16T15:03:03.951485Z DEBUG Operation 107830 not found    
```

The indexing threads don't get stuck at a certain operation, indicating that we indeed recovered from the error.