### PR TITLE
test: `LocalStorage` basic test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,7 +1762,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "parking_lot",
- "parquet",
+ "parquet 31.0.0",
  "paste",
  "percent-encoding",
  "pin-project-lite",
@@ -1788,7 +1788,7 @@ dependencies = [
  "chrono",
  "num_cpus",
  "object_store",
- "parquet",
+ "parquet 31.0.0",
  "sqlparser 0.30.0",
 ]
 
@@ -1923,7 +1923,7 @@ dependencies = [
  "object_store",
  "once_cell",
  "parking_lot",
- "parquet",
+ "parquet 31.0.0",
  "percent-encoding",
  "regex",
  "serde",
@@ -2165,12 +2165,14 @@ dependencies = [
  "deltalake",
  "dozer-tracing",
  "dozer-types",
+ "env_logger",
  "futures",
  "hex-literal",
  "include_dir",
  "kafka",
  "object_store",
  "odbc",
+ "parquet 33.0.0",
  "postgres",
  "postgres-protocol",
  "postgres-types",
@@ -2181,6 +2183,7 @@ dependencies = [
  "reqwest",
  "schema_registry_converter",
  "serial_test",
+ "tempdir",
  "tokio",
  "tokio-postgres",
  "tonic",
@@ -4386,6 +4389,37 @@ dependencies = [
  "snap",
  "thrift 0.17.0",
  "tokio",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "parquet"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b076829801167d889795cd1957989055543430fa1469cb1f6e32b789bfc764"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow-array 33.0.0",
+ "arrow-buffer 33.0.0",
+ "arrow-cast 33.0.0",
+ "arrow-data 33.0.0",
+ "arrow-ipc 33.0.0",
+ "arrow-schema 33.0.0",
+ "arrow-select 33.0.0",
+ "base64 0.21.0",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "hashbrown 0.13.2",
+ "lz4",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "snap",
+ "thrift 0.17.0",
  "twox-hash",
  "zstd",
 ]

--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -44,6 +44,9 @@ serial_test = "1.0.0"
 rand = "0.8.5"
 hex-literal = "0.3.4"
 dozer-tracing = {path = "../dozer-tracing"}
+tempdir = "0.3.7"
+parquet = "33.0.0"
+env_logger = "0.10.0"
 
 [features]
 # Defines a feature named `odbc` that does not enable any other features.

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -31,7 +31,7 @@ use self::grpc::connector::GrpcConnector;
 use self::grpc::{ArrowAdapter, DefaultAdapter};
 use crate::connectors::snowflake::connector::SnowflakeConnector;
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
 #[serde(crate = "dozer_types::serde")]
 /// A source table's CDC event type.
 pub enum CdcType {

--- a/dozer-ingestion/tests/test_connectors.rs
+++ b/dozer-ingestion/tests/test_connectors.rs
@@ -1,0 +1,9 @@
+use test_suite::run_test_suite_basic;
+
+#[test]
+fn test_connectors() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    run_test_suite_basic::<test_suite::LocalStorageObjectStoreConnectorTest>();
+}
+
+mod test_suite;

--- a/dozer-ingestion/tests/test_suite/basic.rs
+++ b/dozer-ingestion/tests/test_suite/basic.rs
@@ -1,0 +1,245 @@
+use dozer_ingestion::{
+    connectors::{CdcType, Connector, TableIdentifier},
+    ingestion::Ingestor,
+};
+use dozer_types::{
+    ingestion_types::IngestionMessageKind,
+    log::warn,
+    types::{Field, FieldType, Operation, Record, Schema},
+};
+
+use super::{data, ConnectorTest};
+
+pub fn run_test_suite_basic<T: ConnectorTest>() {
+    let table_name = "test_table".to_string();
+    for data_fn in [
+        data::append_only_operations_without_primary_key,
+        data::append_only_operations_with_primary_key,
+        data::all_kinds_of_operations,
+    ] {
+        // Load test data.
+        let (schema, operations) = data_fn();
+
+        // Create connector.
+        let schema_name = None;
+        let Some((connector_test, actual_schema)) = T::new(
+            schema_name.clone(),
+            table_name.clone(),
+            schema.clone(),
+            operations.clone(),
+        ) else {
+            warn!("Connector does not support schema {:?} or some operations.", schema_name);
+            continue;
+        };
+        assert_eq!(schema.identifier, actual_schema.identifier);
+        for field in &schema.fields {
+            if !actual_schema
+                .fields
+                .iter()
+                .any(|actual_field| actual_field == field)
+            {
+                warn!("Field {:?} is not supported by the connector.", field)
+            }
+        }
+
+        // Validate connection.
+        connector_test.connector().validate_connection().unwrap();
+
+        // Validate tables.
+        connector_test
+            .connector()
+            .validate_tables(&[TableIdentifier::new(
+                schema_name.clone(),
+                table_name.clone(),
+            )])
+            .unwrap();
+
+        // List columns.
+        let tables = connector_test
+            .connector()
+            .list_columns(vec![TableIdentifier::new(schema_name, table_name.clone())])
+            .unwrap();
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0].name, table_name);
+        assert_eq!(
+            tables[0].column_names,
+            actual_schema
+                .fields
+                .iter()
+                .map(|field| field.name.clone())
+                .collect::<Vec<_>>()
+        );
+
+        // Validate schemas.
+        let schemas = connector_test.connector().get_schemas(&tables).unwrap();
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(schemas[0].as_ref().unwrap().schema, actual_schema);
+        let cdc_type = schemas[0].as_ref().unwrap().cdc_type;
+
+        // Run the connector and check data is ingested.
+        let (ingestor, mut iterator) = Ingestor::initialize_channel(Default::default());
+        std::thread::spawn(move || {
+            connector_test.start();
+            connector_test
+                .connector()
+                .start(&ingestor, tables)
+                .expect("Failed to start connector.");
+        });
+
+        let mut last_identifier = None;
+        for operation in operations {
+            // Connector must send message.
+            let message = iterator.next().unwrap();
+
+            // Identifier must be increasing.
+            if let Some(identifier) = last_identifier {
+                assert!(message.identifier > identifier);
+                last_identifier = Some(message.identifier);
+            }
+
+            // Message must be an operation event.
+            let IngestionMessageKind::OperationEvent(actual_operation) = message.kind else {
+                panic!("Expected an operation event, but got {:?}", message.kind);
+            };
+
+            // Record in operation must match schema.
+            match &actual_operation {
+                Operation::Insert { new } => {
+                    assert_record_matches_schema(new, &actual_schema, false)
+                }
+                Operation::Update { new, old } => {
+                    assert_record_matches_schema(new, &actual_schema, false);
+                    match cdc_type {
+                        CdcType::FullChanges => {
+                            assert_record_matches_schema(old, &actual_schema, false)
+                        }
+                        CdcType::OnlyPK => assert_record_matches_schema(old, &actual_schema, true),
+                        CdcType::Nothing => {
+                            panic!("Connector with CdcType::Nothing should not send update events.")
+                        }
+                    }
+                }
+                Operation::Delete { old } => match cdc_type {
+                    CdcType::FullChanges => {
+                        assert_record_matches_schema(old, &actual_schema, false)
+                    }
+                    CdcType::OnlyPK => assert_record_matches_schema(old, &actual_schema, true),
+                    CdcType::Nothing => {
+                        panic!("Connector with CdcType::Nothing should not send delete events.")
+                    }
+                },
+            }
+
+            // Operation must match expected operation.
+            match (&actual_operation, &operation) {
+                (Operation::Insert { new: actual_new }, Operation::Insert { new }) => {
+                    assert_records_match(actual_new, &actual_schema, new, &schema, false);
+                }
+                (
+                    Operation::Update {
+                        new: actual_new,
+                        old: actual_old,
+                    },
+                    Operation::Update { new, old },
+                ) => {
+                    assert_records_match(actual_new, &actual_schema, new, &schema, false);
+                    match cdc_type {
+                        CdcType::FullChanges => {
+                            assert_records_match(actual_old, &actual_schema, old, &schema, false)
+                        }
+                        CdcType::OnlyPK => {
+                            assert_records_match(actual_old, &actual_schema, old, &schema, true)
+                        }
+                        CdcType::Nothing => {
+                            panic!("Connector with CdcType::Nothing should not send update events.")
+                        }
+                    }
+                }
+                (Operation::Delete { old: actual_old }, Operation::Delete { old }) => {
+                    match cdc_type {
+                        CdcType::FullChanges => {
+                            assert_records_match(actual_old, &actual_schema, old, &schema, false)
+                        }
+                        CdcType::OnlyPK => {
+                            assert_records_match(actual_old, &actual_schema, old, &schema, true)
+                        }
+                        CdcType::Nothing => {
+                            panic!("Connector with CdcType::Nothing should not send delete events.")
+                        }
+                    }
+                }
+                _ => panic!("Expected {:?}, but got {:?}", operation, actual_operation),
+            }
+        }
+    }
+}
+
+fn assert_record_matches_schema(record: &Record, schema: &Schema, only_match_pk: bool) {
+    assert_eq!(record.schema_id, schema.identifier);
+    assert_eq!(record.values.len(), schema.fields.len());
+    for (index, (field, value)) in schema.fields.iter().zip(record.values.iter()).enumerate() {
+        // If `only_match_pk` is true, we only check primary key fields.
+        if only_match_pk && !schema.primary_index.iter().any(|i| i == &index) {
+            continue;
+        }
+        if field.nullable && value == &Field::Null {
+            continue;
+        }
+        match field.typ {
+            FieldType::UInt => {
+                assert!(value.as_uint().is_some())
+            }
+            FieldType::Int => {
+                assert!(value.as_int().is_some())
+            }
+            FieldType::Float => {
+                assert!(value.as_float().is_some())
+            }
+            FieldType::Boolean => assert!(value.as_boolean().is_some()),
+            FieldType::String => assert!(value.as_string().is_some()),
+            FieldType::Text => assert!(value.as_text().is_some()),
+            FieldType::Binary => assert!(value.as_binary().is_some()),
+            FieldType::Decimal => assert!(value.as_decimal().is_some()),
+            FieldType::Timestamp => assert!(value.as_timestamp().is_some()),
+            FieldType::Date => assert!(value.as_date().is_some()),
+            FieldType::Bson => assert!(value.as_bson().is_some()),
+            FieldType::Point => assert!(value.as_point().is_some()),
+        }
+    }
+}
+
+fn assert_records_match(
+    partial_record: &Record,
+    partial_schema: &Schema,
+    record: &Record,
+    schema: &Schema,
+    only_match_pk: bool,
+) {
+    let partial_index_to_index = partial_schema
+        .fields
+        .iter()
+        .map(|field| {
+            schema
+                .fields
+                .iter()
+                .position(|f| f.name == field.name)
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    for (partial_index, partial_value) in partial_record.values.iter().enumerate() {
+        // If `only_match_pk` is true, we only check primary key fields.
+        if only_match_pk
+            && !partial_schema
+                .primary_index
+                .iter()
+                .any(|i| i == &partial_index)
+        {
+            continue;
+        }
+        assert_eq!(
+            partial_value,
+            &record.values[partial_index_to_index[partial_index]]
+        );
+    }
+}

--- a/dozer-ingestion/tests/test_suite/connectors/arrow.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/arrow.rs
@@ -1,0 +1,212 @@
+use std::sync::Arc;
+
+use dozer_types::{
+    arrow,
+    chrono::Datelike,
+    types::{Field, FieldDefinition, FieldType, Operation, Record, Schema},
+};
+
+fn field_type_to_arrow(field_type: FieldType) -> Option<arrow::datatypes::DataType> {
+    match field_type {
+        FieldType::UInt => Some(arrow::datatypes::DataType::UInt64),
+        FieldType::Int => Some(arrow::datatypes::DataType::Int64),
+        FieldType::Float => Some(arrow::datatypes::DataType::Float64),
+        FieldType::Boolean => Some(arrow::datatypes::DataType::Boolean),
+        FieldType::String => Some(arrow::datatypes::DataType::Utf8),
+        FieldType::Text => Some(arrow::datatypes::DataType::LargeUtf8),
+        FieldType::Binary => Some(arrow::datatypes::DataType::LargeBinary),
+        FieldType::Decimal => None,
+        FieldType::Timestamp => Some(arrow::datatypes::DataType::Timestamp(
+            arrow::datatypes::TimeUnit::Nanosecond,
+            None,
+        )),
+        FieldType::Date => Some(arrow::datatypes::DataType::Date32),
+        FieldType::Bson => None,
+        FieldType::Point => None,
+    }
+}
+
+fn field_definition_to_arrow(field_definition: FieldDefinition) -> Option<arrow::datatypes::Field> {
+    field_type_to_arrow(field_definition.typ).map(|data_type| {
+        arrow::datatypes::Field::new(field_definition.name, data_type, field_definition.nullable)
+    })
+}
+
+pub fn schema_to_arrow(schema: Schema) -> (arrow::datatypes::Schema, Schema) {
+    let arrow_fields = schema
+        .fields
+        .iter()
+        .cloned()
+        .filter_map(field_definition_to_arrow)
+        .collect();
+    let arrow_schema = arrow::datatypes::Schema::new(arrow_fields);
+
+    let fields = schema
+        .fields
+        .into_iter()
+        .filter_map(|field| field_type_to_arrow(field.typ).map(|_| field))
+        .collect();
+    let schema = Schema {
+        identifier: schema.identifier,
+        fields,
+        primary_index: vec![],
+    };
+
+    (arrow_schema, schema)
+}
+
+fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
+    fields: F,
+    count: usize,
+    field_type: FieldType,
+) -> Option<Arc<dyn arrow::array::Array>> {
+    Some(match field_type {
+        FieldType::UInt => {
+            let mut builder = arrow::array::UInt64Array::builder(count);
+            for field in fields {
+                match field? {
+                    Field::UInt(value) => builder.append_value(*value),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Int => {
+            let mut builder = arrow::array::Int64Array::builder(count);
+            for field in fields {
+                match field? {
+                    Field::Int(value) => builder.append_value(*value),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Float => {
+            let mut builder = arrow::array::Float64Array::builder(count);
+            for field in fields {
+                match field? {
+                    Field::Float(value) => builder.append_value(value.0),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Boolean => {
+            let mut builder = arrow::array::BooleanArray::builder(count);
+            for field in fields {
+                match field? {
+                    Field::Boolean(value) => builder.append_value(*value),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::String => {
+            let mut builder = arrow::array::StringBuilder::new();
+            for field in fields {
+                match field? {
+                    Field::String(value) => builder.append_value(value),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Text => {
+            let mut builder = arrow::array::LargeStringBuilder::new();
+            for field in fields {
+                match field? {
+                    Field::Text(value) => builder.append_value(value),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Binary => {
+            let mut builder = arrow::array::LargeBinaryBuilder::new();
+            for field in fields {
+                match field? {
+                    Field::Binary(value) => builder.append_value(value),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Decimal => panic!("Decimal not supported"),
+        FieldType::Timestamp => {
+            let mut builder = arrow::array::TimestampNanosecondArray::builder(count);
+            for field in fields {
+                match field? {
+                    Field::Timestamp(value) => builder.append_value(value.timestamp_nanos()),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Date => {
+            let mut builder = arrow::array::Date32Array::builder(count);
+            for field in fields {
+                match field? {
+                    Field::Date(value) => builder.append_value(value.num_days_from_ce()),
+                    Field::Null => builder.append_null(),
+                    _ => panic!("Unexpected field type"),
+                }
+            }
+            Arc::new(builder.finish())
+        }
+        FieldType::Bson => panic!("Bson not supported"),
+        FieldType::Point => panic!("Point not supported"),
+    })
+}
+
+fn records_to_arrow<
+    'a,
+    I: Iterator<Item = Option<&'a Record>> + Clone,
+    R: IntoIterator<IntoIter = I>,
+>(
+    records: R,
+    count: usize,
+    schema: Schema,
+) -> Option<arrow::record_batch::RecordBatch> {
+    let records = records.into_iter();
+
+    let mut columns = vec![];
+    for (index, field) in schema.fields.iter().enumerate() {
+        if field_type_to_arrow(field.typ).is_some() {
+            let fields = records
+                .clone()
+                .map(|record| record.map(|record| &record.values[index]));
+            let column = fields_to_arrow(fields, count, field.typ);
+            columns.push(column?);
+        }
+    }
+
+    let (schema, _) = schema_to_arrow(schema);
+
+    Some(
+        arrow::record_batch::RecordBatch::try_new(Arc::new(schema), columns)
+            .expect("BUG in records_to_arrow"),
+    )
+}
+
+pub fn operations_to_arrow(
+    operations: &[Operation],
+    schema: Schema,
+) -> Option<arrow::record_batch::RecordBatch> {
+    let count = operations.len();
+    let records = operations.iter().map(|operation| {
+        if let Operation::Insert { new } = operation {
+            Some(new)
+        } else {
+            None
+        }
+    });
+    records_to_arrow(records, count, schema)
+}

--- a/dozer-ingestion/tests/test_suite/connectors/mod.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/mod.rs
@@ -1,0 +1,4 @@
+mod arrow;
+mod object_store;
+
+pub use self::object_store::LocalStorageObjectStoreConnectorTest;

--- a/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
@@ -1,0 +1,79 @@
+use dozer_ingestion::connectors::object_store::connector::ObjectStoreConnector;
+use dozer_types::{
+    ingestion_types::{LocalDetails, LocalStorage, Table},
+    types::{Operation, Schema},
+};
+use tempdir::TempDir;
+
+use crate::test_suite::ConnectorTest;
+
+use super::super::arrow::{operations_to_arrow, schema_to_arrow};
+
+pub struct LocalStorageObjectStoreConnectorTest {
+    _temp_dir: TempDir,
+    connector: ObjectStoreConnector<LocalStorage>,
+}
+
+impl ConnectorTest for LocalStorageObjectStoreConnectorTest {
+    type Connector = ObjectStoreConnector<LocalStorage>;
+
+    fn new(
+        schema_name: Option<String>,
+        table_name: String,
+        schema: Schema,
+        operations: Vec<Operation>,
+    ) -> Option<(Self, Schema)> {
+        if schema_name.is_some() {
+            return None;
+        }
+
+        let record_batch = operations_to_arrow(&operations, schema.clone())?;
+
+        let temp_dir = TempDir::new("local").expect("Failed to create temp dir");
+        let path = temp_dir.path().join(&table_name);
+        std::fs::create_dir_all(&path).expect("Failed to create dir");
+
+        let file = std::fs::File::create(path.join("0.parquet")).expect("Failed to create file");
+        let props = parquet::file::properties::WriterProperties::builder().build();
+        let mut writer = parquet::arrow::arrow_writer::ArrowWriter::try_new(
+            file,
+            record_batch.schema(),
+            Some(props),
+        )
+        .expect("Failed to create writer");
+        writer
+            .write(&record_batch)
+            .expect("Failed to write record batch");
+        writer.close().expect("Failed to close writer");
+
+        let prefix = format!("/{table_name}");
+        let local_storage = LocalStorage {
+            details: Some(LocalDetails {
+                path: temp_dir.path().to_str().expect("Non-UTF8 path").to_string(),
+            }),
+            tables: vec![Table {
+                name: table_name,
+                prefix,
+                file_type: "parquet".to_string(),
+                extension: ".parquet".to_string(),
+            }],
+        };
+        let connector = ObjectStoreConnector::new(0, local_storage);
+
+        let (_, schema) = schema_to_arrow(schema);
+
+        Some((
+            Self {
+                _temp_dir: temp_dir,
+                connector,
+            },
+            schema,
+        ))
+    }
+
+    fn connector(&self) -> &Self::Connector {
+        &self.connector
+    }
+
+    fn start(&self) {}
+}

--- a/dozer-ingestion/tests/test_suite/connectors/object_store/mod.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/object_store/mod.rs
@@ -1,0 +1,3 @@
+mod local_storage;
+
+pub use local_storage::LocalStorageObjectStoreConnectorTest;

--- a/dozer-ingestion/tests/test_suite/data.rs
+++ b/dozer-ingestion/tests/test_suite/data.rs
@@ -1,0 +1,63 @@
+use dozer_types::types::{
+    Field, FieldDefinition, FieldType, Operation, Record, Schema, SchemaIdentifier,
+};
+
+pub fn append_only_operations_without_primary_key() -> (Schema, Vec<Operation>) {
+    let mut schema = Schema::empty();
+    schema.identifier = Some(SchemaIdentifier { id: 0, version: 0 });
+    schema.field(
+        FieldDefinition {
+            name: "uint".to_string(),
+            typ: FieldType::UInt,
+            nullable: false,
+            source: Default::default(),
+        },
+        false,
+    );
+
+    let operations = vec![Operation::Insert {
+        new: Record::new(schema.identifier, vec![Field::UInt(0)], None),
+    }];
+
+    (schema, operations)
+}
+
+pub fn append_only_operations_with_primary_key() -> (Schema, Vec<Operation>) {
+    let mut schema = Schema::empty();
+    schema.identifier = Some(SchemaIdentifier { id: 0, version: 0 });
+    schema.field(
+        FieldDefinition {
+            name: "uint".to_string(),
+            typ: FieldType::UInt,
+            nullable: false,
+            source: Default::default(),
+        },
+        true,
+    );
+
+    let operations = vec![Operation::Insert {
+        new: Record::new(schema.identifier, vec![Field::UInt(0)], None),
+    }];
+
+    (schema, operations)
+}
+
+pub fn all_kinds_of_operations() -> (Schema, Vec<Operation>) {
+    let mut schema = Schema::empty();
+    schema.identifier = Some(SchemaIdentifier { id: 0, version: 0 });
+    schema.field(
+        FieldDefinition {
+            name: "uint".to_string(),
+            typ: FieldType::UInt,
+            nullable: false,
+            source: Default::default(),
+        },
+        true,
+    );
+
+    let operations = vec![Operation::Insert {
+        new: Record::new(schema.identifier, vec![Field::UInt(0)], None),
+    }];
+
+    (schema, operations)
+}

--- a/dozer-ingestion/tests/test_suite/mod.rs
+++ b/dozer-ingestion/tests/test_suite/mod.rs
@@ -1,0 +1,33 @@
+use dozer_ingestion::connectors::Connector;
+use dozer_types::types::{Operation, Schema};
+
+pub trait ConnectorTest: Send + Sized + 'static {
+    type Connector: Connector;
+
+    /// Creates a connector which contains a table whose name is `table_name`.
+    ///
+    /// The test should try its best to create a table with the given `schema_name`, `table_name`, `schema` and `operations`.
+    /// If any of the field in `schema` is not supported, it can skip that field.
+    ///
+    /// If `schema_name` is not supported in this connector, or any operation cannot be applied to the table, `None` should be returned.
+    ///
+    /// The actual created schema should be returned.
+    fn new(
+        schema_name: Option<String>,
+        table_name: String,
+        schema: Schema,
+        operations: Vec<Operation>,
+    ) -> Option<(Self, Schema)>;
+
+    fn connector(&self) -> &Self::Connector;
+
+    /// Starts feeding data to the connector.
+    fn start(&self);
+}
+
+mod basic;
+mod connectors;
+mod data;
+
+pub use basic::run_test_suite_basic;
+pub use connectors::LocalStorageObjectStoreConnectorTest;

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -493,11 +493,14 @@ pub enum FieldType {
     Text,
     /// Raw bytes.
     Binary,
-    /// Decimal number.
+    /// `Decimal` represents a 128 bit representation of a fixed-precision decimal number.
+    /// The finite set of values of type `Decimal` are of the form m / 10<sup>e</sup>,
+    /// where m is an integer such that -2<sup>96</sup> < m < 2<sup>96</sup>, and e is an integer
+    /// between 0 and 28 inclusive.
     Decimal,
     /// Timestamp up to nanoseconds.
     Timestamp,
-    /// Date.
+    /// Allows for every date from Jan 1, 262145 BCE to Dec 31, 262143 CE.
     Date,
     /// Bytes that are valid BSON.
     Bson,


### PR DESCRIPTION
This PR adds the `basic` test suite for connectors and the test implementation of the `LocalStorage`.

The test data is only one `Insert` with one field now. It's yet to be extended.