### PR TITLE
chore: include env variables in cache benchmark

### DIFF
--- a/dozer-api/src/errors.rs
+++ b/dozer-api/src/errors.rs
@@ -29,7 +29,7 @@ pub enum ApiError {
     NotFound(#[source] CacheError),
     #[error("Failed to count records")]
     CountFailed(#[source] CacheError),
-    #[error("Failed to query cache")]
+    #[error("Failed to query cache: {0}")]
     QueryFailed(#[source] CacheError),
     #[error("Internal error: {0}")]
     InternalError(#[from] BoxedError),

--- a/dozer-api/src/rest/api_generator.rs
+++ b/dozer-api/src/rest/api_generator.rs
@@ -8,7 +8,7 @@ use dozer_cache::CacheReader;
 use dozer_types::chrono::SecondsFormat;
 use dozer_types::errors::types::TypeError;
 use dozer_types::indexmap::IndexMap;
-use dozer_types::log::info;
+use dozer_types::log::warn;
 use dozer_types::models::api_endpoint::ApiEndpoint;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::types::{Field, Schema, DATE_FORMAT};
@@ -86,7 +86,7 @@ pub async fn list(
         Err(e) => match e {
             ApiError::QueryFailed(_) => {
                 let res: Vec<String> = vec![];
-                info!("No records found.");
+                warn!("No records found.");
                 Ok(HttpResponse::Ok().json(res))
             }
             _ => Err(ApiError::InternalError(Box::new(e))),

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -46,7 +46,7 @@ fn cache(c: &mut Criterion) {
     let commit_size = std::env::var("CACHE_BENCH_COMMIT_SIZE").unwrap_or("".to_string());
     let commit_size: usize = commit_size.parse().unwrap_or(1000);
 
-    let max_size = std::env::var("CACHE_BENCH_COMMIT_SIZE").unwrap_or("".to_string());
+    let max_size = std::env::var("CACHE_BENCH_MAP_SIZE").unwrap_or("".to_string());
     let max_size: usize = max_size.parse().unwrap_or(49999872000);
 
     let cache_manager = LmdbRwCacheManager::new(CacheManagerOptions {

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -1,36 +1,26 @@
+use std::path::Path;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use dozer_cache::cache::expression::{self, FilterExpression, QueryExpression, Skip};
-use dozer_cache::cache::{index, test_utils, LmdbRwCacheManager, RwCache, RwCacheManager};
+use dozer_cache::cache::{
+    test_utils, CacheManagerOptions, LmdbRwCacheManager, RwCache, RwCacheManager,
+};
 use dozer_types::models::api_endpoint::ConflictResolution;
 use dozer_types::parking_lot::Mutex;
 use dozer_types::serde_json::Value;
 use dozer_types::types::{Field, Record, Schema};
 
-fn insert(cache: &Mutex<Box<dyn RwCache>>, schema: &Schema, n: usize) {
+fn insert(cache: &Mutex<Box<dyn RwCache>>, schema: &Schema, n: usize, commit_size: usize) {
     let mut cache = cache.lock();
 
     let val = format!("bar_{n}");
-
     let mut record = Record::new(schema.identifier, vec![Field::String(val.clone())], None);
 
     cache.insert(&mut record).unwrap();
-    let key = index::get_primary_key(&[0], &[Field::String(val)]);
 
-    let _get_record = cache.get(&key).unwrap();
-}
-
-fn delete(cache: &Mutex<Box<dyn RwCache>>, n: usize) {
-    let mut cache = cache.lock();
-    let val = format!("bar_{n}");
-    let key = index::get_primary_key(&[0], &[Field::String(val)]);
-    let _ = cache.delete(&key);
-}
-
-fn get(cache: &Mutex<Box<dyn RwCache>>, n: usize) {
-    let cache = cache.lock();
-    let val = format!("bar_{n}");
-    let key = index::get_primary_key(&[0], &[Field::String(val)]);
-    let _get_record = cache.get(&key).unwrap();
+    if n % commit_size == 0 {
+        cache.commit().unwrap();
+    }
 }
 
 fn query(cache: &Mutex<Box<dyn RwCache>>, _n: usize) {
@@ -51,7 +41,21 @@ fn query(cache: &Mutex<Box<dyn RwCache>>, _n: usize) {
 
 fn cache(c: &mut Criterion) {
     let (schema, secondary_indexes) = test_utils::schema_0();
-    let cache_manager = LmdbRwCacheManager::new(Default::default()).unwrap();
+
+    let path = std::env::var("CACHE_BENCH_PATH").unwrap_or(".dozer".to_string());
+    let commit_size = std::env::var("CACHE_BENCH_COMMIT_SIZE").unwrap_or("".to_string());
+    let commit_size: usize = commit_size.parse().unwrap_or(1000);
+
+    let max_size = std::env::var("CACHE_BENCH_COMMIT_SIZE").unwrap_or("".to_string());
+    let max_size: usize = max_size.parse().unwrap_or(49999872000);
+
+    let cache_manager = LmdbRwCacheManager::new(CacheManagerOptions {
+        max_db_size: 1000,
+        max_size,
+        path: Some(Path::new(&path).to_path_buf()),
+        ..Default::default()
+    })
+    .unwrap();
     let cache = Mutex::new(
         cache_manager
             .create_cache(
@@ -63,17 +67,11 @@ fn cache(c: &mut Criterion) {
     );
 
     let size: usize = 1000000;
-    c.bench_with_input(BenchmarkId::new("cache_insert", size), &size, |b, &s| {
-        b.iter_batched(
-            || delete(&cache, s),
-            |_| insert(&cache, &schema, s),
-            criterion::BatchSize::NumIterations(1),
-        )
-    });
-
-    c.bench_with_input(BenchmarkId::new("cache_get", size), &size, |b, &s| {
+    let mut idx = 0;
+    c.bench_with_input(BenchmarkId::new("cache_insert", size), &size, |b, &_s| {
         b.iter(|| {
-            get(&cache, s);
+            insert(&cache, &schema, idx, commit_size);
+            idx += 1;
         })
     });
 

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -66,18 +66,26 @@ fn cache(c: &mut Criterion) {
             .unwrap(),
     );
 
-    let size: usize = 1000000;
-    let mut idx = 0;
-    c.bench_with_input(BenchmarkId::new("cache_insert", size), &size, |b, &_s| {
-        b.iter(|| {
-            insert(&cache, &schema, idx, commit_size);
-            idx += 1;
-        })
-    });
+    let iterations = std::env::var("CACHE_BENCH_ITERATIONS").unwrap_or("".to_string());
+    let iterations: usize = iterations.parse().unwrap_or(1000000);
 
-    c.bench_with_input(BenchmarkId::new("cache_query", size), &size, |b, &s| {
-        b.iter(|| query(&cache, s))
-    });
+    let mut idx = 0;
+    c.bench_with_input(
+        BenchmarkId::new("cache_insert", iterations),
+        &iterations,
+        |b, &_s| {
+            b.iter(|| {
+                insert(&cache, &schema, idx, commit_size);
+                idx += 1;
+            })
+        },
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("cache_query", iterations),
+        &iterations,
+        |b, &s| b.iter(|| query(&cache, s)),
+    );
 }
 
 criterion_group!(benches, cache);


### PR DESCRIPTION
Support for env variables in the bench script so it could be tuned without changing code. 