### PR TITLE
feat: `Duration` for sql representation + aggregation support

### DIFF
--- a/dozer-sql/src/pipeline/aggregation/avg.rs
+++ b/dozer-sql/src/pipeline/aggregation/avg.rs
@@ -25,6 +25,7 @@ pub fn validate_avg(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
         FieldType::I128 => FieldType::Decimal,
         FieldType::Float => FieldType::Float,
         FieldType::Decimal => FieldType::Decimal,
+        FieldType::Duration => FieldType::Duration,
         FieldType::Boolean
         | FieldType::String
         | FieldType::Text
@@ -32,8 +33,7 @@ pub fn validate_avg(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
         | FieldType::Timestamp
         | FieldType::Binary
         | FieldType::Bson
-        | FieldType::Point
-        | FieldType::Duration => {
+        | FieldType::Point => {
             return Err(PipelineError::InvalidFunctionArgumentType(
                 Avg.to_string(),
                 arg.return_type,
@@ -44,6 +44,7 @@ pub fn validate_avg(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
                     FieldType::I128,
                     FieldType::Float,
                     FieldType::Decimal,
+                    FieldType::Duration,
                 ]),
                 0,
             ));

--- a/dozer-sql/src/pipeline/aggregation/avg.rs
+++ b/dozer-sql/src/pipeline/aggregation/avg.rs
@@ -194,9 +194,9 @@ fn get_average(
                 if *current_count == 0 {
                     return Ok(Field::Null);
                 }
-                let str_dur = sum.to_duration().unwrap().to_string();
+                let str_dur = sum.to_duration()?.unwrap().to_string();
                 let d_sum = sum
-                    .to_duration()
+                    .to_duration()?
                     .ok_or(InvalidValue(str_dur.clone()))
                     .unwrap();
 

--- a/dozer-sql/src/pipeline/aggregation/count.rs
+++ b/dozer-sql/src/pipeline/aggregation/count.rs
@@ -70,6 +70,7 @@ fn get_count(count: u64, return_type: Option<FieldType>) -> Result<Field, Pipeli
                 Count,
                 FieldType::Decimal
             ))),
+            FieldType::Duration => Ok(Field::Int(count as i64)),
             FieldType::Boolean
             | FieldType::String
             | FieldType::Text
@@ -77,10 +78,9 @@ fn get_count(count: u64, return_type: Option<FieldType>) -> Result<Field, Pipeli
             | FieldType::Timestamp
             | FieldType::Binary
             | FieldType::Bson
-            | FieldType::Point
-            | FieldType::Duration => Err(PipelineError::InternalExecutionError(InvalidType(
-                format!("Not supported return type {typ} for {Count}"),
-            ))),
+            | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+                "Not supported return type {typ} for {Count}"
+            )))),
         },
         None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
             "Not supported None return type for {Count}"

--- a/dozer-sql/src/pipeline/aggregation/max.rs
+++ b/dozer-sql/src/pipeline/aggregation/max.rs
@@ -21,13 +21,13 @@ pub fn validate_max(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
         FieldType::Decimal => FieldType::Decimal,
         FieldType::Timestamp => FieldType::Timestamp,
         FieldType::Date => FieldType::Date,
+        FieldType::Duration => FieldType::Duration,
         FieldType::Boolean
         | FieldType::String
         | FieldType::Text
         | FieldType::Binary
         | FieldType::Bson
-        | FieldType::Point
-        | FieldType::Duration => {
+        | FieldType::Point => {
             return Err(PipelineError::InvalidFunctionArgumentType(
                 Max.to_string(),
                 arg.return_type,
@@ -40,6 +40,7 @@ pub fn validate_max(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
                     FieldType::Float,
                     FieldType::Timestamp,
                     FieldType::Date,
+                    FieldType::Duration,
                 ]),
                 0,
             ));

--- a/dozer-sql/src/pipeline/aggregation/max.rs
+++ b/dozer-sql/src/pipeline/aggregation/max.rs
@@ -120,13 +120,17 @@ fn get_max(
                     val
                 ))),
                 FieldType::Date => Ok(Field::Date(calculate_err_field!(val.to_date()?, Max, val))),
+                FieldType::Duration => Ok(Field::Duration(calculate_err_field!(
+                    val.to_duration()?,
+                    Max,
+                    val
+                ))),
                 FieldType::Boolean
                 | FieldType::String
                 | FieldType::Text
                 | FieldType::Binary
                 | FieldType::Bson
-                | FieldType::Point
-                | FieldType::Duration => Err(PipelineError::InternalExecutionError(InvalidType(
+                | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(
                     format!("Not supported return type {typ} for {Max}"),
                 ))),
             },

--- a/dozer-sql/src/pipeline/aggregation/min.rs
+++ b/dozer-sql/src/pipeline/aggregation/min.rs
@@ -120,13 +120,17 @@ fn get_min(
                     val
                 ))),
                 FieldType::Date => Ok(Field::Date(calculate_err_field!(val.to_date()?, Min, val))),
+                FieldType::Duration => Ok(Field::Duration(calculate_err_field!(
+                    val.to_duration()?,
+                    Min,
+                    val
+                ))),
                 FieldType::Boolean
                 | FieldType::String
                 | FieldType::Text
                 | FieldType::Binary
                 | FieldType::Bson
-                | FieldType::Point
-                | FieldType::Duration => Err(PipelineError::InternalExecutionError(InvalidType(
+                | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(
                     format!("Not supported return type {typ} for {Min}"),
                 ))),
             },

--- a/dozer-sql/src/pipeline/aggregation/min.rs
+++ b/dozer-sql/src/pipeline/aggregation/min.rs
@@ -21,13 +21,13 @@ pub fn validate_min(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
         FieldType::Decimal => FieldType::Decimal,
         FieldType::Timestamp => FieldType::Timestamp,
         FieldType::Date => FieldType::Date,
+        FieldType::Duration => FieldType::Duration,
         FieldType::Boolean
         | FieldType::String
         | FieldType::Text
         | FieldType::Binary
         | FieldType::Bson
-        | FieldType::Point
-        | FieldType::Duration => {
+        | FieldType::Point => {
             return Err(PipelineError::InvalidFunctionArgumentType(
                 Min.to_string(),
                 arg.return_type,
@@ -40,6 +40,7 @@ pub fn validate_min(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
                     FieldType::Float,
                     FieldType::Timestamp,
                     FieldType::Date,
+                    FieldType::Duration,
                 ]),
                 0,
             ));

--- a/dozer-sql/src/pipeline/aggregation/sum.rs
+++ b/dozer-sql/src/pipeline/aggregation/sum.rs
@@ -201,12 +201,12 @@ pub fn get_sum(
             FieldType::Duration => {
                 if decr {
                     for field in fields {
-                        let val = calculate_err_field!(field.to_duration(), Sum, field);
+                        let val = calculate_err_field!(field.to_duration()?, Sum, field);
                         current_state.duration_state -= val.0;
                     }
                 } else {
                     for field in fields {
-                        let val = calculate_err_field!(field.to_duration(), Sum, field);
+                        let val = calculate_err_field!(field.to_duration()?, Sum, field);
                         current_state.duration_state += val.0;
                     }
                 }

--- a/dozer-sql/src/pipeline/aggregation/sum.rs
+++ b/dozer-sql/src/pipeline/aggregation/sum.rs
@@ -20,6 +20,7 @@ pub fn validate_sum(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
         FieldType::I128 => FieldType::I128,
         FieldType::Float => FieldType::Float,
         FieldType::Decimal => FieldType::Decimal,
+        FieldType::Duration => FieldType::Duration,
         FieldType::Boolean
         | FieldType::String
         | FieldType::Text
@@ -27,8 +28,7 @@ pub fn validate_sum(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
         | FieldType::Timestamp
         | FieldType::Binary
         | FieldType::Bson
-        | FieldType::Point
-        | FieldType::Duration => {
+        | FieldType::Point => {
             return Err(PipelineError::InvalidFunctionArgumentType(
                 Sum.to_string(),
                 arg.return_type,
@@ -39,6 +39,7 @@ pub fn validate_sum(args: &[Expression], schema: &Schema) -> Result<ExpressionTy
                     FieldType::I128,
                     FieldType::Float,
                     FieldType::Decimal,
+                    FieldType::Duration,
                 ]),
                 0,
             ));

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_avg_tests.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_avg_tests.rs
@@ -1,13 +1,13 @@
 use crate::output;
 use crate::pipeline::aggregation::tests::aggregation_tests_utils::{
-    delete_exp, delete_field, get_decimal_div_field, get_decimal_field, init_input_schema,
-    init_processor, insert_exp, insert_field, update_exp, update_field, FIELD_0_FLOAT,
-    FIELD_100_FLOAT, FIELD_100_INT, FIELD_100_UINT, FIELD_200_FLOAT, FIELD_200_INT, FIELD_200_UINT,
-    FIELD_250_DIV_3_FLOAT, FIELD_350_DIV_3_FLOAT, FIELD_50_FLOAT, FIELD_50_INT, FIELD_50_UINT,
-    FIELD_75_FLOAT, FIELD_NULL, ITALY, SINGAPORE,
+    delete_exp, delete_field, get_decimal_div_field, get_decimal_field, get_duration_div_field,
+    get_duration_field, init_input_schema, init_processor, insert_exp, insert_field, update_exp,
+    update_field, FIELD_0_FLOAT, FIELD_100_FLOAT, FIELD_100_INT, FIELD_100_UINT, FIELD_200_FLOAT,
+    FIELD_200_INT, FIELD_200_UINT, FIELD_250_DIV_3_FLOAT, FIELD_350_DIV_3_FLOAT, FIELD_50_FLOAT,
+    FIELD_50_INT, FIELD_50_UINT, FIELD_75_FLOAT, FIELD_NULL, ITALY, SINGAPORE,
 };
 use dozer_core::DEFAULT_PORT_HANDLE;
-use dozer_types::types::FieldType::{Decimal, Float, Int, UInt};
+use dozer_types::types::FieldType::{Decimal, Duration, Float, Int, UInt};
 use std::collections::HashMap;
 
 #[test]
@@ -554,6 +554,154 @@ fn test_avg_aggregation_decimal() {
     inp = delete_field(ITALY, &get_decimal_field(100));
     out = output!(processor, inp);
     exp = vec![delete_exp(ITALY, &get_decimal_field(100))];
+    assert_eq!(out, exp);
+}
+
+#[test]
+fn test_avg_aggregation_duration() {
+    let schema = init_input_schema(Duration, "AVG");
+    let mut processor = init_processor(
+        "SELECT Country, AVG(Salary) \
+        FROM Users \
+        WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, 100.0
+        -------------
+        AVG = 100.0
+    */
+    let mut inp = insert_field(ITALY, &get_duration_field(100));
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, &get_duration_field(100))];
+    assert_eq!(out, exp);
+
+    // Insert another 100 for segment Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        AVG = 100.0
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Insert 50 for segment Singapore
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        AVG = 100.0
+
+        Singapore, 50.0
+        -------------
+        AVG = 50.0
+    */
+    inp = insert_field(SINGAPORE, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![insert_exp(SINGAPORE, &get_duration_field(50))];
+    assert_eq!(out, exp);
+
+    // Update Singapore segment to Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        AVG = 83.333
+    */
+    inp = update_field(
+        SINGAPORE,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(50),
+    );
+    out = output!(processor, inp);
+    exp = vec![
+        delete_exp(SINGAPORE, &get_duration_field(50)),
+        update_exp(
+            ITALY,
+            ITALY,
+            &get_duration_field(100),
+            &get_duration_div_field(250, 3),
+        ),
+    ];
+    assert_eq!(out, exp);
+
+    // Update Italy value 100 -> 200
+    /*
+        Italy, 200.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        AVG = 116.667
+    */
+    inp = update_field(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(200),
+    );
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_div_field(250, 3),
+        &get_duration_div_field(350, 3),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete 1 record (200)
+    /*
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        AVG = 75.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(200));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_div_field(350, 3),
+        &get_duration_field(75),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete another record (50)
+    /*
+        Italy, 100.0
+        -------------
+        AVG = 100.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(75),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        AVG = 0.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, &get_duration_field(100))];
     assert_eq!(out, exp);
 }
 

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_count_tests.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_count_tests.rs
@@ -1,12 +1,12 @@
 use crate::output;
 use crate::pipeline::aggregation::tests::aggregation_tests_utils::{
-    delete_exp, delete_field, get_date_field, get_decimal_field, get_ts_field, init_input_schema,
-    init_processor, insert_exp, insert_field, update_exp, update_field, DATE8, FIELD_100_FLOAT,
-    FIELD_100_INT, FIELD_1_INT, FIELD_200_FLOAT, FIELD_200_INT, FIELD_2_INT, FIELD_3_INT,
-    FIELD_50_FLOAT, FIELD_50_INT, FIELD_NULL, ITALY, SINGAPORE,
+    delete_exp, delete_field, get_date_field, get_decimal_field, get_duration_field, get_ts_field,
+    init_input_schema, init_processor, insert_exp, insert_field, update_exp, update_field, DATE8,
+    FIELD_100_FLOAT, FIELD_100_INT, FIELD_1_INT, FIELD_200_FLOAT, FIELD_200_INT, FIELD_2_INT,
+    FIELD_3_INT, FIELD_50_FLOAT, FIELD_50_INT, FIELD_NULL, ITALY, SINGAPORE,
 };
 use dozer_core::DEFAULT_PORT_HANDLE;
-use dozer_types::types::FieldType::{Date, Decimal, Float, Int, Timestamp};
+use dozer_types::types::FieldType::{Date, Decimal, Duration, Float, Int, Timestamp};
 use std::collections::HashMap;
 
 #[test]
@@ -359,6 +359,129 @@ fn test_count_aggregation_decimal() {
 }
 
 #[test]
+fn test_count_aggregation_duration() {
+    let schema = init_input_schema(Duration, "COUNT");
+    let mut processor = init_processor(
+        "SELECT Country, COUNT(Salary) \
+            FROM Users \
+            WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, 100.0
+        -------------
+        COUNT = 1
+    */
+    let mut inp = insert_field(ITALY, &get_duration_field(100));
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, FIELD_1_INT)];
+    assert_eq!(out, exp);
+
+    // Insert another 100 for segment Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        COUNT = 2
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_1_INT, FIELD_2_INT)];
+    assert_eq!(out, exp);
+
+    // Insert 50 for segment Singapore
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        COUNT = 2
+
+        Singapore, 50.0
+        ---------------
+        COUNT = 1
+    */
+    inp = insert_field(SINGAPORE, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![insert_exp(SINGAPORE, FIELD_1_INT)];
+    assert_eq!(out, exp);
+
+    // Update Singapore segment to Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        COUNT = 3
+    */
+    inp = update_field(
+        SINGAPORE,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(50),
+    );
+    out = output!(processor, inp);
+    exp = vec![
+        delete_exp(SINGAPORE, FIELD_1_INT),
+        update_exp(ITALY, ITALY, FIELD_2_INT, FIELD_3_INT),
+    ];
+    assert_eq!(out, exp);
+
+    // Update Italy value 100 -> 200
+    /*
+        Italy, 200.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        COUNT = 3
+    */
+    inp = update_field(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(200),
+    );
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_3_INT, FIELD_3_INT)];
+    assert_eq!(out, exp);
+
+    // Delete 1 record (200)
+    /*
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        COUNT = 2
+    */
+    inp = delete_field(ITALY, &get_duration_field(200));
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_3_INT, FIELD_2_INT)];
+    assert_eq!(out, exp);
+
+    // Delete another record (50)
+    /*
+        Italy, 100.0
+        -------------
+        COUNT = 1
+    */
+    inp = delete_field(ITALY, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_2_INT, FIELD_1_INT)];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        COUNT = 0
+    */
+    inp = delete_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, FIELD_1_INT)];
+    assert_eq!(out, exp);
+}
+
+#[test]
 fn test_count_aggregation_int_null() {
     let schema = init_input_schema(Int, "COUNT");
     let mut processor = init_processor(
@@ -672,6 +795,74 @@ fn test_count_aggregation_date_null() {
         COUNT = 2
     */
     inp = update_field(ITALY, ITALY, &get_date_field(DATE8), FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_2_INT, FIELD_2_INT)];
+    assert_eq!(out, exp);
+
+    // Delete a record
+    /*
+        Italy, NULL
+        -------------
+        COUNT = 1
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_2_INT, FIELD_1_INT)];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        COUNT = 0
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, FIELD_1_INT)];
+    assert_eq!(out, exp);
+}
+
+#[test]
+fn test_count_aggregation_duration_null() {
+    let schema = init_input_schema(Duration, "COUNT");
+    let mut processor = init_processor(
+        "SELECT Country, COUNT(Salary) \
+            FROM Users \
+            WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert NULL for segment Italy
+    /*
+        Italy, NULL
+        -------------
+        COUNT = 1
+    */
+    let mut inp = insert_field(ITALY, FIELD_NULL);
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, FIELD_1_INT)];
+    assert_eq!(out, exp);
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, NULL
+        Italy, 100
+        -------------
+        COUNT = 2
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_1_INT, FIELD_2_INT)];
+    assert_eq!(out, exp);
+
+    // Update 100 for segment Italy to NULL
+    /*
+        Italy, NULL
+        Italy, NULL
+        -------------
+        COUNT = 2
+    */
+    inp = update_field(ITALY, ITALY, &get_duration_field(100), FIELD_NULL);
     out = output!(processor, inp);
     exp = vec![update_exp(ITALY, ITALY, FIELD_2_INT, FIELD_2_INT)];
     assert_eq!(out, exp);

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_max_tests.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_max_tests.rs
@@ -1,13 +1,13 @@
 use crate::output;
 use crate::pipeline::aggregation::tests::aggregation_tests_utils::{
-    delete_exp, delete_field, get_date_field, get_decimal_field, get_ts_field, init_input_schema,
-    init_processor, insert_exp, insert_field, update_exp, update_field, DATE16, DATE4, DATE8,
-    FIELD_100_FLOAT, FIELD_100_INT, FIELD_100_UINT, FIELD_200_FLOAT, FIELD_200_INT, FIELD_200_UINT,
-    FIELD_50_FLOAT, FIELD_50_INT, FIELD_50_UINT, FIELD_NULL, ITALY, SINGAPORE,
+    delete_exp, delete_field, get_date_field, get_decimal_field, get_duration_field, get_ts_field,
+    init_input_schema, init_processor, insert_exp, insert_field, update_exp, update_field, DATE16,
+    DATE4, DATE8, FIELD_100_FLOAT, FIELD_100_INT, FIELD_100_UINT, FIELD_200_FLOAT, FIELD_200_INT,
+    FIELD_200_UINT, FIELD_50_FLOAT, FIELD_50_INT, FIELD_50_UINT, FIELD_NULL, ITALY, SINGAPORE,
 };
 use dozer_core::DEFAULT_PORT_HANDLE;
 
-use dozer_types::types::FieldType::{Date, Decimal, Float, Int, Timestamp, UInt};
+use dozer_types::types::FieldType::{Date, Decimal, Duration, Float, Int, Timestamp, UInt};
 use std::collections::HashMap;
 
 #[test]
@@ -498,6 +498,154 @@ fn test_max_aggregation_decimal() {
 }
 
 #[test]
+fn test_max_aggregation_duration() {
+    let schema = init_input_schema(Duration, "MAX");
+    let mut processor = init_processor(
+        "SELECT Country, MAX(Salary) \
+        FROM Users \
+        WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, 100.0
+        -------------
+        MAX = 100.0
+    */
+    let mut inp = insert_field(ITALY, &get_duration_field(100));
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, &get_duration_field(100))];
+    assert_eq!(out, exp);
+
+    // Insert another 100 for segment Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        MAX = 100.0
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Insert 50 for segment Singapore
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        MAX = 100.0
+
+        Singapore, 50.0
+        -------------
+        MAX = 50.0
+    */
+    inp = insert_field(SINGAPORE, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![insert_exp(SINGAPORE, &get_duration_field(50))];
+    assert_eq!(out, exp);
+
+    // Update Singapore segment to Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        MAX = 100.0
+    */
+    inp = update_field(
+        SINGAPORE,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(50),
+    );
+    out = output!(processor, inp);
+    exp = vec![
+        delete_exp(SINGAPORE, &get_duration_field(50)),
+        update_exp(
+            ITALY,
+            ITALY,
+            &get_duration_field(100),
+            &get_duration_field(100),
+        ),
+    ];
+    assert_eq!(out, exp);
+
+    // Update Italy value 100 -> 200
+    /*
+        Italy, 200.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        MAX = 200.0
+    */
+    inp = update_field(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(200),
+    );
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(200),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete 1 record (200)
+    /*
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        MAX = 100.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(200));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(200),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete another record (50)
+    /*
+        Italy, 100.0
+        -------------
+        MAX = 100.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        MAX = 0.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, &get_duration_field(100))];
+    assert_eq!(out, exp);
+}
+
+#[test]
 fn test_max_aggregation_timestamp() {
     let schema = init_input_schema(Timestamp, "MAX");
     let mut processor = init_processor(
@@ -961,6 +1109,84 @@ fn test_max_aggregation_decimal_null() {
         ITALY,
         ITALY,
         &get_decimal_field(100),
+        FIELD_NULL,
+    )];
+    assert_eq!(out, exp);
+
+    // Delete a record
+    /*
+        Italy, NULL
+        -------------
+        MAX = 0.0
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_NULL, FIELD_NULL)];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        MAX = 0.0
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, FIELD_NULL)];
+    assert_eq!(out, exp);
+}
+
+#[test]
+fn test_max_aggregation_duration_null() {
+    let schema = init_input_schema(Duration, "MAX");
+    let mut processor = init_processor(
+        "SELECT Country, MAX(Salary) \
+        FROM Users \
+        WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert NULL for segment Italy
+    /*
+        Italy, NULL
+        -------------
+        MAX = NULL
+    */
+    let mut inp = insert_field(ITALY, FIELD_NULL);
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, FIELD_NULL)];
+    assert_eq!(out, exp);
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, NULL
+        Italy, 100.0
+        -------------
+        MAX = 100.0
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        FIELD_NULL,
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Update 100 for segment Italy to NULL
+    /*
+        Italy, NULL
+        Italy, NULL
+        -------------
+        MAX = 0.0
+    */
+    inp = update_field(ITALY, ITALY, &get_duration_field(100), FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
         FIELD_NULL,
     )];
     assert_eq!(out, exp);

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_min_tests.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_min_tests.rs
@@ -1,13 +1,13 @@
 use crate::output;
 use crate::pipeline::aggregation::tests::aggregation_tests_utils::{
-    delete_exp, delete_field, get_date_field, get_decimal_field, get_ts_field, init_input_schema,
-    init_processor, insert_exp, insert_field, update_exp, update_field, DATE16, DATE4, DATE8,
-    FIELD_100_FLOAT, FIELD_100_INT, FIELD_100_UINT, FIELD_200_FLOAT, FIELD_200_INT, FIELD_200_UINT,
-    FIELD_50_FLOAT, FIELD_50_INT, FIELD_50_UINT, FIELD_NULL, ITALY, SINGAPORE,
+    delete_exp, delete_field, get_date_field, get_decimal_field, get_duration_field, get_ts_field,
+    init_input_schema, init_processor, insert_exp, insert_field, update_exp, update_field, DATE16,
+    DATE4, DATE8, FIELD_100_FLOAT, FIELD_100_INT, FIELD_100_UINT, FIELD_200_FLOAT, FIELD_200_INT,
+    FIELD_200_UINT, FIELD_50_FLOAT, FIELD_50_INT, FIELD_50_UINT, FIELD_NULL, ITALY, SINGAPORE,
 };
 use dozer_core::DEFAULT_PORT_HANDLE;
 
-use dozer_types::types::FieldType::{Date, Decimal, Float, Int, Timestamp, UInt};
+use dozer_types::types::FieldType::{Date, Decimal, Duration, Float, Int, Timestamp, UInt};
 use std::collections::HashMap;
 
 #[test]
@@ -498,6 +498,154 @@ fn test_min_aggregation_decimal() {
 }
 
 #[test]
+fn test_min_aggregation_duration() {
+    let schema = init_input_schema(Duration, "MIN");
+    let mut processor = init_processor(
+        "SELECT Country, MIN(Salary) \
+        FROM Users \
+        WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, 100.0
+        -------------
+        MIN = 100.0
+    */
+    let mut inp = insert_field(ITALY, &get_duration_field(100));
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, &get_duration_field(100))];
+    assert_eq!(out, exp);
+
+    // Insert another 100 for segment Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        MIN = 100.0
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Insert 50 for segment Singapore
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        MIN = 100.0
+
+        Singapore, 50.0
+        -------------
+        MIN = 50.0
+    */
+    inp = insert_field(SINGAPORE, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![insert_exp(SINGAPORE, &get_duration_field(50))];
+    assert_eq!(out, exp);
+
+    // Update Singapore segment to Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        MIN = 50.0
+    */
+    inp = update_field(
+        SINGAPORE,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(50),
+    );
+    out = output!(processor, inp);
+    exp = vec![
+        delete_exp(SINGAPORE, &get_duration_field(50)),
+        update_exp(
+            ITALY,
+            ITALY,
+            &get_duration_field(100),
+            &get_duration_field(50),
+        ),
+    ];
+    assert_eq!(out, exp);
+
+    // Update Italy value 100 -> 200
+    /*
+        Italy, 200.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        MIN = 50.0
+    */
+    inp = update_field(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(200),
+    );
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(50),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete 1 record (200)
+    /*
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        MIN = 50.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(200));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(50),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete another record (50)
+    /*
+        Italy, 100.0
+        -------------
+        MIN = 100.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        MIN = 0.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, &get_duration_field(100))];
+    assert_eq!(out, exp);
+}
+
+#[test]
 fn test_min_aggregation_timestamp() {
     let schema = init_input_schema(Timestamp, "MIN");
     let mut processor = init_processor(
@@ -961,6 +1109,84 @@ fn test_min_aggregation_decimal_null() {
         ITALY,
         ITALY,
         &get_decimal_field(100),
+        FIELD_NULL,
+    )];
+    assert_eq!(out, exp);
+
+    // Delete a record
+    /*
+        Italy, NULL
+        -------------
+        MIN = 0.0
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(ITALY, ITALY, FIELD_NULL, FIELD_NULL)];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        MIN = 0.0
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, FIELD_NULL)];
+    assert_eq!(out, exp);
+}
+
+#[test]
+fn test_min_aggregation_duration_null() {
+    let schema = init_input_schema(Duration, "MIN");
+    let mut processor = init_processor(
+        "SELECT Country, MIN(Salary) \
+        FROM Users \
+        WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert NULL for segment Italy
+    /*
+        Italy, NULL
+        -------------
+        MIN = NULL
+    */
+    let mut inp = insert_field(ITALY, FIELD_NULL);
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, FIELD_NULL)];
+    assert_eq!(out, exp);
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, NULL
+        Italy, 100.0
+        -------------
+        MIN = NULL
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        FIELD_NULL,
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Update 100 for segment Italy to NULL
+    /*
+        Italy, NULL
+        Italy, NULL
+        -------------
+        MIN = 0.0
+    */
+    inp = update_field(ITALY, ITALY, &get_duration_field(100), FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
         FIELD_NULL,
     )];
     assert_eq!(out, exp);

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_sum_tests.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_sum_tests.rs
@@ -1,14 +1,14 @@
 use crate::output;
 use crate::pipeline::aggregation::tests::aggregation_tests_utils::{
-    delete_exp, delete_field, get_decimal_field, init_input_schema, init_processor, insert_exp,
-    insert_field, update_exp, update_field, FIELD_0_FLOAT, FIELD_0_INT, FIELD_100_FLOAT,
-    FIELD_100_INT, FIELD_100_UINT, FIELD_150_FLOAT, FIELD_150_INT, FIELD_150_UINT, FIELD_200_FLOAT,
-    FIELD_200_INT, FIELD_200_UINT, FIELD_250_FLOAT, FIELD_250_INT, FIELD_250_UINT, FIELD_350_FLOAT,
-    FIELD_350_INT, FIELD_350_UINT, FIELD_50_FLOAT, FIELD_50_INT, FIELD_50_UINT, FIELD_NULL, ITALY,
-    SINGAPORE,
+    delete_exp, delete_field, get_decimal_field, get_duration_field, init_input_schema,
+    init_processor, insert_exp, insert_field, update_exp, update_field, FIELD_0_FLOAT, FIELD_0_INT,
+    FIELD_100_FLOAT, FIELD_100_INT, FIELD_100_UINT, FIELD_150_FLOAT, FIELD_150_INT, FIELD_150_UINT,
+    FIELD_200_FLOAT, FIELD_200_INT, FIELD_200_UINT, FIELD_250_FLOAT, FIELD_250_INT, FIELD_250_UINT,
+    FIELD_350_FLOAT, FIELD_350_INT, FIELD_350_UINT, FIELD_50_FLOAT, FIELD_50_INT, FIELD_50_UINT,
+    FIELD_NULL, ITALY, SINGAPORE,
 };
 use dozer_core::DEFAULT_PORT_HANDLE;
-use dozer_types::types::FieldType::{Decimal, Float, Int, UInt};
+use dozer_types::types::FieldType::{Decimal, Duration, Float, Int, UInt};
 use std::collections::HashMap;
 
 #[test]
@@ -499,6 +499,154 @@ fn test_sum_aggregation_decimal() {
 }
 
 #[test]
+fn test_sum_aggregation_duration() {
+    let schema = init_input_schema(Duration, "SUM");
+    let mut processor = init_processor(
+        "SELECT Country, SUM(Salary) \
+        FROM Users \
+        WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, 100.0
+        -------------
+        SUM = 100.0
+    */
+    let mut inp = insert_field(ITALY, &get_duration_field(100));
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, &get_duration_field(100))];
+    assert_eq!(out, exp);
+
+    // Insert another 100 for segment Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        SUM = 200.0
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(200),
+    )];
+    assert_eq!(out, exp);
+
+    // Insert 50 for segment Singapore
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        -------------
+        SUM = 200.0
+
+        Singapore, 50.0
+        ---------------
+        SUM = 50.0
+    */
+    inp = insert_field(SINGAPORE, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![insert_exp(SINGAPORE, &get_duration_field(50))];
+    assert_eq!(out, exp);
+
+    // Update Singapore segment to Italy
+    /*
+        Italy, 100.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        SUM = 250.0
+    */
+    inp = update_field(
+        SINGAPORE,
+        ITALY,
+        &get_duration_field(50),
+        &get_duration_field(50),
+    );
+    out = output!(processor, inp);
+    exp = vec![
+        delete_exp(SINGAPORE, &get_duration_field(50)),
+        update_exp(
+            ITALY,
+            ITALY,
+            &get_duration_field(200),
+            &get_duration_field(250),
+        ),
+    ];
+    assert_eq!(out, exp);
+
+    // Update Italy value 100 -> 200
+    /*
+        Italy, 200.0
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        SUM = 350.0
+    */
+    inp = update_field(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(200),
+    );
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(250),
+        &get_duration_field(350),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete 1 record (200)
+    /*
+        Italy, 100.0
+        Italy, 50.0
+        -------------
+        SUM = 150.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(200));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(350),
+        &get_duration_field(150),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete another record (50)
+    /*
+        Italy, 100.0
+        -------------
+        SUM = 100.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(50));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(150),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        SUM = 0.0
+    */
+    inp = delete_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, &get_duration_field(100))];
+    assert_eq!(out, exp);
+}
+
+#[test]
 fn test_sum_aggregation_int_null() {
     let schema = init_input_schema(Int, "SUM");
     let mut processor = init_processor(
@@ -714,5 +862,88 @@ fn test_sum_aggregation_decimal_null() {
     inp = delete_field(ITALY, FIELD_NULL);
     out = output!(processor, inp);
     exp = vec![delete_exp(ITALY, &get_decimal_field(0))];
+    assert_eq!(out, exp);
+}
+
+#[test]
+fn test_sum_aggregation_duration_null() {
+    let schema = init_input_schema(Duration, "SUM");
+    let mut processor = init_processor(
+        "SELECT Country, SUM(Salary) \
+        FROM Users \
+        WHERE Salary >= 1 GROUP BY Country",
+        HashMap::from([(DEFAULT_PORT_HANDLE, schema)]),
+    )
+    .unwrap();
+
+    // Insert NULL for segment Italy
+    /*
+        Italy, NULL
+        -------------
+        SUM = 0
+    */
+    let mut inp = insert_field(ITALY, FIELD_NULL);
+    let mut out = output!(processor, inp);
+    let mut exp = vec![insert_exp(ITALY, &get_duration_field(0))];
+    assert_eq!(out, exp);
+
+    // Insert 100 for segment Italy
+    /*
+        Italy, NULL
+        Italy, 100
+        -------------
+        SUM = 100
+    */
+    inp = insert_field(ITALY, &get_duration_field(100));
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(0),
+        &get_duration_field(100),
+    )];
+    assert_eq!(out, exp);
+
+    // Update 100 for segment Italy to NULL
+    /*
+        Italy, NULL
+        Italy, NULL
+        -------------
+        SUM = 0
+    */
+    inp = update_field(ITALY, ITALY, &get_duration_field(100), FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(100),
+        &get_duration_field(0),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete a record
+    /*
+        Italy, NULL
+        -------------
+        SUM = 0
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![update_exp(
+        ITALY,
+        ITALY,
+        &get_duration_field(0),
+        &get_duration_field(0),
+    )];
+    assert_eq!(out, exp);
+
+    // Delete last record
+    /*
+        -------------
+        SUM = 0.0
+    */
+    inp = delete_field(ITALY, FIELD_NULL);
+    out = output!(processor, inp);
+    exp = vec![delete_exp(ITALY, &get_duration_field(0))];
     assert_eq!(out, exp);
 }

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_tests_utils.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_tests_utils.rs
@@ -1,6 +1,7 @@
 use dozer_core::{node::PortHandle, DEFAULT_PORT_HANDLE};
 use dozer_types::types::{
-    Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition, DATE_FORMAT,
+    DozerDuration, Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
+    TimeUnit, DATE_FORMAT,
 };
 use std::collections::HashMap;
 
@@ -8,6 +9,7 @@ use crate::pipeline::aggregation::processor::AggregationProcessor;
 use crate::pipeline::errors::PipelineError;
 use crate::pipeline::planner::projection::CommonPlanner;
 use crate::pipeline::tests::utils::get_select;
+use dozer_types::arrow::datatypes::ArrowNativeTypeOp;
 use dozer_types::chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
@@ -178,6 +180,20 @@ pub(crate) fn update_exp(
             None,
         ),
     }
+}
+
+pub fn get_duration_field(val: u128) -> Field {
+    Field::Duration(DozerDuration(
+        std::time::Duration::from_nanos(val as u64),
+        TimeUnit::Nanoseconds,
+    ))
+}
+
+pub fn get_duration_div_field(numerator: i128, denominator: i128) -> Field {
+    Field::Duration(DozerDuration(
+        std::time::Duration::from_nanos((numerator as u64).div_wrapping(denominator as u64)),
+        TimeUnit::Nanoseconds,
+    ))
 }
 
 pub fn get_decimal_field(val: i64) -> Field {

--- a/dozer-sql/src/pipeline/expression/builder.rs
+++ b/dozer-sql/src/pipeline/expression/builder.rs
@@ -119,12 +119,9 @@ impl ExpressionBuilder {
                 leading_precision: _,
                 last_field: _,
                 fractional_seconds_precision: _,
-            } => self.parse_sql_interval_expression(
-                parse_aggregations,
-                value,
-                leading_field,
-                schema,
-            ),
+            } => {
+                self.parse_sql_interval_expression(parse_aggregations, value, leading_field, schema)
+            }
             _ => Err(InvalidExpression(format!("{expression:?}"))),
         }
     }

--- a/dozer-sql/src/pipeline/expression/builder.rs
+++ b/dozer-sql/src/pipeline/expression/builder.rs
@@ -409,7 +409,7 @@ impl ExpressionBuilder {
     fn parse_sql_interval_expression(
         &mut self,
         parse_aggregations: bool,
-        value: &Box<Expr>,
+        value: &Expr,
         leading_field: &Option<DateTimeField>,
         schema: &Schema,
     ) -> Result<Expression, PipelineError> {

--- a/dozer-sql/src/pipeline/expression/builder.rs
+++ b/dozer-sql/src/pipeline/expression/builder.rs
@@ -1,4 +1,3 @@
-
 use dozer_types::{
     ordered_float::OrderedFloat,
     types::{Field, FieldDefinition, Schema, SourceDefinition},
@@ -8,7 +7,6 @@ use sqlparser::ast::{
     FunctionArg, FunctionArgExpr, Ident, TrimWhereField, UnaryOperator as SqlUnaryOperator,
     Value as SqlValue,
 };
-
 
 use crate::pipeline::errors::PipelineError::{
     InvalidArgument, InvalidExpression, InvalidFunction, InvalidNestedAggregationFunction,
@@ -118,16 +116,13 @@ impl ExpressionBuilder {
             SqlExpr::Interval {
                 value,
                 leading_field,
-                leading_precision,
-                last_field,
-                fractional_seconds_precision,
+                leading_precision: _,
+                last_field: _,
+                fractional_seconds_precision: _,
             } => self.parse_sql_interval_expression(
                 parse_aggregations,
                 value,
                 leading_field,
-                leading_precision,
-                last_field,
-                fractional_seconds_precision,
                 schema,
             ),
             _ => Err(InvalidExpression(format!("{expression:?}"))),
@@ -419,9 +414,6 @@ impl ExpressionBuilder {
         parse_aggregations: bool,
         value: &Box<Expr>,
         leading_field: &Option<DateTimeField>,
-        _leading_precision: &Option<u64>,
-        _last_field: &Option<DateTimeField>,
-        _fractional_seconds_precision: &Option<u64>,
         schema: &Schema,
     ) -> Result<Expression, PipelineError> {
         let right = self.parse_sql_expression(parse_aggregations, value, schema)?;

--- a/dozer-sql/src/pipeline/expression/execution.rs
+++ b/dozer-sql/src/pipeline/expression/execution.rs
@@ -427,7 +427,25 @@ fn get_binary_operator_type(
                     false,
                 )),
                 (FieldType::Timestamp, FieldType::Timestamp) => Ok(ExpressionType::new(
-                    FieldType::Int,
+                    FieldType::Duration,
+                    false,
+                    SourceDefinition::Dynamic,
+                    false,
+                )),
+                (FieldType::Timestamp, FieldType::Duration) => Ok(ExpressionType::new(
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                    false,
+                )),
+                (FieldType::Duration, FieldType::Timestamp) => Ok(ExpressionType::new(
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                    false,
+                )),
+                (FieldType::Duration, FieldType::Duration) => Ok(ExpressionType::new(
+                    FieldType::Duration,
                     false,
                     SourceDefinition::Dynamic,
                     false,

--- a/dozer-sql/src/pipeline/expression/tests/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/tests/datetime.rs
@@ -234,66 +234,71 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
     assert!(result.is_err());
 }
 
-// #[test]
-// fn test_timestamp_add() {
-//     let f = run_scalar_fct(
-//         "SELECT ts1 + ts2 FROM users",
-//         Schema::empty()
-//             .field(
-//                 FieldDefinition::new(
-//                     String::from("ts1"),
-//                     FieldType::Timestamp,
-//                     false,
-//                     SourceDefinition::Dynamic,
-//                 ),
-//                 false,
-//             )
-//             .field(
-//                 FieldDefinition::new(
-//                     String::from("ts2"),
-//                     FieldType::Timestamp,
-//                     false,
-//                     SourceDefinition::Dynamic,
-//                 ),
-//                 false,
-//             )
-//             .clone(),
-//         vec![
-//             Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
-//             Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
-//         ],
-//     );
-//     assert_eq!(f, Field::Int(20000));
-// }
+#[test]
+fn test_interval() {
+    let f = run_fct(
+        "SELECT ts1 - INTERVAL '1' SECOND FROM users",
+        Schema::empty()
+            .field(
+                FieldDefinition::new(
+                    String::from("ts1"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .clone(),
+        vec![Field::Timestamp(
+            DateTime::parse_from_rfc3339("2023-01-02T00:12:11Z").unwrap(),
+        )],
+    );
+    assert_eq!(
+        f,
+        Field::Timestamp(DateTime::parse_from_rfc3339("2023-01-02T00:12:10Z").unwrap())
+    );
 
-// #[test]
-// fn test_timestamp_mul() {
-//     let f = run_scalar_fct(
-//         "SELECT ts1 * ts2 FROM users",
-//         Schema::empty()
-//             .field(
-//                 FieldDefinition::new(
-//                     String::from("ts1"),
-//                     FieldType::Timestamp,
-//                     false,
-//                     SourceDefinition::Dynamic,
-//                 ),
-//                 false,
-//             )
-//             .field(
-//                 FieldDefinition::new(
-//                     String::from("ts2"),
-//                     FieldType::Timestamp,
-//                     false,
-//                     SourceDefinition::Dynamic,
-//                 ),
-//                 false,
-//             )
-//             .clone(),
-//         vec![
-//             Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
-//             Field::Timestamp(DateTime::parse_from_rfc3339("1970-01-01T00:00:10Z").unwrap()),
-//         ],
-//     );
-//     assert_eq!(f, Field::Int(100000000));
-// }
+    let f = run_fct(
+        "SELECT ts1 + INTERVAL '1' SECOND FROM users",
+        Schema::empty()
+            .field(
+                FieldDefinition::new(
+                    String::from("ts1"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .clone(),
+        vec![Field::Timestamp(
+            DateTime::parse_from_rfc3339("2023-01-02T00:12:11Z").unwrap(),
+        )],
+    );
+    assert_eq!(
+        f,
+        Field::Timestamp(DateTime::parse_from_rfc3339("2023-01-02T00:12:12Z").unwrap())
+    );
+
+    let f = run_fct(
+        "SELECT INTERVAL '1' SECOND + ts1 FROM users",
+        Schema::empty()
+            .field(
+                FieldDefinition::new(
+                    String::from("ts1"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .clone(),
+        vec![Field::Timestamp(
+            DateTime::parse_from_rfc3339("2023-01-02T00:12:11Z").unwrap(),
+        )],
+    );
+    assert_eq!(
+        f,
+        Field::Timestamp(DateTime::parse_from_rfc3339("2023-01-02T00:12:12Z").unwrap())
+    );
+}

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -548,11 +548,29 @@ impl Field {
         }
     }
 
-    pub fn to_duration(&self) -> Option<DozerDuration> {
+    pub fn to_duration(&self) -> Result<Option<DozerDuration>, TypeError> {
         match self {
-            Field::Duration(d) => Some(*d),
-            Field::Null => Some(DozerDuration::from_str("0").unwrap()),
-            _ => None,
+            Field::UInt(d) => Ok(Some(
+                DozerDuration::from_str(d.to_string().as_str()).unwrap(),
+            )),
+            Field::U128(d) => Ok(Some(
+                DozerDuration::from_str(d.to_string().as_str()).unwrap(),
+            )),
+            Field::Int(d) => Ok(Some(
+                DozerDuration::from_str(d.to_string().as_str()).unwrap(),
+            )),
+            Field::I128(d) => Ok(Some(
+                DozerDuration::from_str(d.to_string().as_str()).unwrap(),
+            )),
+            Field::Duration(d) => Ok(Some(*d)),
+            Field::String(d) => Ok(Some(DozerDuration::from_str(d.as_str()).unwrap())),
+            Field::Text(d) => Ok(Some(DozerDuration::from_str(d.as_str()).unwrap())),
+            Field::Null => Ok(Some(DozerDuration::from_str("0").unwrap())),
+            _ => Err(TypeError::InvalidFieldValue {
+                field_type: FieldType::Duration,
+                nullable: false,
+                value: format!("{:?}", self),
+            }),
         }
     }
 

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -563,8 +563,18 @@ impl Field {
                 DozerDuration::from_str(d.to_string().as_str()).unwrap(),
             )),
             Field::Duration(d) => Ok(Some(*d)),
-            Field::String(d) => Ok(Some(DozerDuration::from_str(d.as_str()).unwrap())),
-            Field::Text(d) => Ok(Some(DozerDuration::from_str(d.as_str()).unwrap())),
+            Field::String(d) | Field::Text(d) => {
+                let dur = DozerDuration::from_str(d.as_str());
+                if let Ok(..) = dur {
+                    Ok(Some(dur.unwrap()))
+                } else {
+                    Err(TypeError::InvalidFieldValue {
+                        field_type: FieldType::Duration,
+                        nullable: false,
+                        value: format!("{:?}", self),
+                    })
+                }
+            }
             Field::Null => Ok(Some(DozerDuration::from_str("0").unwrap())),
             _ => Err(TypeError::InvalidFieldValue {
                 field_type: FieldType::Duration,

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -8,6 +8,7 @@ use rust_decimal::Decimal;
 use serde::{self, Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 use std::time::Duration;
 
 pub const DATE_FORMAT: &str = "%Y-%m-%d";
@@ -547,9 +548,10 @@ impl Field {
         }
     }
 
-    pub fn to_duration(&self) -> Option<&DozerDuration> {
+    pub fn to_duration(&self) -> Option<DozerDuration> {
         match self {
-            Field::Duration(d) => Some(d),
+            Field::Duration(d) => Some(*d),
+            Field::Null => Some(DozerDuration::from_str("0").unwrap()),
             _ => None,
         }
     }

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -333,7 +333,12 @@ impl FromStr for DozerDuration {
     type Err = TypeError;
 
     fn from_str(str: &str) -> Result<Self, Self::Err> {
-        let val = str.parse::<u64>().unwrap_or_default();
+        let error = || InvalidFieldValue {
+            field_type: FieldType::Duration,
+            nullable: false,
+            value: str.to_string(),
+        };
+        let val = str.parse::<u64>().map_err(|_| error())?;
         Ok(Self(
             std::time::Duration::from_nanos(val),
             TimeUnit::Nanoseconds,

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -333,12 +333,7 @@ impl FromStr for DozerDuration {
     type Err = TypeError;
 
     fn from_str(str: &str) -> Result<Self, Self::Err> {
-        let error = || InvalidFieldValue {
-            field_type: FieldType::Duration,
-            nullable: false,
-            value: str.to_string(),
-        };
-        let val = str.parse::<u64>().map_err(|_| error())?;
+        let val = str.parse::<u64>().unwrap_or_default();
         Ok(Self(
             std::time::Duration::from_nanos(val),
             TimeUnit::Nanoseconds,

--- a/dozer-types/src/types/tests.rs
+++ b/dozer-types/src/types/tests.rs
@@ -321,7 +321,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_none());
 
     let field = Field::Int(1);
@@ -339,7 +339,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_none());
 
     let field = Field::U128(1);
@@ -357,7 +357,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_none());
 
     let field = Field::I128(1);
@@ -375,7 +375,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_none());
 
     let field = Field::Float(OrderedFloat::from(1.0));
@@ -393,7 +393,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Boolean(true);
@@ -411,7 +411,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::String("".to_string());
@@ -429,7 +429,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_none());
 
     let field = Field::Text("".to_string());
@@ -447,7 +447,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_none());
 
     let field = Field::Binary(vec![]);
@@ -465,7 +465,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Decimal(Decimal::from(1));
@@ -483,7 +483,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Timestamp(DateTime::from(Utc.timestamp_millis_opt(0).unwrap()));
@@ -501,7 +501,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Date(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
@@ -519,7 +519,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_some());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Bson(vec![]);
@@ -537,7 +537,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_some());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Point(DozerPoint::from((0.0, 0.0)));
@@ -555,7 +555,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_some());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Duration(DozerDuration(
@@ -576,7 +576,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_some());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_none());
 
     let field = Field::Null;
@@ -594,6 +594,6 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_some());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_none());
+    assert!(field.to_duration().is_ok());
     assert!(field.to_null().is_some());
 }

--- a/dozer-types/src/types/tests.rs
+++ b/dozer-types/src/types/tests.rs
@@ -429,7 +429,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_ok());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Text("".to_string());
@@ -447,7 +447,7 @@ fn test_to_conversion() {
     assert!(field.to_date().unwrap().is_none());
     assert!(field.to_bson().is_none());
     assert!(field.to_point().is_none());
-    assert!(field.to_duration().is_ok());
+    assert!(field.to_duration().is_err());
     assert!(field.to_null().is_none());
 
     let field = Field::Binary(vec![]);


### PR DESCRIPTION
Aggregation Support
- [x] Avg - `AVG(DURATION)` -> `DURATION`
- [x] Count - `COUNT(DURATION)` -> `INT`
- [x] Max - `MAX(DURATION)` -> `DURATION`
- [x] Min - `MIN(DURATION)` -> `DURATION`
- [x] Sum - `SUM(DURATION)` -> `DURATION`

SQL Representation
- [x] [`INTERVAL '1' SECOND`](https://docs.rs/sqlparser/latest/sqlparser/parser/struct.Parser.html#method.parse_interval)
- [x] `"6/04/2023 10:00" + INTERVAL '30' SECOND`
- [x] `"6/04/2023 10:00" - INTERVAL '30' SECOND`

Currently only supported TimeUnits are:
* `SECOND` with up to u64  due to https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/std/time/struct.Duration.html#method.from_secs
* `MILLISECOND` or `MILLISECONDS` with up to u64 due to https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/std/time/struct.Duration.html#method.from_millis
* `MICROSECOND` or `MICROSECONDS` with up to u64 due to https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/std/time/struct.Duration.html#method.from_micros
* `NANOSECOND` or `NANOSECONDS` with up to u64 due to https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/std/time/struct.Duration.html#method.from_nanos