### PR TITLE
fix: e2e tests write to directories that are not removed

### DIFF
--- a/dozer-admin/src/tests/applications.rs
+++ b/dozer-admin/src/tests/applications.rs
@@ -22,7 +22,7 @@ mod grpc_service {
         let config = Config {
             app_name: "new_app_name".to_owned(),
             home_dir: "dozer".to_owned(),
-            cache_dir: "dozer".to_owned(),
+            cache_dir: "dozer/cache".to_owned(),
             connections: vec![postgres_config],
             ..Default::default()
         };

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::appsource::AppSourceId;
 use crate::node::PortHandle;
 use dozer_types::errors::internal::BoxedError;
@@ -56,6 +58,8 @@ pub enum ExecutionError {
     FailedToGetPrimaryKey(String),
 
     // Error forwarders
+    #[error("File system error {0:?}: {1}")]
+    FileSystemError(PathBuf, #[source] std::io::Error),
     #[error("Internal type error: {0}")]
     InternalTypeError(#[from] TypeError),
     #[error("Internal error: {0}")]

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -18,8 +18,8 @@ use dozer_api::{actix_web::dev::ServerHandle, grpc, rest, CacheEndpoint};
 use dozer_cache::cache::LmdbRwCacheManager;
 use dozer_core::app::AppPipeline;
 use dozer_core::dag_schemas::DagSchemas;
-use dozer_core::errors::ExecutionError::InternalError;
 
+use dozer_core::errors::ExecutionError;
 use dozer_ingestion::connectors::{SourceSchema, TableInfo};
 use dozer_sql::pipeline::builder::statement_to_pipeline;
 use dozer_sql::pipeline::errors::PipelineError;
@@ -238,12 +238,14 @@ impl Orchestrator for SimpleOrchestrator {
 
         // Api Path
         if !api_dir.exists() {
-            fs::create_dir_all(api_dir).map_err(|e| InternalError(Box::new(e)))?;
+            fs::create_dir_all(&api_dir)
+                .map_err(|e| ExecutionError::FileSystemError(api_dir, e))?;
         }
 
         // cache Path
         if !cache_dir.exists() {
-            fs::create_dir_all(cache_dir).map_err(|e| InternalError(Box::new(e)))?;
+            fs::create_dir_all(&cache_dir)
+                .map_err(|e| ExecutionError::FileSystemError(cache_dir, e))?;
         }
 
         // Pipeline path
@@ -304,12 +306,14 @@ impl Orchestrator for SimpleOrchestrator {
     fn clean(&mut self) -> Result<(), OrchestrationError> {
         let cache_dir = PathBuf::from(self.config.cache_dir.clone());
         if cache_dir.exists() {
-            fs::remove_dir_all(&cache_dir).map_err(|e| InternalError(Box::new(e)))?;
+            fs::remove_dir_all(&cache_dir)
+                .map_err(|e| ExecutionError::FileSystemError(cache_dir, e))?;
         };
 
         let home_dir = PathBuf::from(self.config.home_dir.clone());
         if home_dir.exists() {
-            fs::remove_dir_all(&home_dir).map_err(|e| InternalError(Box::new(e)))?;
+            fs::remove_dir_all(&home_dir)
+                .map_err(|e| ExecutionError::FileSystemError(home_dir, e))?;
         };
 
         Ok(())

--- a/dozer-orchestrator/src/utils.rs
+++ b/dozer-orchestrator/src/utils.rs
@@ -22,7 +22,7 @@ pub fn get_endpoint_log_path(pipeline_dir: &Path, endpoint_name: &str) -> PathBu
 }
 
 pub fn get_cache_dir(config: &Config) -> PathBuf {
-    AsRef::<Path>::as_ref(&config.cache_dir).join("cache")
+    config.cache_dir.clone().into()
 }
 
 fn get_logs_path(pipeline_dir: &Path) -> PathBuf {

--- a/dozer-tests/src/tests/e2e/basic_sql.rs
+++ b/dozer-tests/src/tests/e2e/basic_sql.rs
@@ -1,62 +1,25 @@
-use std::{
-    sync::{atomic::AtomicBool, Arc},
-    thread,
-};
+use std::time::Duration;
 
-use dozer_api::actix_web::rt::Runtime;
-use dozer_orchestrator::{simple::SimpleOrchestrator as Dozer, Orchestrator};
-use dozer_types::grpc_types::common::{
-    common_grpc_service_client::CommonGrpcServiceClient, QueryRequest,
-};
-use dozer_types::{models::app_config::Config, serde_yaml};
-use tempdir::TempDir;
-fn get_config() -> Config {
-    let path = TempDir::new("tests").unwrap();
-    let mut cfg =
-        serde_yaml::from_str::<Config>(include_str!("./fixtures/basic_sql.yaml")).unwrap();
-    cfg.home_dir = path.path().to_str().unwrap().to_string();
-    cfg
-}
+use dozer_types::grpc_types::common::QueryRequest;
 
-#[test]
-fn test_e2e_sql() {
-    let cfg = get_config();
-    let running = Arc::new(AtomicBool::new(true));
-    let r = running.clone();
-    // Start Dozer
-    thread::spawn(move || {
-        let mut dozer = Dozer::new(cfg);
-        dozer.run_all(running).unwrap();
-    });
-    let retries = 10;
-    let url = "http://0.0.0.0:7503";
-    Runtime::new().unwrap().block_on(async {
-        // Query common service
-        let mut res = CommonGrpcServiceClient::connect(url).await;
-        for r in 0..retries {
-            if res.is_ok() {
-                break;
-            }
-            if r == retries - 1 {
-                panic!("failed to connect after {r} times");
-            }
-            thread::sleep(std::time::Duration::from_millis(500));
-            res = CommonGrpcServiceClient::connect(url).await;
-        }
+use super::DozerE2eTest;
 
-        thread::sleep(std::time::Duration::from_millis(1000));
-        let mut common_client = res.unwrap();
+#[tokio::test]
+async fn test_e2e_sql() {
+    let mut test = DozerE2eTest::new(include_str!("./fixtures/basic_sql.yaml")).await;
 
-        let res = common_client
-            .query(QueryRequest {
-                endpoint: "trips".to_string(),
-                query: None,
-            })
-            .await
-            .unwrap();
-        let res = res.into_inner();
-        assert_eq!(res.records.len(), 4);
-    });
+    // Give dozer some time to process the records.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
 
-    r.store(false, std::sync::atomic::Ordering::Relaxed);
+    let common_client = &mut test.common_service_client;
+
+    let res = common_client
+        .query(QueryRequest {
+            endpoint: "trips".to_string(),
+            query: None,
+        })
+        .await
+        .unwrap();
+    let res = res.into_inner();
+    assert_eq!(res.records.len(), 4);
 }

--- a/dozer-tests/src/tests/e2e/mod.rs
+++ b/dozer-tests/src/tests/e2e/mod.rs
@@ -1,2 +1,110 @@
+use std::{
+    future::Future,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use dozer_api::tonic::transport::Channel;
+use dozer_orchestrator::{simple::SimpleOrchestrator, Orchestrator};
+use dozer_types::{
+    grpc_types::{
+        common::common_grpc_service_client::CommonGrpcServiceClient,
+        ingest::ingest_service_client::IngestServiceClient,
+    },
+    models::{app_config::Config, connection::ConnectionConfig},
+    serde_yaml,
+};
+use tempdir::TempDir;
+
 mod basic;
 mod basic_sql;
+
+struct DozerE2eTest {
+    _home_dir: TempDir,
+    dozer_thread: Option<JoinHandle<()>>,
+    running: Arc<AtomicBool>,
+
+    common_service_client: CommonGrpcServiceClient<Channel>,
+    ingest_service_client: Option<IngestServiceClient<Channel>>,
+}
+
+impl DozerE2eTest {
+    async fn new(config_str: &str) -> Self {
+        let temp_dir = TempDir::new("tests").unwrap();
+        let mut config = serde_yaml::from_str::<Config>(config_str).unwrap();
+        config.home_dir = temp_dir.path().to_str().unwrap().to_string();
+        config.cache_dir = temp_dir.path().join("cache").to_str().unwrap().to_string();
+
+        let api = config.api.clone().unwrap_or_default();
+        let api_grpc = api.grpc.unwrap_or_default();
+        let common_service_url = format!("http://{}:{}", api_grpc.host, api_grpc.port);
+
+        let mut ingest_service_url = None;
+        for connection in &config.connections {
+            if let Some(ConnectionConfig::Grpc(config)) = &connection.config {
+                if ingest_service_url.is_some() {
+                    panic!("Found more than one ingest service");
+                }
+                ingest_service_url = Some(format!("http://{}:{}", config.host, config.port));
+            }
+        }
+
+        let running = Arc::new(AtomicBool::new(true));
+        let r = running.clone();
+        let dozer_thread = std::thread::spawn(move || {
+            let mut dozer = SimpleOrchestrator::new(config);
+            dozer.run_all(r).unwrap();
+        });
+
+        let num_retries = 10;
+        let retry_interval = Duration::from_millis(300);
+        let common_service_client = retry_async_fn(num_retries, retry_interval, || {
+            CommonGrpcServiceClient::connect(common_service_url.clone())
+        })
+        .await;
+        let ingest_service_client = if let Some(ingest_service_url) = ingest_service_url {
+            Some(
+                retry_async_fn(num_retries, retry_interval, || {
+                    IngestServiceClient::connect(ingest_service_url.clone())
+                })
+                .await,
+            )
+        } else {
+            None
+        };
+
+        Self {
+            _home_dir: temp_dir,
+            dozer_thread: Some(dozer_thread),
+            running,
+            common_service_client,
+            ingest_service_client,
+        }
+    }
+}
+
+impl Drop for DozerE2eTest {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::SeqCst);
+        self.dozer_thread.take().unwrap().join().unwrap();
+    }
+}
+
+async fn retry_async_fn<T, E, F: Future<Output = Result<T, E>>>(
+    num_retries: u8,
+    retry_interval: Duration,
+    f: impl Fn() -> F,
+) -> T {
+    for _ in 0..num_retries {
+        let result = f().await;
+        if let Ok(result) = result {
+            return result;
+        }
+        tokio::time::sleep(retry_interval).await;
+    }
+    panic!("failed to connect after {num_retries} times");
+}

--- a/dozer-types/src/models/app_config.rs
+++ b/dozer-types/src/models/app_config.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::{
     api_config::ApiConfig, api_endpoint::ApiEndpoint, connection::Connection, flags::Flags,
     source::Source, telemetry::TelemetryConfig,
@@ -17,12 +19,12 @@ pub struct Config {
 
     #[prost(string, tag = "3")]
     #[serde(default = "default_home_dir")]
-    ///directory for all process; Default: ~/.dozer
+    ///directory for all process; Default: ./.dozer
     pub home_dir: String,
 
     #[prost(string, tag = "4")]
     #[serde(default = "default_cache_dir")]
-    ///directory for cache. Default: ~/.dozer/cache
+    ///directory for cache. Default: ./.dozer/cache
     pub cache_dir: String,
 
     #[prost(message, repeated, tag = "5")]
@@ -88,7 +90,11 @@ pub fn default_home_dir() -> String {
 }
 
 pub fn default_cache_dir() -> String {
-    format!("{}/cache", DEFAULT_HOME_DIR)
+    AsRef::<Path>::as_ref(DEFAULT_HOME_DIR)
+        .join("cache")
+        .to_str()
+        .unwrap()
+        .to_string()
 }
 
 pub fn default_file_buffer_capacity() -> u64 {


### PR DESCRIPTION
There were two bugs:

1. The generated `TempDir` was set to `home_dir` but `TempDir` is dropped earlier than dozer finishes, so dozer creates the directory again and not removed.

2. `cache_dir` was not set using `TempDir` and results in dozer writing to `./.dozer/cache`.