### PR TITLE
chore: refactor operation tests with proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,10 +930,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -1013,7 +1028,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.4.4",
 ]
 
 [[package]]
@@ -2237,6 +2252,7 @@ dependencies = [
  "lmdb-rkv-sys",
  "multimap",
  "num-traits",
+ "proptest",
  "sqlparser 0.32.0",
  "tempdir",
  "uuid",
@@ -4761,6 +4777,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,6 +4959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5023,6 +5066,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5177,7 +5229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -5377,6 +5429,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -6715,6 +6779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6820,6 +6890,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -22,6 +22,7 @@ hashbrown = "0.13"
 ahash = "0.8.3"
 bloom = "0.3.2"
 enum_dispatch = "0.3.11"
+proptest = "1.1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-sql/src/pipeline/expression/scalar/tests/cast.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/cast.rs
@@ -19,31 +19,46 @@ use crate::pipeline::expression::scalar::tests::scalar_common::run_scalar_fct;
 //         "SELECT CAST(field AS UINT) FROM users",
 //         Schema::empty()
 //             .field(
-//                 FieldDefinition::new(String::from("field"), FieldType::Int, false),
+//                 FieldDefinition::new(
+//                     String::from("field"),
+//                     FieldType::Int,
+//                     false,
+//                     SourceDefinition::Dynamic,
+//                 ),
 //                 false,
 //             )
 //             .clone(),
 //         vec![Field::Int(42)],
 //     );
 //     assert_eq!(f, Field::UInt(42));
-
+//
 //     let f = run_scalar_fct(
 //         "SELECT CAST(field AS UINT) FROM users",
 //         Schema::empty()
 //             .field(
-//                 FieldDefinition::new(String::from("field"), FieldType::String, false),
+//                 FieldDefinition::new(
+//                     String::from("field"),
+//                     FieldType::String,
+//                     false,
+//                     SourceDefinition::Dynamic,
+//                 ),
 //                 false,
 //             )
 //             .clone(),
 //         vec![Field::String("42".to_string())],
 //     );
 //     assert_eq!(f, Field::UInt(42));
-
+//
 //     let f = run_scalar_fct(
 //         "SELECT CAST(field AS UINT) FROM users",
 //         Schema::empty()
 //             .field(
-//                 FieldDefinition::new(String::from("field"), FieldType::UInt, false),
+//                 FieldDefinition::new(
+//                     String::from("field"),
+//                     FieldType::UInt,
+//                     false,
+//                     SourceDefinition::Dynamic,
+//                 ),
 //                 false,
 //             )
 //             .clone(),

--- a/dozer-sql/src/pipeline/expression/scalar/tests/mathematical.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/mathematical.rs
@@ -1,0 +1,915 @@
+use crate::pipeline::expression::execution::Expression::Literal;
+use crate::pipeline::expression::mathematical::{
+    evaluate_add, evaluate_div, evaluate_mod, evaluate_mul, evaluate_sub,
+};
+use dozer_types::types::Record;
+use dozer_types::{
+    ordered_float::OrderedFloat,
+    rust_decimal::Decimal,
+    types::{Field, Schema},
+};
+use num_traits::FromPrimitive;
+
+use proptest::prelude::*;
+use std::num::Wrapping;
+
+#[test]
+fn test_uint_math() {
+    proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, i_num1: i64, i_num2: i64, f_num1: f64, f_num2: f64)| {
+        let row = Record::new(None, vec![], None);
+
+        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let int1 = Box::new(Literal(Field::Int(i_num1)));
+        let int2 = Box::new(Literal(Field::Int(i_num2)));
+        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let dec1 = Box::new(Literal(Field::Decimal(Decimal::from(u_num1))));
+        let dec2 = Box::new(Literal(Field::Decimal(Decimal::from(u_num2))));
+
+        let null = Box::new(Literal(Field::Null));
+
+        //// left: UInt, right: UInt
+        assert_eq!(
+            // UInt + UInt = UInt
+            evaluate_add(&Schema::empty(), &uint1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::UInt((Wrapping(u_num1) + Wrapping(u_num2)).0)
+        );
+        assert_eq!(
+            // UInt - UInt = UInt
+            evaluate_sub(&Schema::empty(), &uint1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::UInt((Wrapping(u_num1) - Wrapping(u_num2)).0)
+        );
+        assert_eq!(
+            // UInt * UInt = UInt
+            evaluate_mul(&Schema::empty(), &uint2, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::UInt((Wrapping(u_num2) * Wrapping(u_num1)).0)
+        );
+        assert_eq!(
+            // UInt / UInt = Float
+            evaluate_div(&Schema::empty(), &uint2, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
+        );
+        assert_eq!(
+            // UInt % UInt = UInt
+            evaluate_mod(&Schema::empty(), &uint1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::UInt((Wrapping(u_num1) % Wrapping(u_num2)).0)
+        );
+
+        //// left: UInt, right: Int
+        assert_eq!(
+            // UInt + Int = Int
+            evaluate_add(&Schema::empty(), &uint1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(u_num1 as i64) + Wrapping(i_num2)).0)
+        );
+        assert_eq!(
+            // UInt - Int = Int
+            evaluate_sub(&Schema::empty(), &uint1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(u_num1 as i64) - Wrapping(i_num2)).0)
+        );
+        assert_eq!(
+            // UInt * Int = Int
+            evaluate_mul(&Schema::empty(), &uint2, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(u_num2 as i64) * Wrapping(i_num1)).0)
+        );
+        assert_eq!(
+            // UInt / Int = Float
+            evaluate_div(&Schema::empty(), &uint2, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
+        );
+        assert_eq!(
+            // UInt % Int = Int
+            evaluate_mod(&Schema::empty(), &uint1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(u_num1 as i64) % Wrapping(i_num2)).0)
+        );
+
+        //// left: UInt, right: Float
+        assert_eq!(
+            // UInt + Float = Float
+            evaluate_add(&Schema::empty(), &uint1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() + f_num2))
+        );
+        assert_eq!(
+            // UInt - Float = Float
+            evaluate_sub(&Schema::empty(), &uint1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() - f_num2))
+        );
+        assert_eq!(
+            // UInt * Float = Float
+            evaluate_mul(&Schema::empty(), &uint2, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() * f_num1))
+        );
+        assert_eq!(
+            // UInt / Float = Float
+            evaluate_div(&Schema::empty(), &uint2, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f_num1))
+        );
+        assert_eq!(
+            // UInt % Float = Float
+            evaluate_mod(&Schema::empty(), &uint1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() % f_num2))
+        );
+
+        //// left: UInt, right: Decimal
+        assert_eq!(
+            // UInt + Decimal = Decimal
+            evaluate_add(&Schema::empty(), &uint1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_u64(u_num1).unwrap() + Decimal::from_u64(u_num2).unwrap())
+        );
+        assert_eq!(
+            // UInt - Decimal = Decimal
+            evaluate_sub(&Schema::empty(), &uint1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_u64(u_num1).unwrap() - Decimal::from_u64(u_num2).unwrap())
+        );
+        //// todo: Multiplication overflowed
+        // assert_eq!(
+        //     // UInt * Decimal = Decimal
+        //     evaluate_mul(&Schema::empty(), &uint2, &dec1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from_u64(u_num2).unwrap() * Decimal::from_u64(u_num1).unwrap())
+        // );
+        assert_eq!(
+            // UInt / Decimal = Decimal
+            evaluate_div(&Schema::empty(), &uint2, &dec1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_u64(u_num2).unwrap() / Decimal::from_u64(u_num1).unwrap())
+        );
+        assert_eq!(
+            // UInt % Decimal = Decimal
+            evaluate_mod(&Schema::empty(), &uint1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_u64(u_num1).unwrap() % Decimal::from_u64(u_num2).unwrap())
+        );
+
+        //// left: UInt, right: Null
+        assert_eq!(
+            // UInt + Null = Null
+            evaluate_add(&Schema::empty(), &uint1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // UInt - Null = Null
+            evaluate_sub(&Schema::empty(), &uint1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // UInt * Null = Null
+            evaluate_mul(&Schema::empty(), &uint2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // UInt / Null = Null
+            evaluate_div(&Schema::empty(), &uint2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // UInt % Null = Null
+            evaluate_mod(&Schema::empty(), &uint1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+    });
+}
+
+#[test]
+fn test_int_math() {
+    proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, i_num1: i64, i_num2: i64, f_num1: f64, f_num2: f64)| {
+        let row = Record::new(None, vec![], None);
+
+        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let int1 = Box::new(Literal(Field::Int(i_num1)));
+        let int2 = Box::new(Literal(Field::Int(i_num2)));
+        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let dec1 = Box::new(Literal(Field::Decimal(Decimal::from(u_num1))));
+        let dec2 = Box::new(Literal(Field::Decimal(Decimal::from(u_num2))));
+
+        let null = Box::new(Literal(Field::Null));
+
+        //// left: Int, right: UInt
+        assert_eq!(
+            // Int + UInt = Int
+            evaluate_add(&Schema::empty(), &int1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num1) + Wrapping(u_num2 as i64)).0)
+        );
+        assert_eq!(
+            // Int - UInt = Int
+            evaluate_sub(&Schema::empty(), &int1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num1) - Wrapping(u_num2 as i64)).0)
+        );
+        assert_eq!(
+            // Int * UInt = Int
+            evaluate_mul(&Schema::empty(), &int2, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num2) * Wrapping(u_num1 as i64)).0)
+        );
+        assert_eq!(
+            // Int / UInt = Float
+            evaluate_div(&Schema::empty(), &int2, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
+        );
+        assert_eq!(
+            // Int % UInt = Int
+            evaluate_mod(&Schema::empty(), &int1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num1) % Wrapping(u_num2 as i64)).0)
+        );
+
+        //// left: Int, right: Int
+        assert_eq!(
+            // Int + Int = Int
+            evaluate_add(&Schema::empty(), &int1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num1) + Wrapping(i_num2)).0)
+        );
+        assert_eq!(
+            // Int - Int = Int
+            evaluate_sub(&Schema::empty(), &int1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num1) - Wrapping(i_num2)).0)
+        );
+        assert_eq!(
+            // Int * Int = Int
+            evaluate_mul(&Schema::empty(), &int2, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num2) * Wrapping(i_num1)).0)
+        );
+        assert_eq!(
+            // Int / Int = Float
+            evaluate_div(&Schema::empty(), &int2, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
+        );
+        assert_eq!(
+            // Int % Int = Int
+            evaluate_mod(&Schema::empty(), &int1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int((Wrapping(i_num1) % Wrapping(i_num2)).0)
+        );
+
+        //// left: Int, right: Float
+        assert_eq!(
+            // Int + Float = Float
+            evaluate_add(&Schema::empty(), &int1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() + f_num2))
+        );
+        assert_eq!(
+            // Int - Float = Float
+            evaluate_sub(&Schema::empty(), &int1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() - f_num2))
+        );
+        assert_eq!(
+            // Int * Float = Float
+            evaluate_mul(&Schema::empty(), &int2, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() * f_num1))
+        );
+        assert_eq!(
+            // Int / Float = Float
+            evaluate_div(&Schema::empty(), &int2, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f_num1))
+        );
+        assert_eq!(
+            // Int % Float = Float
+            evaluate_mod(&Schema::empty(), &int1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() % f_num2))
+        );
+
+        //// left: Int, right: Decimal
+        assert_eq!(
+            // Int + Decimal = Decimal
+            evaluate_add(&Schema::empty(), &int1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_i64(i_num1).unwrap() + Decimal::from_u64(u_num2).unwrap())
+        );
+        assert_eq!(
+            // Int - Decimal = Decimal
+            evaluate_sub(&Schema::empty(), &int1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_i64(i_num1).unwrap() - Decimal::from_u64(u_num2).unwrap())
+        );
+        // // todo: Multiplication overflowed
+        // assert_eq!(
+        //     // Int * Decimal = Decimal
+        //     evaluate_mul(&Schema::empty(), &int2, &dec1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from_i64(i_num2).unwrap() * Decimal::from_u64(u_num1).unwrap())
+        // );
+        assert_eq!(
+            // Int / Decimal = Decimal
+            evaluate_div(&Schema::empty(), &int2, &dec1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_i64(i_num2).unwrap() / Decimal::from_u64(u_num1).unwrap())
+        );
+        assert_eq!(
+            // Int % Decimal = Decimal
+            evaluate_mod(&Schema::empty(), &int1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from_i64(i_num1).unwrap() % Decimal::from_u64(u_num2).unwrap())
+        );
+
+        //// left: Int, right: Null
+        assert_eq!(
+            // Int + Null = Null
+            evaluate_add(&Schema::empty(), &int1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Int - Null = Null
+            evaluate_sub(&Schema::empty(), &int1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Int * Null = Null
+            evaluate_mul(&Schema::empty(), &int2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Int / Null = Null
+            evaluate_div(&Schema::empty(), &int2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Int % Null = Null
+            evaluate_mod(&Schema::empty(), &int1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+    });
+}
+
+#[test]
+fn test_float_math() {
+    proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, i_num1: i64, i_num2: i64, f_num1: f64, f_num2: f64)| {
+        let row = Record::new(None, vec![], None);
+
+        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let int1 = Box::new(Literal(Field::Int(i_num1)));
+        let int2 = Box::new(Literal(Field::Int(i_num2)));
+        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let _dec1 = Box::new(Literal(Field::Decimal(Decimal::from(u_num1))));
+        let _dec2 = Box::new(Literal(Field::Decimal(Decimal::from(u_num2))));
+
+        let null = Box::new(Literal(Field::Null));
+
+        //// left: Float, right: UInt
+        assert_eq!(
+            // Float + UInt = Float
+            evaluate_add(&Schema::empty(), &float1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_u64(u_num2).unwrap()))
+        );
+        assert_eq!(
+            // Float - UInt = Float
+            evaluate_sub(&Schema::empty(), &float1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_u64(u_num2).unwrap()))
+        );
+        assert_eq!(
+            // Float * UInt = Float
+            evaluate_mul(&Schema::empty(), &float2, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_u64(u_num1).unwrap()))
+        );
+        assert_eq!(
+            // Float / UInt = Float
+            evaluate_div(&Schema::empty(), &float2, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_u64(u_num1).unwrap()))
+        );
+        assert_eq!(
+            // Float % UInt = Float
+            evaluate_mod(&Schema::empty(), &float1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_u64(u_num2).unwrap()))
+        );
+
+        //// left: Float, right: Int
+        assert_eq!(
+            // Float + Int = Float
+            evaluate_add(&Schema::empty(), &float1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_i64(i_num2).unwrap()))
+        );
+        assert_eq!(
+            // Float - Int = Float
+            evaluate_sub(&Schema::empty(), &float1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_i64(i_num2).unwrap()))
+        );
+        assert_eq!(
+            // Float * Int = Float
+            evaluate_mul(&Schema::empty(), &float2, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_i64(i_num1).unwrap()))
+        );
+        assert_eq!(
+            // Float / Int = Float
+            evaluate_div(&Schema::empty(), &float2, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_i64(i_num1).unwrap()))
+        );
+        assert_eq!(
+            // Float % Int = Float
+            evaluate_mod(&Schema::empty(), &float1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_i64(i_num2).unwrap()))
+        );
+
+        //// left: Float, right: Float
+        assert_eq!(
+            // Float + Float = Float
+            evaluate_add(&Schema::empty(), &float1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1 + f_num2))
+        );
+        assert_eq!(
+            // Float - Float = Float
+            evaluate_sub(&Schema::empty(), &float1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1 - f_num2))
+        );
+        assert_eq!(
+            // Float * Float = Float
+            evaluate_mul(&Schema::empty(), &float2, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num2 * f_num1))
+        );
+        assert_eq!(
+            // Float / Float = Float
+            evaluate_div(&Schema::empty(), &float2, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num2 / f_num1))
+        );
+        assert_eq!(
+            // Float % Float = Float
+            evaluate_mod(&Schema::empty(), &float1, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num1 % f_num2))
+        );
+
+        // //// left: Float, right: Decimal
+        // assert_eq!(
+        //     // Float + Decimal = Decimal
+        //     evaluate_add(&Schema::empty(), &float1, &dec2, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from_f64(f_num1).unwrap() + Decimal::from_u64(u_num2).unwrap())
+        // );
+        // assert_eq!(
+        //     // Float - Decimal = Decimal
+        //     evaluate_sub(&Schema::empty(), &float1, &dec2, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from_f64(f_num1).unwrap() - Decimal::from_u64(u_num2).unwrap())
+        // );
+        // // // todo: Multiplication overflowed
+        // // assert_eq!(
+        // //     // Float * Decimal = Decimal
+        // //     evaluate_mul(&Schema::empty(), &float2, &dec1, &row)
+        // //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        // //     Field::Decimal(Decimal::from_f64(f_num2).unwrap() * Decimal::from_u64(u_num1).unwrap())
+        // // );
+        // assert_eq!(
+        //     // Float / Decimal = Decimal
+        //     evaluate_div(&Schema::empty(), &float2, &dec1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from_f64(f_num2).unwrap() / Decimal::from_u64(u_num1).unwrap())
+        // );
+        // assert_eq!(
+        //     // Float % Decimal = Decimal
+        //     evaluate_mod(&Schema::empty(), &float1, &dec2, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from_f64(f_num1).unwrap() % Decimal::from_u64(u_num2).unwrap())
+        // );
+
+        //// left: Float, right: Null
+        assert_eq!(
+            // Float + Null = Null
+            evaluate_add(&Schema::empty(), &float1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Float - Null = Null
+            evaluate_sub(&Schema::empty(), &float1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Float * Null = Null
+            evaluate_mul(&Schema::empty(), &float2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Float / Null = Null
+            evaluate_div(&Schema::empty(), &float2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Float % Null = Null
+            evaluate_mod(&Schema::empty(), &float1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+    });
+}
+
+#[test]
+fn test_decimal_math() {
+    proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, i_num1: i64, i_num2: i64, f_num1: f64, f_num2: f64)| {
+        let row = Record::new(None, vec![], None);
+
+        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let int1 = Box::new(Literal(Field::Int(i_num1)));
+        let int2 = Box::new(Literal(Field::Int(i_num2)));
+        let _float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let _float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let dec1 = Box::new(Literal(Field::Decimal(Decimal::from(u_num1))));
+        let dec2 = Box::new(Literal(Field::Decimal(Decimal::from(u_num2))));
+
+        let null = Box::new(Literal(Field::Null));
+
+        //// left: Decimal, right: UInt
+        assert_eq!(
+            // Decimal + UInt = Decimal
+            evaluate_add(&Schema::empty(), &dec1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) + Decimal::from(u_num2))
+        );
+        assert_eq!(
+            // Decimal - UInt = Decimal
+            evaluate_sub(&Schema::empty(), &dec1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) - Decimal::from(u_num2))
+        );
+        // // todo: Multiplication overflowed
+        // assert_eq!(
+        //     // Decimal * UInt = Decimal
+        //     evaluate_mul(&Schema::empty(), &dec2, &uint1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num2) * Decimal::from(u_num1))
+        // );
+        assert_eq!(
+            // Decimal / UInt = Decimal
+            evaluate_div(&Schema::empty(), &dec2, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num2) / Decimal::from(u_num1))
+        );
+        assert_eq!(
+            // Decimal % UInt = Decimal
+            evaluate_mod(&Schema::empty(), &dec1, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) % Decimal::from(u_num2))
+        );
+
+        //// left: Decimal, right: Int
+        assert_eq!(
+            // Decimal + Int = Decimal
+            evaluate_add(&Schema::empty(), &dec1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) + Decimal::from(i_num2))
+        );
+        assert_eq!(
+            // Decimal - Int = Decimal
+            evaluate_sub(&Schema::empty(), &dec1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) - Decimal::from(i_num2))
+        );
+        // // todo: Multiplication overflowed
+        // assert_eq!(
+        //     // Decimal * Int = Float
+        //     evaluate_mul(&Schema::empty(), &dec2, &int1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num2) * Decimal::from(i_num1))
+        // );
+        assert_eq!(
+            // Decimal / Int = Decimal
+            evaluate_div(&Schema::empty(), &dec2, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num2) / Decimal::from(i_num1))
+        );
+        assert_eq!(
+            // Decimal % Int = Decimal
+            evaluate_mod(&Schema::empty(), &dec1, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) % Decimal::from(i_num2))
+        );
+
+        //// left: Decimal, right: Float
+        // // todo: conversion error sue to overflow
+        // assert_eq!(
+        //     // Decimal + Float = Decimal
+        //     evaluate_add(&Schema::empty(), &dec1, &float2, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num1) + Decimal::from_f64(f_num2).unwrap())
+        // );
+        // // todo: conversion error sue to overflow
+        // assert_eq!(
+        //     // Decimal - Float = Decimal
+        //     evaluate_sub(&Schema::empty(), &dec1, &float2, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num1) - Decimal::from_f64(f_num2).unwrap())
+        // );
+        // // todo: Multiplication overflowed
+        // assert_eq!(
+        //     // Decimal * Float = Decimal
+        //     evaluate_mul(&Schema::empty(), &dec2, &float1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num2) * Decimal::from_f64(f_num1).unwrap())
+        // );
+        // // todo: Division by zero
+        // assert_eq!(
+        //     // Decimal / Float = Decimal
+        //     evaluate_div(&Schema::empty(), &dec2, &float1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num2) / Decimal::from_f64(f_num1).unwrap())
+        // );
+        // // todo: Division by zero
+        // assert_eq!(
+        //     // Decimal % Float = Decimal
+        //     evaluate_mod(&Schema::empty(), &dec1, &float2, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num1) % Decimal::from_f64(f_num2).unwrap())
+        // );
+
+        //// left: Decimal, right: Decimal
+        assert_eq!(
+            // Decimal + Decimal = Decimal
+            evaluate_add(&Schema::empty(), &dec1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) + Decimal::from_u64(u_num2).unwrap())
+        );
+        assert_eq!(
+            // Decimal - Decimal = Decimal
+            evaluate_sub(&Schema::empty(), &dec1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) - Decimal::from_u64(u_num2).unwrap())
+        );
+        // // todo: Multiplication overflowed
+        // assert_eq!(
+        //     // Decimal * Decimal = Decimal
+        //     evaluate_mul(&Schema::empty(), &dec2, &dec1, &row)
+        //         .unwrap_or_else(|e| panic!("{}", e.to_string())),
+        //     Field::Decimal(Decimal::from(u_num2).unwrap() * Decimal::from_u64(u_num1).unwrap())
+        // );
+        assert_eq!(
+            // Decimal / Decimal = Decimal
+            evaluate_div(&Schema::empty(), &dec2, &dec1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num2) / Decimal::from_u64(u_num1).unwrap())
+        );
+        assert_eq!(
+            // Decimal % Decimal = Decimal
+            evaluate_mod(&Schema::empty(), &dec1, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Decimal(Decimal::from(u_num1) % Decimal::from_u64(u_num2).unwrap())
+        );
+
+        //// left: Decimal, right: Null
+        assert_eq!(
+            // Decimal + Null = Null
+            evaluate_add(&Schema::empty(), &dec1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal - Null = Null
+            evaluate_sub(&Schema::empty(), &dec1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal * Null = Null
+            evaluate_mul(&Schema::empty(), &dec2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal / Null = Null
+            evaluate_div(&Schema::empty(), &dec2, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal % Null = Null
+            evaluate_mod(&Schema::empty(), &dec1, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+    })
+}
+
+#[test]
+fn test_null_math() {
+    proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, i_num1: i64, i_num2: i64, f_num1: f64, f_num2: f64)| {
+        let row = Record::new(None, vec![], None);
+
+        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let int1 = Box::new(Literal(Field::Int(i_num1)));
+        let int2 = Box::new(Literal(Field::Int(i_num2)));
+        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let dec1 = Box::new(Literal(Field::Decimal(Decimal::from(u_num1))));
+        let dec2 = Box::new(Literal(Field::Decimal(Decimal::from(u_num2))));
+
+        let null = Box::new(Literal(Field::Null));
+
+        //// left: Null, right: UInt
+        assert_eq!(
+            // Null + UInt = Null
+            evaluate_add(&Schema::empty(), &null, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null - UInt = Null
+            evaluate_sub(&Schema::empty(), &null, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null * UInt = Null
+            evaluate_mul(&Schema::empty(), &null, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal / UInt = Null
+            evaluate_div(&Schema::empty(), &null, &uint1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal % UInt = Null
+            evaluate_mod(&Schema::empty(), &null, &uint2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+
+        //// left: Null, right: Int
+        assert_eq!(
+            // Null + Int = Null
+            evaluate_add(&Schema::empty(), &null, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null - Int = Null
+            evaluate_sub(&Schema::empty(), &null, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null * Int = Null
+            evaluate_mul(&Schema::empty(), &null, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal / Int = Null
+            evaluate_div(&Schema::empty(), &null, &int1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal % Int = Null
+            evaluate_mod(&Schema::empty(), &null, &int2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+
+        //// left: Null, right: Float
+        assert_eq!(
+            // Null + Float = Null
+            evaluate_add(&Schema::empty(), &null, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null - Float = Null
+            evaluate_sub(&Schema::empty(), &null, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null * Float = Null
+            evaluate_mul(&Schema::empty(), &null, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal / Float = Null
+            evaluate_div(&Schema::empty(), &null, &float1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal % Float = Null
+            evaluate_mod(&Schema::empty(), &null, &float2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+
+        //// left: Null, right: Decimal
+        assert_eq!(
+            // Null + Decimal = Null
+            evaluate_add(&Schema::empty(), &null, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null - Decimal = Null
+            evaluate_sub(&Schema::empty(), &null, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null * Decimal = Null
+            evaluate_mul(&Schema::empty(), &null, &dec1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal / Decimal = Null
+            evaluate_div(&Schema::empty(), &null, &dec1, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal % Decimal = Null
+            evaluate_mod(&Schema::empty(), &null, &dec2, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+
+        //// left: Null, right: Null
+        assert_eq!(
+            // Null + Null = Null
+            evaluate_add(&Schema::empty(), &null, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null - Null = Null
+            evaluate_sub(&Schema::empty(), &null, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Null * Null = Null
+            evaluate_mul(&Schema::empty(), &null, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal / Null = Null
+            evaluate_div(&Schema::empty(), &null, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+        assert_eq!(
+            // Decimal % Null = Null
+            evaluate_mod(&Schema::empty(), &null, &null, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+    })
+}

--- a/dozer-sql/src/pipeline/expression/scalar/tests/mod.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/mod.rs
@@ -3,6 +3,8 @@ mod cast;
 #[cfg(test)]
 mod datetime;
 #[cfg(test)]
+mod mathematical;
+#[cfg(test)]
 mod number;
 #[cfg(test)]
 mod scalar_common;

--- a/dozer-sql/src/pipeline/expression/scalar/tests/number.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/tests/number.rs
@@ -1,102 +1,109 @@
 use crate::pipeline::expression::execution::Expression::Literal;
-use crate::pipeline::expression::scalar::number::evaluate_round;
+use crate::pipeline::expression::scalar::number::{evaluate_abs, evaluate_round};
 use crate::pipeline::expression::scalar::tests::scalar_common::run_scalar_fct;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::types::{Field, FieldDefinition, FieldType, Record, Schema, SourceDefinition};
+use proptest::prelude::*;
+use std::ops::Neg;
 
 #[test]
 fn test_abs() {
-    let f = run_scalar_fct(
-        "SELECT ABS(c) FROM USERS",
-        Schema::empty()
-            .field(
-                FieldDefinition::new(
-                    String::from("c"),
-                    FieldType::Int,
-                    false,
-                    SourceDefinition::Dynamic,
-                ),
-                false,
-            )
-            .clone(),
-        vec![Field::Int(-1)],
-    );
-    assert_eq!(f, Field::Int(1));
+    proptest!(ProptestConfig::with_cases(1000), |(i_num in 0i64..100000000i64, f_num in 0f64..100000000f64)| {
+        let row = Record::new(None, vec![], None);
+
+        let v = Box::new(Literal(Field::Int(i_num.neg())));
+        assert_eq!(
+            evaluate_abs(&Schema::empty(), &v, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int(i_num)
+        );
+
+        let row = Record::new(None, vec![], None);
+
+        let v = Box::new(Literal(Field::Float(OrderedFloat(f_num.neg()))));
+        assert_eq!(
+            evaluate_abs(&Schema::empty(), &v, &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num))
+        );
+    });
 }
 
 #[test]
 fn test_round() {
-    let row = Record::new(None, vec![], None);
+    proptest!(ProptestConfig::with_cases(1000), |(i_num: i64, f_num: f64, i_pow: i32, f_pow: f32)| {
+        let row = Record::new(None, vec![], None);
 
-    let v = Box::new(Literal(Field::Int(1)));
-    let d = &Box::new(Literal(Field::Int(0)));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Int(1)
-    );
+        let v = Box::new(Literal(Field::Int(i_num)));
+        let d = &Box::new(Literal(Field::Int(0)));
+        assert_eq!(
+            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Int(i_num)
+        );
 
-    let v = Box::new(Literal(Field::Float(OrderedFloat(2.1))));
-    let d = &Box::new(Literal(Field::Int(0)));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Float(OrderedFloat(2.0))
-    );
+        let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+        let d = &Box::new(Literal(Field::Int(0)));
+        assert_eq!(
+            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num.round()))
+        );
 
-    let v = Box::new(Literal(Field::Float(OrderedFloat(2.6))));
-    let d = &Box::new(Literal(Field::Int(0)));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Float(OrderedFloat(3.0))
-    );
+        let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+        let d = &Box::new(Literal(Field::Int(i_pow as i64)));
+        let order = 10.0_f64.powi(i_pow);
+        assert_eq!(
+            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat((f_num * order).round() / order))
+        );
 
-    let v = Box::new(Literal(Field::Float(OrderedFloat(2.633))));
-    let d = &Box::new(Literal(Field::Int(2)));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Float(OrderedFloat(2.63))
-    );
+        let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+        let d = &Box::new(Literal(Field::Float(OrderedFloat(f_pow as f64))));
+        let order = 10.0_f64.powi(f_pow.round() as i32);
+        assert_eq!(
+            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat((f_num * order).round() / order))
+        );
 
-    let v = Box::new(Literal(Field::Float(OrderedFloat(212.633))));
-    let d = &Box::new(Literal(Field::Int(-2)));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Float(OrderedFloat(200.0))
-    );
+        let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+        let d = &Box::new(Literal(Field::String(f_pow.to_string())));
+        assert_eq!(
+            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Float(OrderedFloat(f_num.round()))
+        );
 
-    let v = Box::new(Literal(Field::Float(OrderedFloat(2.633))));
-    let d = &Box::new(Literal(Field::Float(OrderedFloat(2.1))));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Float(OrderedFloat(2.63))
-    );
+        let v = Box::new(Literal(Field::Null));
+        let d = &Box::new(Literal(Field::String(i_pow.to_string())));
+        assert_eq!(
+            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+                .unwrap_or_else(|e| panic!("{}", e.to_string())),
+            Field::Null
+        );
+    });
+}
 
-    let v = Box::new(Literal(Field::Float(OrderedFloat(2.633))));
-    let d = &Box::new(Literal(Field::String("2.3".to_string())));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Float(OrderedFloat(3.0))
-    );
-
-    let v = Box::new(Literal(Field::Null));
-    let d = &Box::new(Literal(Field::String("2".to_string())));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Null
-    );
-
-    let v = Box::new(Literal(Field::Null));
-    let d = &Box::new(Literal(Field::String("2".to_string())));
-    assert_eq!(
-        evaluate_round(&Schema::empty(), &v, Some(d), &row)
-            .unwrap_or_else(|e| panic!("{}", e.to_string())),
-        Field::Null
-    );
+#[test]
+fn test_abs_logic() {
+    proptest!(ProptestConfig::with_cases(1000), |(i_num in 0i64..100000000i64)| {
+        let f = run_scalar_fct(
+            "SELECT ABS(c) FROM USERS",
+            Schema::empty()
+                .field(
+                    FieldDefinition::new(
+                        String::from("c"),
+                        FieldType::Int,
+                        false,
+                        SourceDefinition::Dynamic,
+                    ),
+                    false,
+                )
+                .clone(),
+            vec![Field::Int(i_num.neg())],
+        );
+        assert_eq!(f, Field::Int(i_num));
+    });
 }


### PR DESCRIPTION
Refactor existing unit tests with proptest
- [x] [number](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/scalar/number.rs)
- [x] [mathematical](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/scalar/tests/cast.rs#L646) // TODO: overflowing of Decimal for multiplication needs to be solved
- [x] [scalar](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/scalar/number.rs)
- [x] [logical](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/logical.rs#L71)

Todo
- [ ] [datetime](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/scalar/tests/datetime.rs)
- [ ] [string](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/scalar/string.rs)
- [ ] [comparison](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/comparison.rs#L373)
- [ ] [geo](https://github.com/getdozer/dozer/tree/main/dozer-sql/src/pipeline/expression/geo/tests)
- [ ] logical operator tests (starting from SQL, for example, using `run_scalar_fct()`) into dozer-tests
- [ ] [cast](https://github.com/getdozer/dozer/blob/main/dozer-sql/src/pipeline/expression/scalar/tests/cast.rs#L16) // TODO: only logical testing is possible