### PR TITLE
perf: Use `MDB_APPEND` when possible

### DIFF
--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/mod.rs
@@ -231,13 +231,11 @@ impl OperationLog {
 
         record.version = Some(record_version);
         // Record operation. The operation id must not exist.
-        if !self.operation_id_to_operation.insert(
+        self.operation_id_to_operation.append(
             txn,
             &operation_id,
             OperationBorrow::Insert { record_id, record },
-        )? {
-            panic!("Inconsistent state: operation id already exists");
-        }
+        )?;
         Ok(Some(record_id))
     }
 
@@ -287,15 +285,13 @@ impl OperationLog {
         // Generate new operation id.
         let operation_id = self.next_operation_id.fetch_add(txn, 1)?;
         // Record delete operation. The operation id must not exist.
-        if !self.operation_id_to_operation.insert(
+        self.operation_id_to_operation.append(
             txn,
             &operation_id,
             OperationBorrow::Delete {
                 operation_id: insert_operation_id,
             },
-        )? {
-            panic!("Inconsistent state: operation id already exists");
-        }
+        )?;
         Ok(Some(metadata.version))
     }
 }

--- a/dozer-types/src/borrow/mod.rs
+++ b/dozer-types/src/borrow/mod.rs
@@ -77,6 +77,7 @@ macro_rules! impl_borrow_for_clone_type {
 
 impl_borrow_for_clone_type!(u8, u32, u64, Record, IndexDefinition, SchemaWithIndex);
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Cow<'a, B: Borrow + 'a> {
     Borrowed(B::Borrowed<'a>),
     Owned(B),


### PR DESCRIPTION
Closes #1215 

# Testing method

With config file:

```yaml
connections:    
  - config : !LocalStorage
      details:
        path: data
      tables:
        - !Table
          name: trips
          prefix: /trips
          file_type: parquet
          extension: .parquet
    name: ny_taxi

endpoints:
  - name: trips
    path: /trips
    table_name: trips

cache_max_map_size: 10000000000
```

and data from `dozer-samples-connectors-local-storage` e2e test.

Comment https://github.com/getdozer/dozer/blob/main/dozer-api/src/cache_builder/log_reader.rs#L73.

```bash
dozer migrate
dozer app run
```

`time cargo run -- release dozer -- api run`

Hit Ctrl + C when counter reaches 3_000_000.

# Before

```text
cargo run --release -- api run  168.85s user 13.52s system 264% cpu 1:09.03 total
```

# After

```text
cargo run --release -- api run  64.95s user 0.91s system 464% cpu 14.188 total
```

5x speed up.