### PR TITLE
chore: Check map size before creating lmdb environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,6 +2252,7 @@ dependencies = [
  "dozer-types",
  "lmdb-rkv",
  "lmdb-rkv-sys",
+ "page_size",
  "tempdir",
 ]
 
@@ -4310,6 +4311,16 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "page_size"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parity-scale-codec"

--- a/dozer-storage/Cargo.toml
+++ b/dozer-storage/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["getdozer/dozer-dev"]
 dozer-types = { path = "../dozer-types" }
 lmdb-rkv = "0.14.0"
 lmdb-rkv-sys = "0.11.2"
+page_size = "0.5.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-storage/src/errors.rs
+++ b/dozer-storage/src/errors.rs
@@ -5,8 +5,8 @@ use dozer_types::thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum StorageError {
-    #[error("Unable to open or create database at location: {0}")]
-    OpenOrCreateError(String),
+    #[error("Bad map size: {map_size}, must be a multiple of system page size, which is currently {page_size}")]
+    BadPageSize { map_size: usize, page_size: usize },
     #[error("Unable to deserialize type: {} - Reason: {}", typ, reason.to_string())]
     DeserializationError {
         typ: &'static str,
@@ -17,10 +17,6 @@ pub enum StorageError {
         typ: &'static str,
         reason: BoxedError,
     },
-    #[error("Invalid dataset: {0}")]
-    InvalidDatasetIdentifier(String),
-    #[error("Invalid key: {0}")]
-    InvalidKey(String),
     #[error("Invalid record")]
     InvalidRecord,
 

--- a/dozer-storage/src/lmdb_storage.rs
+++ b/dozer-storage/src/lmdb_storage.rs
@@ -94,6 +94,14 @@ impl LmdbEnvironmentManager {
         name: &str,
         options: LmdbEnvironmentOptions,
     ) -> Result<Self, StorageError> {
+        let page_size = page_size::get();
+        if options.max_map_sz == 0 || options.max_map_sz % page_size != 0 {
+            return Err(StorageError::BadPageSize {
+                map_size: options.max_map_sz,
+                page_size,
+            });
+        }
+
         let full_path = base_path.join(Path::new(name));
 
         let mut builder = Environment::new();


### PR DESCRIPTION
Lmdb map size must be a multiple of system page size, but it didn't check that.

Wrong map size may result in lmdb crash later, so we check before creating the environment.