### PR TITLE
test: Add `DataReadyConnectorTest` and implement `LocalStorage`

### DIFF
--- a/dozer-ingestion/src/connectors/grpc/connector.rs
+++ b/dozer-ingestion/src/connectors/grpc/connector.rs
@@ -161,7 +161,6 @@ where
                 .iter()
                 .any(|(name, _)| name == &table.name && table.schema.is_none())
             {
-                dbg!(&table);
                 return Err(ConnectorError::TableNotFound(table_name(
                     table.schema.as_deref(),
                     &table.name,

--- a/dozer-ingestion/tests/test_connectors.rs
+++ b/dozer-ingestion/tests/test_connectors.rs
@@ -1,9 +1,10 @@
-use test_suite::run_test_suite_basic;
+use test_suite::{run_test_suite_basic_data_ready, run_test_suite_basic_insert_only};
 
 #[test]
 fn test_connectors() {
     let _ = env_logger::builder().is_test(true).try_init();
-    run_test_suite_basic::<test_suite::LocalStorageObjectStoreConnectorTest>();
+    run_test_suite_basic_data_ready::<test_suite::LocalStorageObjectStoreConnectorTest>();
+    run_test_suite_basic_insert_only::<test_suite::LocalStorageObjectStoreConnectorTest>();
 }
 
 mod test_suite;

--- a/dozer-ingestion/tests/test_suite/connectors/arrow.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/arrow.rs
@@ -79,42 +79,43 @@ pub fn record_batch_with_all_supported_data_types() -> arrow::record_batch::Reco
         Field::new("date32_null", DataType::Date32, true),
         Field::new("date64", DataType::Date64, false),
         Field::new("date64_null", DataType::Date64, true),
-        Field::new("time32_second", DataType::Time32(TimeUnit::Second), false),
-        Field::new(
-            "time32_second_null",
-            DataType::Time32(TimeUnit::Second),
-            true,
-        ),
-        Field::new(
-            "time32_millisecond",
-            DataType::Time32(TimeUnit::Millisecond),
-            false,
-        ),
-        Field::new(
-            "time32_millisecond_null",
-            DataType::Time32(TimeUnit::Millisecond),
-            true,
-        ),
-        Field::new(
-            "time64_microsecond",
-            DataType::Time64(TimeUnit::Microsecond),
-            false,
-        ),
-        Field::new(
-            "time64_microsecond_null",
-            DataType::Time64(TimeUnit::Microsecond),
-            true,
-        ),
-        Field::new(
-            "time64_nanosecond",
-            DataType::Time64(TimeUnit::Nanosecond),
-            false,
-        ),
-        Field::new(
-            "time64_nanosecond_null",
-            DataType::Time64(TimeUnit::Nanosecond),
-            true,
-        ),
+        // TODO: uncomment when `Time32` conversion is fixed.
+        // Field::new("time32_second", DataType::Time32(TimeUnit::Second), false),
+        // Field::new(
+        //     "time32_second_null",
+        //     DataType::Time32(TimeUnit::Second),
+        //     true,
+        // ),
+        // Field::new(
+        //     "time32_millisecond",
+        //     DataType::Time32(TimeUnit::Millisecond),
+        //     false,
+        // ),
+        // Field::new(
+        //     "time32_millisecond_null",
+        //     DataType::Time32(TimeUnit::Millisecond),
+        //     true,
+        // ),
+        // Field::new(
+        //     "time64_microsecond",
+        //     DataType::Time64(TimeUnit::Microsecond),
+        //     false,
+        // ),
+        // Field::new(
+        //     "time64_microsecond_null",
+        //     DataType::Time64(TimeUnit::Microsecond),
+        //     true,
+        // ),
+        // Field::new(
+        //     "time64_nanosecond",
+        //     DataType::Time64(TimeUnit::Nanosecond),
+        //     false,
+        // ),
+        // Field::new(
+        //     "time64_nanosecond_null",
+        //     DataType::Time64(TimeUnit::Nanosecond),
+        //     true,
+        // ),
         // `Duration` not supported by parquet writer.
         // Field::new(
         //     "duration_second",
@@ -168,15 +169,15 @@ pub fn record_batch_with_all_supported_data_types() -> arrow::record_batch::Reco
         Field::new("large_binary_null", DataType::LargeBinary, true),
         Field::new("utf8", DataType::Utf8, false),
         Field::new("utf8_null", DataType::Utf8, true),
-        Field::new("large_utf8", DataType::LargeUtf8, false),
+        // TODO: uncomment when `LargeUtf8` conversion is fixed.
+        // Field::new("large_utf8", DataType::LargeUtf8, false),
         Field::new("large_utf8_null", DataType::LargeUtf8, true),
     ]);
 
     use arrow::array::{
         Array, BinaryArray, BooleanArray, Date32Array, Date64Array, FixedSizeBinaryArray,
         Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
-        LargeBinaryArray, LargeStringArray, StringArray, Time32MillisecondArray, Time32SecondArray,
-        Time64MicrosecondArray, Time64NanosecondArray, TimestampMicrosecondArray,
+        LargeBinaryArray, LargeStringArray, StringArray, TimestampMicrosecondArray,
         TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
         UInt32Array, UInt64Array, UInt8Array,
     };
@@ -218,14 +219,14 @@ pub fn record_batch_with_all_supported_data_types() -> arrow::record_batch::Reco
         Arc::new(Date32Array::from_iter([Some(0), None])),
         Arc::new(Date64Array::from_iter_values([0, 1])),
         Arc::new(Date64Array::from_iter([Some(0), None])),
-        Arc::new(Time32SecondArray::from_iter_values([0, 1])),
-        Arc::new(Time32SecondArray::from_iter([Some(0), None])),
-        Arc::new(Time32MillisecondArray::from_iter_values([0, 1])),
-        Arc::new(Time32MillisecondArray::from_iter([Some(0), None])),
-        Arc::new(Time64MicrosecondArray::from_iter_values([0, 1])),
-        Arc::new(Time64MicrosecondArray::from_iter([Some(0), None])),
-        Arc::new(Time64NanosecondArray::from_iter_values([0, 1])),
-        Arc::new(Time64NanosecondArray::from_iter([Some(0), None])),
+        // Arc::new(Time32SecondArray::from_iter_values([0, 1])),
+        // Arc::new(Time32SecondArray::from_iter([Some(0), None])),
+        // Arc::new(Time32MillisecondArray::from_iter_values([0, 1])),
+        // Arc::new(Time32MillisecondArray::from_iter([Some(0), None])),
+        // Arc::new(Time64MicrosecondArray::from_iter_values([0, 1])),
+        // Arc::new(Time64MicrosecondArray::from_iter([Some(0), None])),
+        // Arc::new(Time64NanosecondArray::from_iter_values([0, 1])),
+        // Arc::new(Time64NanosecondArray::from_iter([Some(0), None])),
         // Arc::new(DurationSecondArray::from_iter_values([0, 1])),
         // Arc::new(DurationSecondArray::from_iter([Some(0), None])),
         // Arc::new(DurationMillisecondArray::from_iter_values([0, 1])),
@@ -253,7 +254,7 @@ pub fn record_batch_with_all_supported_data_types() -> arrow::record_batch::Reco
         Arc::new(LargeBinaryArray::from_iter([Some([]), None])),
         Arc::new(StringArray::from_iter_values(["", "1"])),
         Arc::new(StringArray::from_iter([Some(""), None])),
-        Arc::new(LargeStringArray::from_iter_values(["", "1"])),
+        // Arc::new(LargeStringArray::from_iter_values(["", "1"])),
         Arc::new(LargeStringArray::from_iter([Some(""), None])),
     ];
 

--- a/dozer-ingestion/tests/test_suite/connectors/arrow.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/arrow.rs
@@ -3,8 +3,263 @@ use std::sync::Arc;
 use dozer_types::{
     arrow,
     chrono::Datelike,
-    types::{Field, FieldDefinition, FieldType, Operation, Record, Schema},
+    types::{Field, FieldDefinition, FieldType, Record, Schema},
 };
+
+pub fn record_batch_with_all_supported_data_types() -> arrow::record_batch::RecordBatch {
+    use arrow::datatypes::{DataType, Field, TimeUnit};
+
+    let schema = arrow::datatypes::Schema::new(vec![
+        Field::new("bool", DataType::Boolean, false),
+        Field::new("bool_null", DataType::Boolean, true),
+        Field::new("int8", DataType::Int8, false),
+        Field::new("int8_null", DataType::Int8, true),
+        Field::new("int16", DataType::Int16, false),
+        Field::new("int16_null", DataType::Int16, true),
+        Field::new("int32", DataType::Int32, false),
+        Field::new("int32_null", DataType::Int32, true),
+        Field::new("int64", DataType::Int64, false),
+        Field::new("int64_null", DataType::Int64, true),
+        Field::new("uint8", DataType::UInt8, false),
+        Field::new("uint8_null", DataType::UInt8, true),
+        Field::new("uint16", DataType::UInt16, false),
+        Field::new("uint16_null", DataType::UInt16, true),
+        Field::new("uint32", DataType::UInt32, false),
+        Field::new("uint32_null", DataType::UInt32, true),
+        Field::new("uint64", DataType::UInt64, false),
+        Field::new("uint64_null", DataType::UInt64, true),
+        // `Float16` not supported by parquet writer.
+        // Field::new("float16", DataType::Float16, false),
+        // Field::new("float16_null", DataType::Float16, true),
+        Field::new("float32", DataType::Float32, false),
+        Field::new("float32_null", DataType::Float32, true),
+        Field::new("float64", DataType::Float64, false),
+        Field::new("float64_null", DataType::Float64, true),
+        Field::new(
+            "timestamp_second",
+            DataType::Timestamp(TimeUnit::Second, None),
+            false,
+        ),
+        Field::new(
+            "timestamp_second_null",
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        ),
+        Field::new(
+            "timestamp_millisecond",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
+        Field::new(
+            "timestamp_millisecond_null",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            true,
+        ),
+        Field::new(
+            "timestamp_microsecond",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+        Field::new(
+            "timestamp_microsecond_null",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            true,
+        ),
+        Field::new(
+            "timestamp_nanosecond",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        ),
+        Field::new(
+            "timestamp_nanosecond_null",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        ),
+        Field::new("date32", DataType::Date32, false),
+        Field::new("date32_null", DataType::Date32, true),
+        Field::new("date64", DataType::Date64, false),
+        Field::new("date64_null", DataType::Date64, true),
+        Field::new("time32_second", DataType::Time32(TimeUnit::Second), false),
+        Field::new(
+            "time32_second_null",
+            DataType::Time32(TimeUnit::Second),
+            true,
+        ),
+        Field::new(
+            "time32_millisecond",
+            DataType::Time32(TimeUnit::Millisecond),
+            false,
+        ),
+        Field::new(
+            "time32_millisecond_null",
+            DataType::Time32(TimeUnit::Millisecond),
+            true,
+        ),
+        Field::new(
+            "time64_microsecond",
+            DataType::Time64(TimeUnit::Microsecond),
+            false,
+        ),
+        Field::new(
+            "time64_microsecond_null",
+            DataType::Time64(TimeUnit::Microsecond),
+            true,
+        ),
+        Field::new(
+            "time64_nanosecond",
+            DataType::Time64(TimeUnit::Nanosecond),
+            false,
+        ),
+        Field::new(
+            "time64_nanosecond_null",
+            DataType::Time64(TimeUnit::Nanosecond),
+            true,
+        ),
+        // `Duration` not supported by parquet writer.
+        // Field::new(
+        //     "duration_second",
+        //     DataType::Duration(TimeUnit::Second),
+        //     false,
+        // ),
+        // Field::new(
+        //     "duration_second_null",
+        //     DataType::Duration(TimeUnit::Second),
+        //     true,
+        // ),
+        // Field::new(
+        //     "duration_millisecond",
+        //     DataType::Duration(TimeUnit::Millisecond),
+        //     false,
+        // ),
+        // Field::new(
+        //     "duration_millisecond_null",
+        //     DataType::Duration(TimeUnit::Millisecond),
+        //     true,
+        // ),
+        // Field::new(
+        //     "duration_microsecond",
+        //     DataType::Duration(TimeUnit::Microsecond),
+        //     false,
+        // ),
+        // Field::new(
+        //     "duration_microsecond_null",
+        //     DataType::Duration(TimeUnit::Microsecond),
+        //     true,
+        // ),
+        // Field::new(
+        //     "duration_nanosecond",
+        //     DataType::Duration(TimeUnit::Nanosecond),
+        //     false,
+        // ),
+        // Field::new(
+        //     "duration_nanosecond_null",
+        //     DataType::Duration(TimeUnit::Nanosecond),
+        //     true,
+        // ),
+        Field::new("binary", DataType::Binary, false),
+        Field::new("binary_null", DataType::Binary, true),
+        Field::new("fixed_size_binary_1", DataType::FixedSizeBinary(1), false),
+        Field::new(
+            "fixed_size_binary_1_null",
+            DataType::FixedSizeBinary(1),
+            true,
+        ),
+        Field::new("large_binary", DataType::LargeBinary, false),
+        Field::new("large_binary_null", DataType::LargeBinary, true),
+        Field::new("utf8", DataType::Utf8, false),
+        Field::new("utf8_null", DataType::Utf8, true),
+        Field::new("large_utf8", DataType::LargeUtf8, false),
+        Field::new("large_utf8_null", DataType::LargeUtf8, true),
+    ]);
+
+    use arrow::array::{
+        Array, BinaryArray, BooleanArray, Date32Array, Date64Array, FixedSizeBinaryArray,
+        Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+        LargeBinaryArray, LargeStringArray, StringArray, Time32MillisecondArray, Time32SecondArray,
+        Time64MicrosecondArray, Time64NanosecondArray, TimestampMicrosecondArray,
+        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
+        UInt32Array, UInt64Array, UInt8Array,
+    };
+
+    let columns: Vec<Arc<dyn Array>> = vec![
+        Arc::new(BooleanArray::from_iter([Some(true), Some(false)])),
+        Arc::new(BooleanArray::from_iter([Some(true), None])),
+        Arc::new(Int8Array::from_iter_values([0, 1])),
+        Arc::new(Int8Array::from_iter([Some(0), None])),
+        Arc::new(Int16Array::from_iter_values([0, 1])),
+        Arc::new(Int16Array::from_iter([Some(0), None])),
+        Arc::new(Int32Array::from_iter_values([0, 1])),
+        Arc::new(Int32Array::from_iter([Some(0), None])),
+        Arc::new(Int64Array::from_iter_values([0, 1])),
+        Arc::new(Int64Array::from_iter([Some(0), None])),
+        Arc::new(UInt8Array::from_iter_values([0, 1])),
+        Arc::new(UInt8Array::from_iter([Some(0), None])),
+        Arc::new(UInt16Array::from_iter_values([0, 1])),
+        Arc::new(UInt16Array::from_iter([Some(0), None])),
+        Arc::new(UInt32Array::from_iter_values([0, 1])),
+        Arc::new(UInt32Array::from_iter([Some(0), None])),
+        Arc::new(UInt64Array::from_iter_values([0, 1])),
+        Arc::new(UInt64Array::from_iter([Some(0), None])),
+        // Arc::new(Float16Array::from_iter_values([0i8.into(), 1i8.into()])),
+        // Arc::new(Float16Array::from_iter([Some(0i8.into()), None])),
+        Arc::new(Float32Array::from_iter_values([0.0, 1.0])),
+        Arc::new(Float32Array::from_iter([Some(0.0), None])),
+        Arc::new(Float64Array::from_iter_values([0.0, 1.0])),
+        Arc::new(Float64Array::from_iter([Some(0.0), None])),
+        Arc::new(TimestampSecondArray::from_iter_values([0, 1])),
+        Arc::new(TimestampSecondArray::from_iter([Some(0), None])),
+        Arc::new(TimestampMillisecondArray::from_iter_values([0, 1])),
+        Arc::new(TimestampMillisecondArray::from_iter([Some(0), None])),
+        Arc::new(TimestampMicrosecondArray::from_iter_values([0, 1])),
+        Arc::new(TimestampMicrosecondArray::from_iter([Some(0), None])),
+        Arc::new(TimestampNanosecondArray::from_iter_values([0, 1])),
+        Arc::new(TimestampNanosecondArray::from_iter([Some(0), None])),
+        Arc::new(Date32Array::from_iter_values([0, 1])),
+        Arc::new(Date32Array::from_iter([Some(0), None])),
+        Arc::new(Date64Array::from_iter_values([0, 1])),
+        Arc::new(Date64Array::from_iter([Some(0), None])),
+        Arc::new(Time32SecondArray::from_iter_values([0, 1])),
+        Arc::new(Time32SecondArray::from_iter([Some(0), None])),
+        Arc::new(Time32MillisecondArray::from_iter_values([0, 1])),
+        Arc::new(Time32MillisecondArray::from_iter([Some(0), None])),
+        Arc::new(Time64MicrosecondArray::from_iter_values([0, 1])),
+        Arc::new(Time64MicrosecondArray::from_iter([Some(0), None])),
+        Arc::new(Time64NanosecondArray::from_iter_values([0, 1])),
+        Arc::new(Time64NanosecondArray::from_iter([Some(0), None])),
+        // Arc::new(DurationSecondArray::from_iter_values([0, 1])),
+        // Arc::new(DurationSecondArray::from_iter([Some(0), None])),
+        // Arc::new(DurationMillisecondArray::from_iter_values([0, 1])),
+        // Arc::new(DurationMillisecondArray::from_iter([Some(0), None])),
+        // Arc::new(DurationMicrosecondArray::from_iter_values([0, 1])),
+        // Arc::new(DurationMicrosecondArray::from_iter([Some(0), None])),
+        // Arc::new(DurationNanosecondArray::from_iter_values([0, 1])),
+        // Arc::new(DurationNanosecondArray::from_iter([Some(0), None])),
+        // Arc::new(IntervalMonthDayNanoArray::from_iter_values([0, 1])),
+        // Arc::new(IntervalMonthDayNanoArray::from_iter([Some(0), None])),
+        Arc::new(BinaryArray::from_iter_values([
+            [].as_slice(),
+            [1].as_slice(),
+        ])),
+        Arc::new(BinaryArray::from_iter([Some([]), None])),
+        Arc::new(FixedSizeBinaryArray::try_from_iter([[0], [1]].into_iter()).unwrap()),
+        Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size([Some([0]), None].into_iter(), 1)
+                .unwrap(),
+        ),
+        Arc::new(LargeBinaryArray::from_iter_values([
+            [].as_slice(),
+            [1].as_slice(),
+        ])),
+        Arc::new(LargeBinaryArray::from_iter([Some([]), None])),
+        Arc::new(StringArray::from_iter_values(["", "1"])),
+        Arc::new(StringArray::from_iter([Some(""), None])),
+        Arc::new(LargeStringArray::from_iter_values(["", "1"])),
+        Arc::new(LargeStringArray::from_iter([Some(""), None])),
+    ];
+
+    arrow::record_batch::RecordBatch::try_new(Arc::new(schema), columns)
+        .expect("BUG in record_batch_with_all_supported_data_types")
+}
 
 fn field_type_to_arrow(field_type: FieldType) -> Option<arrow::datatypes::DataType> {
     match field_type {
@@ -55,16 +310,16 @@ pub fn schema_to_arrow(schema: Schema) -> (arrow::datatypes::Schema, Schema) {
     (arrow_schema, schema)
 }
 
-fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
+fn fields_to_arrow<'a, F: IntoIterator<Item = &'a Field>>(
     fields: F,
     count: usize,
     field_type: FieldType,
-) -> Option<Arc<dyn arrow::array::Array>> {
-    Some(match field_type {
+) -> Arc<dyn arrow::array::Array> {
+    match field_type {
         FieldType::UInt => {
             let mut builder = arrow::array::UInt64Array::builder(count);
             for field in fields {
-                match field? {
+                match field {
                     Field::UInt(value) => builder.append_value(*value),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -75,7 +330,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::Int => {
             let mut builder = arrow::array::Int64Array::builder(count);
             for field in fields {
-                match field? {
+                match field {
                     Field::Int(value) => builder.append_value(*value),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -86,7 +341,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::Float => {
             let mut builder = arrow::array::Float64Array::builder(count);
             for field in fields {
-                match field? {
+                match field {
                     Field::Float(value) => builder.append_value(value.0),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -97,7 +352,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::Boolean => {
             let mut builder = arrow::array::BooleanArray::builder(count);
             for field in fields {
-                match field? {
+                match field {
                     Field::Boolean(value) => builder.append_value(*value),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -108,7 +363,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::String => {
             let mut builder = arrow::array::StringBuilder::new();
             for field in fields {
-                match field? {
+                match field {
                     Field::String(value) => builder.append_value(value),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -119,7 +374,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::Text => {
             let mut builder = arrow::array::LargeStringBuilder::new();
             for field in fields {
-                match field? {
+                match field {
                     Field::Text(value) => builder.append_value(value),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -130,7 +385,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::Binary => {
             let mut builder = arrow::array::LargeBinaryBuilder::new();
             for field in fields {
-                match field? {
+                match field {
                     Field::Binary(value) => builder.append_value(value),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -142,7 +397,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::Timestamp => {
             let mut builder = arrow::array::TimestampNanosecondArray::builder(count);
             for field in fields {
-                match field? {
+                match field {
                     Field::Timestamp(value) => builder.append_value(value.timestamp_nanos()),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -153,7 +408,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         FieldType::Date => {
             let mut builder = arrow::array::Date32Array::builder(count);
             for field in fields {
-                match field? {
+                match field {
                     Field::Date(value) => builder.append_value(value.num_days_from_ce()),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
@@ -163,50 +418,21 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = Option<&'a Field>>>(
         }
         FieldType::Bson => panic!("Bson not supported"),
         FieldType::Point => panic!("Point not supported"),
-    })
+    }
 }
 
-fn records_to_arrow<
-    'a,
-    I: Iterator<Item = Option<&'a Record>> + Clone,
-    R: IntoIterator<IntoIter = I>,
->(
-    records: R,
-    count: usize,
-    schema: Schema,
-) -> Option<arrow::record_batch::RecordBatch> {
-    let records = records.into_iter();
-
+pub fn records_to_arrow(records: &[Record], schema: Schema) -> arrow::record_batch::RecordBatch {
     let mut columns = vec![];
     for (index, field) in schema.fields.iter().enumerate() {
         if field_type_to_arrow(field.typ).is_some() {
-            let fields = records
-                .clone()
-                .map(|record| record.map(|record| &record.values[index]));
-            let column = fields_to_arrow(fields, count, field.typ);
-            columns.push(column?);
+            let fields = records.iter().map(|record| &record.values[index]);
+            let column = fields_to_arrow(fields, records.len(), field.typ);
+            columns.push(column);
         }
     }
 
     let (schema, _) = schema_to_arrow(schema);
 
-    Some(
-        arrow::record_batch::RecordBatch::try_new(Arc::new(schema), columns)
-            .expect("BUG in records_to_arrow"),
-    )
-}
-
-pub fn operations_to_arrow(
-    operations: &[Operation],
-    schema: Schema,
-) -> Option<arrow::record_batch::RecordBatch> {
-    let count = operations.len();
-    let records = operations.iter().map(|operation| {
-        if let Operation::Insert { new } = operation {
-            Some(new)
-        } else {
-            None
-        }
-    });
-    records_to_arrow(records, count, schema)
+    arrow::record_batch::RecordBatch::try_new(Arc::new(schema), columns)
+        .expect("BUG in records_to_arrow")
 }

--- a/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
@@ -1,64 +1,58 @@
 use dozer_ingestion::connectors::object_store::connector::ObjectStoreConnector;
 use dozer_types::{
+    arrow,
     ingestion_types::{LocalDetails, LocalStorage, Table},
-    types::{Operation, Schema},
+    types::{Record, Schema},
 };
 use tempdir::TempDir;
 
-use crate::test_suite::ConnectorTest;
+use crate::test_suite::{DataReadyConnectorTest, InsertOnlyConnectorTest};
 
-use super::super::arrow::{operations_to_arrow, schema_to_arrow};
+use super::super::arrow::{
+    record_batch_with_all_supported_data_types, records_to_arrow, schema_to_arrow,
+};
 
 pub struct LocalStorageObjectStoreConnectorTest {
     _temp_dir: TempDir,
     connector: ObjectStoreConnector<LocalStorage>,
 }
 
-impl ConnectorTest for LocalStorageObjectStoreConnectorTest {
+impl DataReadyConnectorTest for LocalStorageObjectStoreConnectorTest {
+    type Connector = ObjectStoreConnector<LocalStorage>;
+
+    fn new() -> Self {
+        let record_batch = record_batch_with_all_supported_data_types();
+        let (temp_dir, connector) = create_connector("sample".to_string(), &record_batch);
+        Self {
+            _temp_dir: temp_dir,
+            connector,
+        }
+    }
+
+    fn connector(&self) -> &Self::Connector {
+        &self.connector
+    }
+}
+
+impl InsertOnlyConnectorTest for LocalStorageObjectStoreConnectorTest {
     type Connector = ObjectStoreConnector<LocalStorage>;
 
     fn new(
         schema_name: Option<String>,
         table_name: String,
         schema: Schema,
-        operations: Vec<Operation>,
+        records: Vec<Record>,
     ) -> Option<(Self, Schema)> {
         if schema_name.is_some() {
             return None;
         }
+        if !schema.is_append_only() {
+            return None;
+        }
 
-        let record_batch = operations_to_arrow(&operations, schema.clone())?;
+        let record_batch = records_to_arrow(&records, schema.clone());
 
-        let temp_dir = TempDir::new("local").expect("Failed to create temp dir");
-        let path = temp_dir.path().join(&table_name);
-        std::fs::create_dir_all(&path).expect("Failed to create dir");
-
-        let file = std::fs::File::create(path.join("0.parquet")).expect("Failed to create file");
-        let props = parquet::file::properties::WriterProperties::builder().build();
-        let mut writer = parquet::arrow::arrow_writer::ArrowWriter::try_new(
-            file,
-            record_batch.schema(),
-            Some(props),
-        )
-        .expect("Failed to create writer");
-        writer
-            .write(&record_batch)
-            .expect("Failed to write record batch");
-        writer.close().expect("Failed to close writer");
-
-        let prefix = format!("/{table_name}");
-        let local_storage = LocalStorage {
-            details: Some(LocalDetails {
-                path: temp_dir.path().to_str().expect("Non-UTF8 path").to_string(),
-            }),
-            tables: vec![Table {
-                name: table_name,
-                prefix,
-                file_type: "parquet".to_string(),
-                extension: ".parquet".to_string(),
-            }],
-        };
-        let connector = ObjectStoreConnector::new(0, local_storage);
+        let (temp_dir, connector) = create_connector(table_name, &record_batch);
 
         let (_, schema) = schema_to_arrow(schema);
 
@@ -74,6 +68,42 @@ impl ConnectorTest for LocalStorageObjectStoreConnectorTest {
     fn connector(&self) -> &Self::Connector {
         &self.connector
     }
+}
 
-    fn start(&self) {}
+fn create_connector(
+    table_name: String,
+    record_batch: &arrow::record_batch::RecordBatch,
+) -> (TempDir, ObjectStoreConnector<LocalStorage>) {
+    let temp_dir = TempDir::new("local").expect("Failed to create temp dir");
+    let path = temp_dir.path().join(&table_name);
+    std::fs::create_dir_all(&path).expect("Failed to create dir");
+
+    let file = std::fs::File::create(path.join("0.parquet")).expect("Failed to create file");
+    let props = parquet::file::properties::WriterProperties::builder().build();
+    let mut writer = parquet::arrow::arrow_writer::ArrowWriter::try_new(
+        file,
+        record_batch.schema(),
+        Some(props),
+    )
+    .expect("Failed to create writer");
+    writer
+        .write(record_batch)
+        .expect("Failed to write record batch");
+    writer.close().expect("Failed to close writer");
+
+    let prefix = format!("/{table_name}");
+    let local_storage = LocalStorage {
+        details: Some(LocalDetails {
+            path: temp_dir.path().to_str().expect("Non-UTF8 path").to_string(),
+        }),
+        tables: vec![Table {
+            name: table_name,
+            prefix,
+            file_type: "parquet".to_string(),
+            extension: ".parquet".to_string(),
+        }],
+    };
+    let connector = ObjectStoreConnector::new(0, local_storage);
+
+    (temp_dir, connector)
 }

--- a/dozer-ingestion/tests/test_suite/data.rs
+++ b/dozer-ingestion/tests/test_suite/data.rs
@@ -1,8 +1,6 @@
-use dozer_types::types::{
-    Field, FieldDefinition, FieldType, Operation, Record, Schema, SchemaIdentifier,
-};
+use dozer_types::types::{Field, FieldDefinition, FieldType, Record, Schema, SchemaIdentifier};
 
-pub fn append_only_operations_without_primary_key() -> (Schema, Vec<Operation>) {
+pub fn records_without_primary_key() -> (Schema, Vec<Record>) {
     let mut schema = Schema::empty();
     schema.identifier = Some(SchemaIdentifier { id: 0, version: 0 });
     schema.field(
@@ -15,14 +13,12 @@ pub fn append_only_operations_without_primary_key() -> (Schema, Vec<Operation>) 
         false,
     );
 
-    let operations = vec![Operation::Insert {
-        new: Record::new(schema.identifier, vec![Field::UInt(0)], None),
-    }];
+    let records = vec![Record::new(schema.identifier, vec![Field::UInt(0)], None)];
 
-    (schema, operations)
+    (schema, records)
 }
 
-pub fn append_only_operations_with_primary_key() -> (Schema, Vec<Operation>) {
+pub fn records_with_primary_key() -> (Schema, Vec<Record>) {
     let mut schema = Schema::empty();
     schema.identifier = Some(SchemaIdentifier { id: 0, version: 0 });
     schema.field(
@@ -35,29 +31,7 @@ pub fn append_only_operations_with_primary_key() -> (Schema, Vec<Operation>) {
         true,
     );
 
-    let operations = vec![Operation::Insert {
-        new: Record::new(schema.identifier, vec![Field::UInt(0)], None),
-    }];
+    let records = vec![Record::new(schema.identifier, vec![Field::UInt(0)], None)];
 
-    (schema, operations)
-}
-
-pub fn all_kinds_of_operations() -> (Schema, Vec<Operation>) {
-    let mut schema = Schema::empty();
-    schema.identifier = Some(SchemaIdentifier { id: 0, version: 0 });
-    schema.field(
-        FieldDefinition {
-            name: "uint".to_string(),
-            typ: FieldType::UInt,
-            nullable: false,
-            source: Default::default(),
-        },
-        true,
-    );
-
-    let operations = vec![Operation::Insert {
-        new: Record::new(schema.identifier, vec![Field::UInt(0)], None),
-    }];
-
-    (schema, operations)
+    (schema, records)
 }

--- a/dozer-ingestion/tests/test_suite/mod.rs
+++ b/dozer-ingestion/tests/test_suite/mod.rs
@@ -1,33 +1,42 @@
 use dozer_ingestion::connectors::Connector;
-use dozer_types::types::{Operation, Schema};
+use dozer_types::types::{Operation, Record, Schema};
 
-pub trait ConnectorTest: Send + Sized + 'static {
+pub trait DataReadyConnectorTest: Send + Sized + 'static {
+    type Connector: Connector;
+
+    fn new() -> Self;
+
+    fn connector(&self) -> &Self::Connector;
+}
+
+pub trait InsertOnlyConnectorTest: Send + Sized + 'static {
     type Connector: Connector;
 
     /// Creates a connector which contains a table whose name is `table_name`.
     ///
-    /// The test should try its best to create a table with the given `schema_name`, `table_name`, `schema` and `operations`.
+    /// The test should try its best to create a table with the given `schema_name`, `table_name` and `schema`.
     /// If any of the field in `schema` is not supported, it can skip that field.
     ///
-    /// If `schema_name` is not supported in this connector, or any operation cannot be applied to the table, `None` should be returned.
+    /// If `schema_name` or `schema.primary_index` is not supported in this connector, `None` should be returned.
     ///
-    /// The actual created schema should be returned.
+    /// The actually created schema should be returned.
     fn new(
         schema_name: Option<String>,
         table_name: String,
         schema: Schema,
-        operations: Vec<Operation>,
+        records: Vec<Record>,
     ) -> Option<(Self, Schema)>;
 
     fn connector(&self) -> &Self::Connector;
+}
 
-    /// Starts feeding data to the connector.
-    fn start(&self);
+pub trait CrudConnectorTest: InsertOnlyConnectorTest {
+    fn start_crud(&self, operations: Vec<Operation>);
 }
 
 mod basic;
 mod connectors;
 mod data;
 
-pub use basic::run_test_suite_basic;
+pub use basic::{run_test_suite_basic_data_ready, run_test_suite_basic_insert_only};
 pub use connectors::LocalStorageObjectStoreConnectorTest;


### PR DESCRIPTION
This PR adds another connector test trait `DataReadyConnectorTest`, which requires the connector to setup data by itself, instead of using test suite generated data.

This serves the purpose of data type test. There's only one (or zero) way to map a dozer type to an external type, but many external types may be mapped to the same dozer type. `DataReadyConnectorTest` should generate such a database that every possible external data type is covered.

`LocalStorage` implements this trait and exposes two bugs. We've temporarily disabled checking the buggy data types so this PR can be merged.