### PR TITLE
chore: Round `cache_max_map_size` to multiple of page size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
  "futures",
  "handlebars",
  "include_dir",
+ "page_size",
  "rustyline",
  "rustyline-derive",
  "serde",

--- a/dozer-orchestrator/Cargo.toml
+++ b/dozer-orchestrator/Cargo.toml
@@ -34,6 +34,7 @@ rustyline-derive = "0.8.0"
 crossterm = "0.26.0"
 futures = "0.3.26"
 dozer-storage = { path = "../dozer-storage" }
+page_size = "0.5.0"
 
 [[bin]]
 edition = "2021"

--- a/dozer-orchestrator/src/cli/helper.rs
+++ b/dozer-orchestrator/src/cli/helper.rs
@@ -2,13 +2,21 @@ use crate::errors::OrchestrationError;
 use crate::simple::SimpleOrchestrator as Dozer;
 use crate::{errors::CliError, Orchestrator};
 
+use dozer_types::models::app_config::default_cache_max_map_size;
 use dozer_types::prettytable::{row, Table};
 use dozer_types::{models::app_config::Config, serde_yaml};
 use handlebars::Handlebars;
 use std::{collections::BTreeMap, fs};
 
 pub fn init_dozer(config_path: String) -> Result<Dozer, CliError> {
-    let config = load_config(config_path)?;
+    let mut config = load_config(config_path)?;
+
+    let cache_max_map_size = config
+        .cache_max_map_size
+        .unwrap_or_else(default_cache_max_map_size);
+    let page_size = page_size::get() as u64;
+    config.cache_max_map_size = Some(cache_max_map_size / page_size * page_size);
+
     Ok(Dozer::new(config))
 }
 

--- a/dozer-orchestrator/src/main.rs
+++ b/dozer-orchestrator/src/main.rs
@@ -106,7 +106,6 @@ fn run() -> Result<(), OrchestrationError> {
     } else {
         render_logo();
 
-        let mut dozer = init_dozer(cli.config_path)?;
         dozer.run_all(running)
     }
 }


### PR DESCRIPTION
Use experience is better this way. They can use arbitrary `max_cache_map_size` instead of calculating multiple of `4096` or `16384`.