### PR TITLE
chore: Remove unused spin loop in `run_all`. Sleep in spin loop of api thread.

### DIFF
--- a/dozer-orchestrator/src/main.rs
+++ b/dozer-orchestrator/src/main.rs
@@ -9,6 +9,7 @@ use dozer_types::tracing::{error, info};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use std::{process, thread};
 
 fn main() {
@@ -74,7 +75,10 @@ fn run() -> Result<(), OrchestrationError> {
                             std::panic::panic_any(e);
                         }
                     });
-                    while running.load(Ordering::SeqCst) {}
+                    // HACK: until we do api thread graceful shutdown, spin on the running flag.
+                    while running.load(Ordering::SeqCst) {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
                     Ok(())
                 }
                 ApiCommands::GenerateToken => {


### PR DESCRIPTION
Fixes #1285 

Two different CPU usage problem.

In `dozer`, there's an unnecessary `while` loop before joining the pipeline thread. Joining is already blocking.

In `dozer api run`, there's a `while` hack because api server doesn't respect `running` flag. We put a `sleep` in the loop.