### PR TITLE
test: Add ny taxi sample to e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,9 @@ dozer-ui
 
 # Integration test generated files
 dozer-tests/src/e2e_tests/cases/*/local_runner/
-dozer-tests/src/e2e_tests/cases/*/buildkite_runner/
+dozer-tests/src/e2e_tests/cases/*/buildkite_runner*/
 
 dozer-ingestion/src/tests/cases/*/local_runner/
-dozer-ingestion/src/tests/cases/*/buildkite_runner/
+dozer-ingestion/src/tests/cases/*/buildkite_runner*/
 # Connectors Benches YAML
 dozer-ingestion/benches/connectors.yaml

--- a/dozer-tests/README.md
+++ b/dozer-tests/README.md
@@ -55,7 +55,17 @@ The framework traverses `dozer-config.yaml`, and for every `connection`, it trie
 
 The connection directory may have a `Dockerfile` used for building the image. The build context will be the connection directory.
 
-If there's no `Dockerfile` under the connection directory, it must contain a `service.yaml` file, whose content will be added to the connection service section of the docker commpose file. The `build` section of `service.yaml` will be overwritten, to the `Dockerfile` if it exists, removed if not. The working directory of the `docker compose` run will be the repository root, so be careful with relative paths in `service.yaml` (better don't use them).
+If there's no `Dockerfile` under the connection directory, it must contain a `service.yaml` file, whose content will be added to the connection service section of the docker compose file. The `build` section of `service.yaml` will be overwritten, to the `Dockerfile` if it exists, removed if not. The working directory of the `docker compose` run will be the repository root, so be careful with relative paths in `service.yaml` (better don't use them).
+
+### Health check the connection
+
+We support all 3 kinds of health checks that docker compose supports.
+
+If a file named`oneshot` is found under the connection directory, health check criteria will be `service_completed_successfully`.
+
+Otherwise, if `service.yaml` contains a `healthcheck` section, health check criteria will be `service_healthy`.
+
+Otherwise, health check criteria will be `service_started`.
 
 ### Troubleshoot Connections
 

--- a/dozer-tests/src/e2e_tests/case.rs
+++ b/dozer-tests/src/e2e_tests/case.rs
@@ -16,6 +16,7 @@ pub struct Connection {
     pub directory: PathBuf,
     pub service: Option<Service>,
     pub has_docker_file: bool,
+    pub has_oneshot_file: bool,
 }
 
 pub enum CaseKind {
@@ -55,12 +56,15 @@ impl Case {
                 panic!("Connection {connection_dir:?} must have either service.yaml or Dockerfile");
             }
 
+            let oneshot_file = connection_dir.join("oneshot");
+
             connections.insert(
                 connection.name.clone(),
                 Connection {
                     directory: connection_dir,
                     service,
                     has_docker_file: docker_file.exists(),
+                    has_oneshot_file: oneshot_file.exists(),
                 },
             );
         }

--- a/dozer-tests/src/e2e_tests/cases/dozer-samples-connectors-local-storage/dozer-config.yaml
+++ b/dozer-tests/src/e2e_tests/cases/dozer-samples-connectors-local-storage/dozer-config.yaml
@@ -1,0 +1,37 @@
+connections:    
+  - config : !LocalStorage
+      details:
+        path: data
+      tables:
+        - !Table
+          name: trips
+          prefix: /trips
+          file_type: parquet
+          extension: .parquet
+    name: ny_taxi
+
+sql: |
+  SELECT 
+    PULocationID as pickup_location, 
+    DOLocationID as dropoff_location, 
+    COUNT(PULocationID, DOLocationID) as total_trips, 
+    MIN(trip_time) as min_trip_time,  
+    MAX(trip_time) as max_trip_time 
+  INTO trips_cache
+  FROM trips
+  GROUP BY PULocationID, DOLocationID
+  HAVING COUNT(PULocationID, DOLocationID) > 1000;
+sources:
+  - name: trips
+    table_name: trips
+    connection: !Ref ny_taxi
+    columns:
+
+endpoints:
+  - name: trips_cache
+    path: /trips
+    table_name: trips_cache
+    index:
+      primary_key: 
+        - pickup_location
+        - dropoff_location

--- a/dozer-tests/src/e2e_tests/cases/dozer-samples-connectors-local-storage/expectations.json
+++ b/dozer-tests/src/e2e_tests/cases/dozer-samples-connectors-local-storage/expectations.json
@@ -1,0 +1,46 @@
+[
+    "HealthyService",
+    {
+        "Endpoint": {
+            "endpoint": "trips_cache",
+            "expectations": [
+                {
+                    "Schema": {
+                        "fields": [
+                            {
+                                "name": "pickup_location",
+                                "typ": "Int",
+                                "nullable": true,
+                                "source": "Dynamic"
+                            },
+                            {
+                                "name": "dropoff_location",
+                                "typ": "Int",
+                                "nullable": true,
+                                "source": "Dynamic"
+                            },
+                            {
+                                "name": "total_trips",
+                                "typ": "Int",
+                                "nullable": false,
+                                "source": "Dynamic"
+                            },
+                            {
+                                "name": "min_trip_time",
+                                "typ": "Int",
+                                "nullable": true,
+                                "source": "Dynamic"
+                            },
+                            {
+                                "name": "max_trip_time",
+                                "typ": "Int",
+                                "nullable": true,
+                                "source": "Dynamic"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/dozer-tests/src/e2e_tests/connections/ny_taxi/init.sh
+++ b/dozer-tests/src/e2e_tests/connections/ny_taxi/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl --create-dirs -o data/trips/fhvhv_tripdata_2022-01.parquet https://d37ci6vzurychx.cloudfront.net/trip-data/fhvhv_tripdata_2022-01.parquet
+chmod -R a+rx data

--- a/dozer-tests/src/e2e_tests/connections/ny_taxi/service.yaml
+++ b/dozer-tests/src/e2e_tests/connections/ny_taxi/service.yaml
@@ -1,0 +1,8 @@
+container_name: ny_taxi
+image: curlimages/curl
+user: root
+working_dir: /root
+command: sh dozer-tests/src/e2e_tests/connections/ny_taxi/init.sh
+volumes:
+  # All these `..` leads to repository root, which is the `dozer` working directory.
+  - ../../../../../..:/root

--- a/dozer-tests/src/e2e_tests/docker_compose.rs
+++ b/dozer-tests/src/e2e_tests/docker_compose.rs
@@ -34,6 +34,10 @@ pub struct Service {
     #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub volumes: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty", default = "HashMap::new")]
     pub depends_on: HashMap<String, DependsOn>,

--- a/dozer-tests/src/e2e_tests/runner/running_env.rs
+++ b/dozer-tests/src/e2e_tests/runner/running_env.rs
@@ -57,40 +57,34 @@ pub fn create_buildkite_runner_envs(case: &Case) -> Vec<RunningEnv> {
 }
 
 fn create_buildkite_runner_env(case: &Case, single_dozer_container: bool) -> RunningEnv {
-    let buildkite_dir = case.case_dir.join("buildkite_runner");
-    create_dir_if_not_existing(&buildkite_dir);
+    let docker_compose_dir = case.case_dir.join(if single_dozer_container {
+        "builkite_runner_dozer_single_container"
+    } else {
+        "buildkite_runner_dozer_multi_container"
+    });
+    create_dir_if_not_existing(&docker_compose_dir);
 
     let dozer_config_path = write_dozer_config_for_running_in_docker_compose(
         case.dozer_config.clone(),
         &case.connections,
-        &buildkite_dir,
+        &docker_compose_dir,
     );
-
-    let docker_compose_dir = buildkite_dir.join(if single_dozer_container {
-        "dozer_single_container"
-    } else {
-        "dozer_multi_container"
-    });
-    create_dir_if_not_existing(&docker_compose_dir);
 
     let mut services = HashMap::new();
 
     let connections_healthy_service_name =
         add_connection_services(&case.connections, &mut services);
 
-    let (
-        dozer_api_service_name,
-        dozer_service_name_for_error_expectation,
-        dozer_config_path_in_container,
-    ) = if single_dozer_container {
-        add_dozer_service(
-            &dozer_config_path,
-            connections_healthy_service_name,
-            &mut services,
-        )
-    } else {
-        todo!()
-    };
+    let (dozer_api_service_name, dozer_service_name_for_error_expectation) =
+        if single_dozer_container {
+            add_dozer_service(
+                &dozer_config_path,
+                connections_healthy_service_name,
+                &mut services,
+            )
+        } else {
+            todo!()
+        };
 
     let dozer_test_client_service_name = if let CaseKind::Expectations(_) = &case.kind {
         Some(add_dozer_test_client_service(
@@ -115,7 +109,7 @@ fn create_buildkite_runner_env(case: &Case, single_dozer_container: bool) -> Run
         RunningEnv::WithErrorExpectation {
             docker_compose_path,
             dozer_service_name: dozer_service_name_for_error_expectation,
-            dozer_config_path: dozer_config_path_in_container,
+            dozer_config_path,
         }
     }
 }
@@ -124,7 +118,7 @@ fn add_dozer_service(
     dozer_config_path: &str,
     depends_on_service_name: Option<String>,
     services: &mut HashMap<String, Service>,
-) -> (String, String, String) {
+) -> (String, String) {
     let mut depends_on = HashMap::new();
     if let Some(depends_on_service_name) = depends_on_service_name {
         depends_on.insert(
@@ -136,7 +130,8 @@ fn add_dozer_service(
     }
 
     let dozer_service_name = "dozer";
-    let dozer_config_path_in_container = "/dozer/dozer-config.yaml";
+    let current_dir = current_dir().expect("Cannot get current dir");
+    let current_dir = current_dir.to_str().expect("Non-UTF8 path {current_dir:?}");
     services.insert(
         dozer_service_name.to_string(),
         Service {
@@ -145,12 +140,10 @@ fn add_dozer_service(
             build: None,
             ports: vec![],
             environment: vec!["ETH_WSS_URL".to_string(), "ETH_HTTPS_URL".to_string()],
-            volumes: vec![format!(
-                "{dozer_config_path}:{dozer_config_path_in_container}"
-            )],
-            command: Some(format!(
-                "dozer --config-path {dozer_config_path_in_container}"
-            )),
+            volumes: vec![format!("{current_dir}:{current_dir}")],
+            user: None,
+            working_dir: Some(current_dir.to_string()),
+            command: Some(format!("dozer --config-path {dozer_config_path}")),
             depends_on,
             healthcheck: None,
         },
@@ -159,7 +152,6 @@ fn add_dozer_service(
     (
         dozer_service_name.to_string(),
         dozer_service_name.to_string(),
-        dozer_config_path_in_container.to_string(),
     )
 }
 
@@ -205,6 +197,8 @@ fn add_dozer_test_client_service(
                 format!("{case_dir}:{case_dir_in_container}"),
                 format!("{connections_dir}:{connections_dir_in_container}"),
             ],
+            user: None,
+            working_dir: None,
             command: Some(format!(
                 "{dozer_test_client_path_in_container} --wait-in-millis 10000 --dozer-api-host {dozer_api_service_name} --case-dir {case_dir_in_container} --connections-dir {connections_dir_in_container}"
             )),
@@ -247,7 +241,9 @@ fn add_connection_services(
         depends_on.insert(
             name.clone(),
             DependsOn {
-                condition: if service.healthcheck.is_some() {
+                condition: if connection.has_oneshot_file {
+                    Condition::ServiceCompletedSuccessfully
+                } else if service.healthcheck.is_some() {
                     Condition::ServiceHealthy
                 } else {
                     Condition::ServiceStarted
@@ -271,6 +267,8 @@ fn add_connection_services(
             ports: vec![],
             environment: vec![],
             volumes: vec![],
+            user: None,
+            working_dir: None,
             command: Some("echo 'All connections are healthy'".to_string()),
             depends_on,
             healthcheck: None,


### PR DESCRIPTION
This PR adds the necessary mechanism for setting up a local storage connector in e2e tests, and adds a new e2e test according to https://github.com/getdozer/dozer-samples/tree/main/connectors/local-storage.

It also implements the local storage connection `ny_taxi` used by the test.