### PR TITLE
chore: Use `CacheWriteOptions` instead of `ConflictResolution`

### DIFF
--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -8,7 +8,6 @@ use dozer_types::{
 };
 
 use dozer_cache::cache::{CacheRecord, LmdbRwCacheManager, RwCacheManager};
-use dozer_types::models::api_endpoint::ConflictResolution;
 
 pub fn get_schema() -> SchemaWithIndex {
     let fields = vec![
@@ -110,11 +109,7 @@ pub fn initialize_cache(
     let cache_manager = LmdbRwCacheManager::new(Default::default()).unwrap();
     let (schema, secondary_indexes) = schema.unwrap_or_else(get_schema);
     let mut cache = cache_manager
-        .create_cache(
-            schema.clone(),
-            secondary_indexes,
-            ConflictResolution::default(),
-        )
+        .create_cache(schema.clone(), secondary_indexes, Default::default())
         .unwrap();
     let records = get_sample_records(schema);
     for mut record in records {

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -5,7 +5,6 @@ use dozer_cache::cache::expression::{self, FilterExpression, QueryExpression, Sk
 use dozer_cache::cache::{
     test_utils, CacheManagerOptions, LmdbRwCacheManager, RwCache, RwCacheManager,
 };
-use dozer_types::models::api_endpoint::ConflictResolution;
 use dozer_types::parking_lot::Mutex;
 use dozer_types::serde_json::Value;
 use dozer_types::types::{Field, Record, Schema};
@@ -58,11 +57,7 @@ fn cache(c: &mut Criterion) {
     .unwrap();
     let cache = Mutex::new(
         cache_manager
-            .create_cache(
-                schema.clone(),
-                secondary_indexes,
-                ConflictResolution::default(),
-            )
+            .create_cache(schema.clone(), secondary_indexes, Default::default())
             .unwrap(),
     );
 

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
@@ -1,5 +1,5 @@
 use crate::cache::index;
-use crate::cache::lmdb::cache::MainEnvironment;
+use crate::cache::lmdb::cache::{CacheWriteOptions, MainEnvironment};
 use crate::cache::test_utils::schema_multi_indices;
 use crate::errors::CacheError;
 use dozer_types::models::api_endpoint::{
@@ -11,8 +11,13 @@ use super::RwMainEnvironment;
 
 fn init_env(conflict_resolution: ConflictResolution) -> (RwMainEnvironment, Schema) {
     let schema = schema_multi_indices();
+    let write_options = CacheWriteOptions {
+        insert_resolution: OnInsertResolutionTypes::from(conflict_resolution.on_insert),
+        delete_resolution: OnDeleteResolutionTypes::from(conflict_resolution.on_delete),
+        update_resolution: OnUpdateResolutionTypes::from(conflict_resolution.on_update),
+    };
     let main_env =
-        RwMainEnvironment::new(Some(&schema), &Default::default(), conflict_resolution).unwrap();
+        RwMainEnvironment::new(Some(&schema), &Default::default(), write_options).unwrap();
     (main_env, schema.0)
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/mod.rs
@@ -1,4 +1,3 @@
-use dozer_types::models::api_endpoint::ConflictResolution;
 use dozer_types::parking_lot::Mutex;
 use std::path::PathBuf;
 use std::{fmt::Debug, sync::Arc};
@@ -10,7 +9,7 @@ use super::{
     indexing::IndexingThreadPool,
 };
 use crate::cache::expression::QueryExpression;
-use crate::cache::{CacheRecord, RecordMeta, UpsertResult};
+use crate::cache::{CacheRecord, CacheWriteOptions, RecordMeta, UpsertResult};
 use crate::errors::CacheError;
 
 mod main_environment;
@@ -83,10 +82,10 @@ impl LmdbRwCache {
     pub fn new(
         schema: Option<&SchemaWithIndex>,
         options: &CacheOptions,
+        write_options: CacheWriteOptions,
         indexing_thread_pool: Arc<Mutex<IndexingThreadPool>>,
-        conflict_resolution: ConflictResolution,
     ) -> Result<Self, CacheError> {
-        let rw_main_env = RwMainEnvironment::new(schema, options, conflict_resolution)?;
+        let rw_main_env = RwMainEnvironment::new(schema, options, write_options)?;
 
         let options = CacheOptions {
             path: Some((

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -4,7 +4,6 @@ use crate::cache::expression::{FilterExpression, Operator, QueryExpression};
 use crate::cache::lmdb::cache::{CacheOptions, LmdbRoCache, LmdbRwCache};
 use crate::cache::lmdb::indexing::IndexingThreadPool;
 use crate::cache::{lmdb::tests::utils as lmdb_utils, test_utils, RoCache, RwCache};
-use dozer_types::models::api_endpoint::ConflictResolution;
 use dozer_types::parking_lot::Mutex;
 use dozer_types::serde_json::Value;
 use dozer_types::types::Field;
@@ -28,8 +27,8 @@ fn read_and_write() {
             path: Some(path.clone()),
             intersection_chunk_size: 1,
         },
+        Default::default(),
         indexing_thread_pool.clone(),
-        ConflictResolution::default(),
     )
     .unwrap();
 

--- a/dozer-cache/src/cache/lmdb/tests/utils.rs
+++ b/dozer-cache/src/cache/lmdb/tests/utils.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use dozer_types::models::api_endpoint::ConflictResolution;
 use dozer_types::parking_lot::Mutex;
 use dozer_types::types::{Field, IndexDefinition, Record, Schema, SchemaWithIndex};
 
@@ -25,8 +24,8 @@ pub fn create_cache(
     let cache = LmdbRwCache::new(
         Some(&schema),
         &Default::default(),
+        Default::default(),
         indexing_thread_pool.clone(),
-        ConflictResolution::default(),
     )
     .unwrap();
     (cache, indexing_thread_pool, schema.0, schema.1)

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -3,7 +3,9 @@ use std::fmt::Debug;
 
 use self::expression::QueryExpression;
 use crate::errors::CacheError;
-use dozer_types::models::api_endpoint::ConflictResolution;
+use dozer_types::models::api_endpoint::{
+    OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes,
+};
 use dozer_types::{
     serde::{Deserialize, Serialize},
     types::{IndexDefinition, Record, Schema, SchemaWithIndex},
@@ -39,6 +41,13 @@ pub trait RoCacheManager: Send + Sync + Debug {
     fn open_ro_cache(&self, name: &str) -> Result<Option<Box<dyn RoCache>>, CacheError>;
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CacheWriteOptions {
+    pub insert_resolution: OnInsertResolutionTypes,
+    pub delete_resolution: OnDeleteResolutionTypes,
+    pub update_resolution: OnUpdateResolutionTypes,
+}
+
 pub trait RwCacheManager: RoCacheManager {
     /// Opens a cache in read-write mode with given name or an alias with that name.
     ///
@@ -46,7 +55,7 @@ pub trait RwCacheManager: RoCacheManager {
     fn open_rw_cache(
         &self,
         name: &str,
-        conflict_resolution: ConflictResolution,
+        write_options: CacheWriteOptions,
     ) -> Result<Option<Box<dyn RwCache>>, CacheError>;
 
     /// Creates a new cache with given `schema`s, which can also be opened in read-only mode using `open_ro_cache`.
@@ -58,7 +67,7 @@ pub trait RwCacheManager: RoCacheManager {
         &self,
         schema: Schema,
         indexes: Vec<IndexDefinition>,
-        conflict_resolution: ConflictResolution,
+        write_options: CacheWriteOptions,
     ) -> Result<Box<dyn RwCache>, CacheError>;
 
     /// Creates an alias `alias` for a cache with name `name`.

--- a/dozer-tests/src/cache_tests/film/load_database.rs
+++ b/dozer-tests/src/cache_tests/film/load_database.rs
@@ -1,7 +1,6 @@
 use bson::doc;
 use csv::StringRecord;
 use dozer_cache::cache::{LmdbRwCacheManager, RoCache, RoCacheManager, RwCacheManager};
-use dozer_types::models::api_endpoint::ConflictResolution;
 use dozer_types::{chrono::DateTime, types::IndexDefinition};
 use mongodb::{options::ClientOptions, Client, Collection, IndexModel};
 
@@ -19,11 +18,7 @@ pub async fn load_database(
     let schema = film_schema();
     let cache_manager = LmdbRwCacheManager::new(Default::default()).unwrap();
     let mut cache = cache_manager
-        .create_cache(
-            schema.clone(),
-            secondary_indexes,
-            ConflictResolution::default(),
-        )
+        .create_cache(schema.clone(), secondary_indexes, Default::default())
         .unwrap();
 
     // Connect to mongodb and clear collection.

--- a/dozer-types/src/models/api_endpoint.rs
+++ b/dozer-types/src/models/api_endpoint.rs
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for OnInsertResolutionTypes {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, ::prost::Enumeration)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, ::prost::Enumeration)]
 pub enum OnUpdateResolutionTypes {
     Nothing = 0,
     Upsert = 1,
@@ -109,7 +109,7 @@ impl<'de> Deserialize<'de> for OnUpdateResolutionTypes {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, ::prost::Enumeration)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum OnDeleteResolutionTypes {
     Nothing = 0,


### PR DESCRIPTION
This is a simple refactor for adding more options to `CacheWriteOptions` in the following PR.