### PR TITLE
perf: Put indexing thread pool to idle if indexes are up to date

### DIFF
--- a/dozer-api/src/grpc/common/tests/mod.rs
+++ b/dozer-api/src/grpc/common/tests/mod.rs
@@ -135,7 +135,6 @@ async fn test_grpc_common_get_fields() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_grpc_common_on_event() {
     // start fake internal pipeline
     let (sender_shutdown_internal, rx_internal) = oneshot::channel::<()>();

--- a/dozer-cache/src/cache/lmdb/cache/query/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/query/tests.rs
@@ -11,7 +11,7 @@ use dozer_types::{
 
 #[test]
 fn query_secondary_sorted_inverted() {
-    let (mut cache, mut indexing_thread_pool, schema, _) = create_cache(schema_1);
+    let (mut cache, indexing_thread_pool, schema, _) = create_cache(schema_1);
 
     let mut record = Record::new(
         schema.identifier,
@@ -26,7 +26,7 @@ fn query_secondary_sorted_inverted() {
     cache.insert(&mut record).unwrap();
     assert!(record.version.is_some());
     cache.commit().unwrap();
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     let filter = FilterExpression::And(vec![
         FilterExpression::Simple("a".to_string(), Operator::EQ, Value::from(1)),
@@ -48,7 +48,7 @@ fn query_secondary_sorted_inverted() {
 
 #[test]
 fn query_secondary_full_text() {
-    let (mut cache, mut indexing_thread_pool, schema, _) = create_cache(schema_full_text);
+    let (mut cache, indexing_thread_pool, schema, _) = create_cache(schema_full_text);
 
     let mut record = Record::new(
         schema.identifier,
@@ -62,7 +62,7 @@ fn query_secondary_full_text() {
     cache.insert(&mut record).unwrap();
     assert!(record.version.is_some());
     cache.commit().unwrap();
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     let filter = FilterExpression::Simple("foo".into(), Operator::Contains, "good".into());
 
@@ -83,7 +83,7 @@ fn query_secondary_full_text() {
 
 #[test]
 fn query_secondary_vars() {
-    let (mut cache, mut indexing_thread_pool, schema, _) = create_cache(schema_1);
+    let (mut cache, indexing_thread_pool, schema, _) = create_cache(schema_1);
 
     let items = vec![
         (1, Some("yuri".to_string()), Some(521)),
@@ -100,7 +100,7 @@ fn query_secondary_vars() {
         insert_rec_1(&mut cache, &schema, val);
     }
     cache.commit().unwrap();
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     test_query(json!({}), 8, &cache);
 
@@ -194,7 +194,7 @@ fn query_secondary_vars() {
 
 #[test]
 fn query_secondary_multi_indices() {
-    let (mut cache, mut indexing_thread_pool, schema, _) = create_cache(schema_multi_indices);
+    let (mut cache, indexing_thread_pool, schema, _) = create_cache(schema_multi_indices);
 
     for (id, text) in [
         (1, "apple ball cake dance"),
@@ -214,7 +214,7 @@ fn query_secondary_multi_indices() {
         assert!(record.version.is_some());
     }
     cache.commit().unwrap();
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     let query = query_from_filter(FilterExpression::And(vec![
         FilterExpression::Simple("id".into(), Operator::GT, Value::from(2)),

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_secondary_indexes() {
-        let (mut cache, mut indexing_thread_pool, schema, secondary_indexes) =
+        let (mut cache, indexing_thread_pool, schema, secondary_indexes) =
             create_cache(test_utils::schema_1);
 
         let items = vec![
@@ -117,7 +117,7 @@ mod tests {
             lmdb_utils::insert_rec_1(&mut cache, &schema, val);
         }
         cache.commit().unwrap();
-        indexing_thread_pool.wait_until_catchup();
+        indexing_thread_pool.lock().wait_until_catchup();
 
         // No of index dbs
         let index_counts = lmdb_utils::get_index_counts(&cache);
@@ -134,7 +134,7 @@ mod tests {
             cache.delete(&Field::Int(a).encode()).unwrap();
         }
         cache.commit().unwrap();
-        indexing_thread_pool.wait_until_catchup();
+        indexing_thread_pool.lock().wait_until_catchup();
 
         assert_eq!(
             lmdb_utils::get_index_counts(&cache)
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn test_full_text_secondary_index_with_duplicated_words() {
-        let (mut cache, mut indexing_thread_pool, schema, _) =
+        let (mut cache, indexing_thread_pool, schema, _) =
             create_cache(test_utils::schema_full_text);
 
         let items = vec![(
@@ -181,7 +181,7 @@ mod tests {
         }
 
         cache.commit().unwrap();
-        indexing_thread_pool.wait_until_catchup();
+        indexing_thread_pool.lock().wait_until_catchup();
 
         assert_eq!(
             lmdb_utils::get_index_counts(&cache)

--- a/dozer-cache/src/cache/lmdb/indexing.rs
+++ b/dozer-cache/src/cache/lmdb/indexing.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Barrier,
+    mpsc::{Receiver, Sender},
+    Arc,
 };
 
 use dozer_storage::LmdbEnvironment;
@@ -9,26 +9,26 @@ use dozer_types::{
     parking_lot::Mutex,
 };
 
-use crate::errors::CacheError;
+use crate::{cache::lmdb::cache::SecondaryEnvironment, errors::CacheError};
 
 use super::cache::{LmdbRoCache, MainEnvironment, RoMainEnvironment, RwSecondaryEnvironment};
 
 #[derive(Debug)]
 pub struct IndexingThreadPool {
-    num_threads: usize,
-    termination_barrier: Arc<Barrier>,
     caches: Vec<Cache>,
-    running: Running,
+    task_completion_sender: Sender<(usize, usize)>,
+    task_completion_receiver: Receiver<(usize, usize)>,
+    pool: rayon::ThreadPool,
 }
 
 impl IndexingThreadPool {
     pub fn new(num_threads: usize) -> Self {
-        let termination_barrier = Arc::new(Barrier::new(num_threads + 1));
+        let (sender, receiver) = std::sync::mpsc::channel();
         Self {
-            num_threads,
             caches: Vec::new(),
-            running: create_running(num_threads, termination_barrier.clone()),
-            termination_barrier,
+            task_completion_sender: sender,
+            task_completion_receiver: receiver,
+            pool: create_thread_pool(num_threads),
         }
     }
 
@@ -37,16 +37,19 @@ impl IndexingThreadPool {
         main_env: RoMainEnvironment,
         secondary_envs: Vec<RwSecondaryEnvironment>,
     ) {
+        let num_secondary_envs = secondary_envs.len();
         let secondary_envs = secondary_envs
             .into_iter()
-            .map(|env| Arc::new(Mutex::new(env)))
+            .map(|env| (Arc::new(Mutex::new(env)), false))
             .collect();
         let cache = Cache {
             main_env,
             secondary_envs,
         };
-        add_indexing_tasks(&mut self.running, &cache);
         self.caches.push(cache);
+        for secondary_index in 0..num_secondary_envs {
+            self.spawn_task_if_not_running(self.caches.len() - 1, secondary_index);
+        }
     }
 
     pub fn find_cache(&self, name: &str) -> Option<LmdbRoCache> {
@@ -55,7 +58,7 @@ impl IndexingThreadPool {
                 let secondary_envs = cache
                     .secondary_envs
                     .iter()
-                    .map(|env| env.lock().share())
+                    .map(|(env, _)| env.lock().share())
                     .collect();
                 return Some(LmdbRoCache {
                     main_env: cache.main_env.clone(),
@@ -66,113 +69,127 @@ impl IndexingThreadPool {
         None
     }
 
-    pub fn wait_until_catchup(&mut self) {
-        let running = std::mem::replace(
-            &mut self.running,
-            create_running(self.num_threads, self.termination_barrier.clone()),
-        );
-        drop(running);
-        self.termination_barrier.wait();
+    pub fn wake(&mut self, env_name: &str) {
+        self.refresh_task_state();
+        for index in 0..self.caches.len() {
+            let cache = &self.caches[index];
+            if cache.main_env.name() == env_name {
+                for secondary_index in 0..cache.secondary_envs.len() {
+                    self.spawn_task_if_not_running(index, secondary_index);
+                }
+            }
+        }
+    }
 
-        for cache in self.caches.iter() {
-            add_indexing_tasks(&mut self.running, cache);
+    pub fn wait_until_catchup(&mut self) {
+        while self
+            .caches
+            .iter()
+            .any(|cache| cache.secondary_envs.iter().any(|(_, running)| *running))
+        {
+            let (index, secondary_index) = self
+                .task_completion_receiver
+                .recv()
+                .expect("At least one sender is alive");
+            self.mark_not_running(index, secondary_index);
+        }
+    }
+
+    fn refresh_task_state(&mut self) {
+        while let Ok((index, secondary_index)) = self.task_completion_receiver.try_recv() {
+            self.mark_not_running(index, secondary_index);
+        }
+    }
+
+    fn mark_not_running(&mut self, index: usize, secondary_index: usize) {
+        let running = &mut self.caches[index].secondary_envs[secondary_index].1;
+        debug_assert!(*running);
+        *running = false;
+    }
+
+    fn spawn_task_if_not_running(&mut self, index: usize, secondary_index: usize) {
+        let cache = &mut self.caches[index];
+        let (secondary_env, running) = &mut cache.secondary_envs[secondary_index];
+        if !*running {
+            let main_env = cache.main_env.clone();
+            let secondary_env = secondary_env.clone();
+            let sender = self.task_completion_sender.clone();
+            self.pool.spawn(move || {
+                index_and_log_error(index, secondary_index, main_env, secondary_env, sender);
+            });
+            *running = true;
         }
     }
 }
 
-fn create_running(num_threads: usize, termination_barrier: Arc<Barrier>) -> Running {
-    Running::new(num_threads, move |_| {
-        termination_barrier.wait();
-    })
-}
-
-fn add_indexing_tasks(running: &mut Running, cache: &Cache) {
-    for secondary_env in &cache.secondary_envs {
-        running.add_indexing_task(cache.main_env.clone(), secondary_env.clone());
-    }
+fn create_thread_pool(num_threads: usize) -> rayon::ThreadPool {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .thread_name(|index| format!("indexing-thread-{}", index))
+        .build()
+        .unwrap()
 }
 
 #[derive(Debug, Clone)]
 struct Cache {
     main_env: RoMainEnvironment,
-    secondary_envs: Vec<Arc<Mutex<RwSecondaryEnvironment>>>,
-}
-
-#[derive(Debug)]
-struct Running {
-    inner: rayon::ThreadPool,
-    running: Arc<AtomicBool>,
-}
-
-impl Running {
-    fn new(num_threads: usize, exit_handler: impl Fn(usize) + Send + Sync + 'static) -> Self {
-        let inner = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_threads)
-            .thread_name(|index| format!("indexing-thread-{}", index))
-            .exit_handler(exit_handler)
-            .build()
-            .unwrap();
-
-        Self {
-            inner,
-            running: Arc::new(AtomicBool::new(true)),
-        }
-    }
-
-    fn add_indexing_task(
-        &self,
-        main_env: RoMainEnvironment,
-        secondary_env: Arc<Mutex<RwSecondaryEnvironment>>,
-    ) {
-        let running = self.running.clone();
-        self.inner
-            .spawn(move || index_and_log_error(main_env, secondary_env, running));
-    }
-}
-
-impl Drop for Running {
-    fn drop(&mut self) {
-        self.running.store(false, Ordering::SeqCst);
-    }
+    secondary_envs: Vec<(Arc<Mutex<RwSecondaryEnvironment>>, bool)>,
 }
 
 fn index_and_log_error(
+    index: usize,
+    secondary_index: usize,
     main_env: RoMainEnvironment,
     secondary_env: Arc<Mutex<RwSecondaryEnvironment>>,
-    running: Arc<AtomicBool>,
+    task_completion_sender: Sender<(usize, usize)>,
 ) {
+    // Loop until map full or up to date.
     loop {
         let mut secondary_env = secondary_env.lock();
 
-        // Run `index` for at least once before quitting.
-        if let Err(e) = index(&main_env, &mut secondary_env) {
-            debug!("Error while indexing {}: {e}", main_env.name());
-            if e.is_map_full() {
-                error!(
-                    "Cache {} has reached its maximum size. Try to increase `cache_max_map_size` in the config.",
-                    main_env.name()
+        match run_indexing(&main_env, &mut secondary_env) {
+            Ok(true) => {
+                break;
+            }
+            Ok(false) => {
+                debug!(
+                    "Some operation can't be read from {}: {:?}",
+                    main_env.name(),
+                    secondary_env.index_definition()
                 );
+                rayon::yield_local();
+                continue;
+            }
+            Err(e) => {
+                debug!("Error while indexing {}: {e}", main_env.name());
+                if e.is_map_full() {
+                    error!(
+                        "Cache {} has reached its maximum size. Try to increase `cache_max_map_size` in the config.",
+                        main_env.name()
+                    );
+                    break;
+                }
             }
         }
-
-        if !running.load(Ordering::SeqCst) {
-            break;
-        }
-
-        rayon::yield_local();
+    }
+    if task_completion_sender
+        .send((index, secondary_index))
+        .is_err()
+    {
+        error!("`IndexingThreadPool` dropped while indexing task is running");
     }
 }
 
-fn index(
+fn run_indexing(
     main_env: &RoMainEnvironment,
     secondary_env: &mut RwSecondaryEnvironment,
-) -> Result<(), CacheError> {
+) -> Result<bool, CacheError> {
     let txn = main_env.begin_txn()?;
 
     let span = dozer_types::tracing::span!(dozer_types::tracing::Level::TRACE, "build_indexes",);
     let _enter = span.enter();
 
-    secondary_env.index(&txn, main_env.operation_log())?;
+    let result = secondary_env.index(&txn, main_env.operation_log())?;
     secondary_env.commit()?;
-    Ok(())
+    Ok(result)
 }

--- a/dozer-cache/src/cache/lmdb/tests/basic.rs
+++ b/dozer-cache/src/cache/lmdb/tests/basic.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::cache::{
     expression::{self, FilterExpression, QueryExpression, Skip},
     index,
@@ -6,18 +8,19 @@ use crate::cache::{
     RoCache, RwCache,
 };
 use dozer_types::{
+    parking_lot::Mutex,
     serde_json::Value,
     types::{Field, Record, Schema},
 };
 
 use super::utils::create_cache;
 
-fn _setup() -> (LmdbRwCache, IndexingThreadPool, Schema) {
+fn _setup() -> (LmdbRwCache, Arc<Mutex<IndexingThreadPool>>, Schema) {
     let (cache, indexing_thread_pool, schema, _) = create_cache(test_utils::schema_0);
     (cache, indexing_thread_pool, schema)
 }
 
-fn _setup_empty_primary_index() -> (LmdbRwCache, IndexingThreadPool, Schema) {
+fn _setup_empty_primary_index() -> (LmdbRwCache, Arc<Mutex<IndexingThreadPool>>, Schema) {
     let (cache, indexing_thread_pool, schema, _) =
         create_cache(test_utils::schema_empty_primary_index);
     (cache, indexing_thread_pool, schema)
@@ -39,14 +42,14 @@ fn get_schema() {
 #[test]
 fn insert_get_and_delete_record() {
     let val = "bar".to_string();
-    let (mut cache, mut indexing_thread_pool, schema) = _setup();
+    let (mut cache, indexing_thread_pool, schema) = _setup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 0);
 
     let mut record = Record::new(schema.identifier, vec![Field::String(val.clone())], None);
     cache.insert(&mut record).unwrap();
     cache.commit().unwrap();
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 1);
 
@@ -59,7 +62,7 @@ fn insert_get_and_delete_record() {
 
     assert_eq!(cache.delete(&key).unwrap(), version);
     cache.commit().unwrap();
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 0);
 
@@ -93,7 +96,7 @@ fn insert_and_update_record() {
 
 fn insert_and_query_record_impl(
     mut cache: LmdbRwCache,
-    mut indexing_thread_pool: IndexingThreadPool,
+    indexing_thread_pool: Arc<Mutex<IndexingThreadPool>>,
     schema: Schema,
 ) {
     let val = "bar".to_string();
@@ -101,7 +104,7 @@ fn insert_and_query_record_impl(
 
     cache.insert(&mut record).unwrap();
     cache.commit().unwrap();
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     // Query with an expression
     let exp = query_from_filter(FilterExpression::Simple(

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use crate::cache::expression::{FilterExpression, Operator, QueryExpression};
 use crate::cache::lmdb::cache::{CacheOptions, LmdbRoCache, LmdbRwCache};
 use crate::cache::lmdb::indexing::IndexingThreadPool;
 use crate::cache::{lmdb::tests::utils as lmdb_utils, test_utils, RoCache, RwCache};
 use dozer_types::models::api_endpoint::ConflictResolution;
+use dozer_types::parking_lot::Mutex;
 use dozer_types::serde_json::Value;
 use dozer_types::types::Field;
 use tempdir::TempDir;
@@ -15,17 +18,17 @@ fn read_and_write() {
     // write and read from cache from two different threads.
 
     let schema = test_utils::schema_1();
-    let mut indexing_thread_pool = IndexingThreadPool::new(1);
+    let indexing_thread_pool = Arc::new(Mutex::new(IndexingThreadPool::new(1)));
     let mut cache_writer = LmdbRwCache::new(
         Some(&schema),
         &CacheOptions {
-            max_readers: 1,
+            max_readers: 2,
             max_db_size: 100,
             max_size: 1024 * 1024,
             path: Some(path.clone()),
             intersection_chunk_size: 1,
         },
-        &mut indexing_thread_pool,
+        indexing_thread_pool.clone(),
         ConflictResolution::default(),
     )
     .unwrap();
@@ -42,7 +45,7 @@ fn read_and_write() {
     }
     cache_writer.commit().unwrap();
 
-    indexing_thread_pool.wait_until_catchup();
+    indexing_thread_pool.lock().wait_until_catchup();
 
     let read_options = CacheOptions {
         path: Some(path),

--- a/dozer-storage/src/tests/lmdb_sys.rs
+++ b/dozer-storage/src/tests/lmdb_sys.rs
@@ -13,9 +13,7 @@ fn create_env() -> (Environment, Database) {
     fs::create_dir(tmp_dir.path()).unwrap();
 
     let mut builder = Environment::new();
-    builder.set_flags(
-        EnvironmentFlags::NO_SYNC | EnvironmentFlags::NO_LOCK | EnvironmentFlags::NO_TLS,
-    );
+    builder.set_flags(EnvironmentFlags::NO_SYNC | EnvironmentFlags::NO_TLS);
     builder.set_max_dbs(10);
     builder.set_max_readers(10);
     builder.set_map_size(1024 * 1024 * 1024);


### PR DESCRIPTION
The indexing threads used to be looping even if there's nothing to index.

This PR fixes that. Now the indexing threads will go idle if secondary indexes are up to date. The main database commit will wake up the indexing threads.

Part of #1285 