### PR TITLE
chore: Remove unused `id` in `PostgresConnector`

### DIFF
--- a/dozer-ingestion/examples/postgres/main.rs
+++ b/dozer-ingestion/examples/postgres/main.rs
@@ -21,7 +21,7 @@ fn main() {
             .to_owned(),
     };
 
-    let connector = PostgresConnector::new(1, postgres_config);
+    let connector = PostgresConnector::new(postgres_config);
     let tables = connector
         .list_columns(vec![TableIdentifier::from_table_name("users".to_string())])
         .unwrap();

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -157,7 +157,7 @@ pub fn get_connector(connection: Connection) -> Result<Box<dyn Connector>, Conne
             if let Some(dbname) = postgres_config.config.get_dbname() {
                 debug!("Connecting to postgres database - {}", dbname.to_string());
             }
-            Ok(Box::new(PostgresConnector::new(1, postgres_config)))
+            Ok(Box::new(PostgresConnector::new(postgres_config)))
         }
         ConnectionConfig::Ethereum(eth_config) => match eth_config.provider.unwrap() {
             dozer_types::ingestion_types::EthProviderConfig::Log(log_config) => Ok(Box::new(

--- a/dozer-ingestion/src/connectors/postgres/connector.rs
+++ b/dozer-ingestion/src/connectors/postgres/connector.rs
@@ -25,7 +25,6 @@ pub struct PostgresConfig {
 
 #[derive(Debug)]
 pub struct PostgresConnector {
-    pub id: u64,
     name: String,
     replication_conn_config: Config,
     conn_config: Config,
@@ -39,7 +38,7 @@ pub struct ReplicationSlotInfo {
 }
 
 impl PostgresConnector {
-    pub fn new(id: u64, config: PostgresConfig) -> PostgresConnector {
+    pub fn new(config: PostgresConfig) -> PostgresConnector {
         let mut replication_conn_config = config.config.clone();
         replication_conn_config.replication_mode(ReplicationMode::Logical);
 
@@ -49,7 +48,6 @@ impl PostgresConnector {
         // conn_str_plain- conn_config
 
         PostgresConnector {
-            id,
             name: config.name,
             conn_config: config.config,
             replication_conn_config,
@@ -169,7 +167,6 @@ impl Connector for PostgresConnector {
             })
             .collect::<Vec<_>>();
         let iterator = PostgresIterator::new(
-            self.id,
             self.name.clone(),
             self.get_publication_name(),
             self.get_slot_name(),

--- a/dozer-ingestion/src/connectors/postgres/replicator.rs
+++ b/dozer-ingestion/src/connectors/postgres/replicator.rs
@@ -24,7 +24,6 @@ use super::xlog_mapper::MappedReplicationMessage;
 
 pub struct CDCHandler<'a> {
     pub name: String,
-    pub connector_id: u64,
     pub ingestor: &'a Ingestor,
 
     pub replication_conn_config: tokio_postgres::Config,

--- a/dozer-ingestion/src/connectors/postgres/snapshotter.rs
+++ b/dozer-ingestion/src/connectors/postgres/snapshotter.rs
@@ -22,7 +22,6 @@ use dozer_types::types::Operation;
 pub struct PostgresSnapshotter<'a> {
     pub conn_config: tokio_postgres::Config,
     pub ingestor: &'a Ingestor,
-    pub connector_id: u64,
 }
 
 impl<'a> PostgresSnapshotter<'a> {
@@ -143,9 +142,7 @@ mod tests {
     use crate::{
         connectors::{
             postgres::{
-                connection::helper::map_connection_config,
-                connector::{PostgresConfig, PostgresConnector},
-                tests::client::TestPostgresClient,
+                connection::helper::map_connection_config, tests::client::TestPostgresClient,
             },
             ListOrFilterColumns,
         },
@@ -173,19 +170,11 @@ mod tests {
 
             let mut rng = rand::thread_rng();
             let table_name = format!("test_table_{}", rng.gen::<u32>());
-            let connector_name = format!("pg_connector_{}", rng.gen::<u32>());
 
             test_client.create_simple_table("public", &table_name);
             test_client.insert_rows(&table_name, 2, None);
 
             let conn_config = map_connection_config(config).unwrap();
-
-            let postgres_config = PostgresConfig {
-                name: connector_name,
-                config: conn_config.clone(),
-            };
-
-            let connector = PostgresConnector::new(1, postgres_config);
 
             let input_tables = vec![ListOrFilterColumns {
                 name: table_name,
@@ -199,7 +188,6 @@ mod tests {
             let snapshotter = PostgresSnapshotter {
                 conn_config,
                 ingestor: &ingestor,
-                connector_id: connector.id,
             };
 
             let actual = snapshotter.sync_tables(&input_tables);
@@ -239,19 +227,11 @@ mod tests {
 
             let mut rng = rand::thread_rng();
             let table_name = format!("test_table_{}", rng.gen::<u32>());
-            let connector_name = format!("pg_connector_{}", rng.gen::<u32>());
 
             test_client.create_simple_table("public", &table_name);
             test_client.insert_rows(&table_name, 2, None);
 
             let conn_config = map_connection_config(config).unwrap();
-
-            let postgres_config = PostgresConfig {
-                name: connector_name,
-                config: conn_config.clone(),
-            };
-
-            let connector = PostgresConnector::new(1, postgres_config);
 
             let input_table_name = String::from("not_existing_table");
             let input_tables = vec![ListOrFilterColumns {
@@ -266,7 +246,6 @@ mod tests {
             let snapshotter = PostgresSnapshotter {
                 conn_config,
                 ingestor: &ingestor,
-                connector_id: connector.id,
             };
 
             let actual = snapshotter.sync_tables(&input_tables);
@@ -297,16 +276,8 @@ mod tests {
 
             let mut rng = rand::thread_rng();
             let table_name = format!("test_table_{}", rng.gen::<u32>());
-            let connector_name = format!("pg_connector_{}", rng.gen::<u32>());
 
             let conn_config = map_connection_config(config).unwrap();
-
-            let postgres_config = PostgresConfig {
-                name: connector_name,
-                config: conn_config.clone(),
-            };
-
-            let connector = PostgresConnector::new(1, postgres_config);
 
             let input_tables = vec![ListOrFilterColumns {
                 name: table_name,
@@ -320,7 +291,6 @@ mod tests {
             let snapshotter = PostgresSnapshotter {
                 conn_config,
                 ingestor: &ingestor,
-                connector_id: connector.id,
             };
 
             let actual = snapshotter.sync_tables(&input_tables);

--- a/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
@@ -37,7 +37,7 @@ mod tests {
                 config: conn_config.clone(),
             };
 
-            let connector = PostgresConnector::new(1, postgres_config);
+            let connector = PostgresConnector::new(postgres_config);
 
             // let result = connector.can_start_from((1, 0)).unwrap();
             // assert!(!result, "Cannot continue, because slot doesnt exist");
@@ -92,7 +92,7 @@ mod tests {
                 config: conn_config.clone(),
             };
 
-            let connector = PostgresConnector::new(1, postgres_config);
+            let connector = PostgresConnector::new(postgres_config);
 
             let mut replication_conn_config = conn_config;
             replication_conn_config.replication_mode(ReplicationMode::Logical);
@@ -122,7 +122,7 @@ mod tests {
             // assume that we already received two rows
             // let last_parsed_position = 2_u64;
             // thread::spawn(move || {
-            //     let connector = PostgresConnector::new(1, postgres_config);
+            //     let connector = PostgresConnector::new(postgres_config);
             //     let _ = connector.start(
             //         Some((u64::from(parsed_lsn), last_parsed_position)),
             //         &ingestor,


### PR DESCRIPTION
I was writing postgres tests and found this seemingly unused field.

Feel free to close the PR is it's actually useful.