### PR TITLE
fix: Use `tokio::time::sleep` instead of `std::thread::sleep`

### DIFF
--- a/dozer-api/examples/reader.rs
+++ b/dozer-api/examples/reader.rs
@@ -1,7 +1,6 @@
 use std::{env, path::Path};
 
 use dozer_api::LogReader;
-use futures_util::StreamExt;
 
 #[tokio::main]
 async fn main() {
@@ -11,12 +10,13 @@ async fn main() {
     if args.len() == 2 {
         path = &args[1];
     };
-    let log_reader = LogReader::new(Path::new(path), "logs", 0, None).unwrap();
-
-    tokio::pin!(log_reader);
+    let mut log_reader = LogReader::new(Path::new(path), "logs", 0, None)
+        .await
+        .unwrap();
 
     let mut counter = 0;
-    while let Some(_op) = log_reader.next().await {
+    loop {
+        log_reader.next_op().await;
         counter += 1;
 
         if counter > 100000 {

--- a/dozer-api/src/grpc/typed/tests/service.rs
+++ b/dozer-api/src/grpc/typed/tests/service.rs
@@ -48,14 +48,9 @@ async fn start_internal_pipeline_client() -> Result<Receiver<Operation>, GrpcErr
 
 pub async fn setup_pipeline() -> (Vec<Arc<CacheEndpoint>>, Receiver<Operation>) {
     let endpoint = test_utils::get_endpoint();
-    let schema = test_utils::get_schema().0;
-    let cache_endpoint = CacheEndpoint::new(
+    let cache_endpoint = CacheEndpoint::open(
         &*test_utils::initialize_cache(&endpoint.name, None),
-        schema,
         endpoint,
-        test_utils::get_log_path().as_path(),
-        None,
-        None,
     )
     .unwrap();
 
@@ -63,7 +58,7 @@ pub async fn setup_pipeline() -> (Vec<Arc<CacheEndpoint>>, Receiver<Operation>) 
         .await
         .unwrap_or(broadcast::channel::<Operation>(1).1);
 
-    (vec![Arc::new(cache_endpoint.0)], receiver)
+    (vec![Arc::new(cache_endpoint)], receiver)
 }
 
 async fn setup_typed_service(security: Option<ApiSecurity>) -> TypedService {

--- a/dozer-api/src/rest/tests/auth.rs
+++ b/dozer-api/src/rest/tests/auth.rs
@@ -70,16 +70,7 @@ async fn check_status(
         security,
         CorsOptions::Permissive,
         vec![Arc::new(
-            CacheEndpoint::new(
-                &*cache_manager,
-                test_utils::get_schema().0,
-                endpoint.clone(),
-                test_utils::get_log_path().as_path(),
-                None,
-                None,
-            )
-            .unwrap()
-            .0,
+            CacheEndpoint::open(&*cache_manager, endpoint.clone()).unwrap(),
         )],
     );
     let app = actix_web::test::init_service(api_server).await;
@@ -101,23 +92,13 @@ async fn _call_auth_token_api(
     body: Option<Value>,
 ) -> ServiceResponse<impl MessageBody> {
     let endpoint = test_utils::get_endpoint();
-    let schema = test_utils::get_schema();
     let schema_name = endpoint.name.clone();
     let cache_manager = test_utils::initialize_cache(&schema_name, None);
     let api_server = ApiServer::create_app_entry(
         Some(ApiSecurity::Jwt(secret)),
         CorsOptions::Permissive,
         vec![Arc::new(
-            CacheEndpoint::new(
-                &*cache_manager,
-                schema.0,
-                endpoint,
-                test_utils::get_log_path().as_path(),
-                None,
-                None,
-            )
-            .unwrap()
-            .0,
+            CacheEndpoint::open(&*cache_manager, endpoint).unwrap(),
         )],
     );
     let app = actix_web::test::init_service(api_server).await;

--- a/dozer-api/src/rest/tests/routes.rs
+++ b/dozer-api/src/rest/tests/routes.rs
@@ -30,16 +30,7 @@ async fn list_route() {
         None,
         CorsOptions::Permissive,
         vec![Arc::new(
-            CacheEndpoint::new(
-                &*cache_manager,
-                test_utils::get_schema().0,
-                endpoint.clone(),
-                test_utils::get_log_path().as_path(),
-                None,
-                None,
-            )
-            .unwrap()
-            .0,
+            CacheEndpoint::open(&*cache_manager, endpoint.clone()).unwrap(),
         )],
     );
     let app = actix_web::test::init_service(api_server).await;
@@ -98,16 +89,7 @@ async fn count_and_query_route() {
         None,
         CorsOptions::Permissive,
         vec![Arc::new(
-            CacheEndpoint::new(
-                &*cache_manager,
-                test_utils::get_schema().0,
-                endpoint.clone(),
-                test_utils::get_log_path().as_path(),
-                None,
-                None,
-            )
-            .unwrap()
-            .0,
+            CacheEndpoint::open(&*cache_manager, endpoint.clone()).unwrap(),
         )],
     );
     let app = actix_web::test::init_service(api_server).await;
@@ -152,16 +134,7 @@ async fn get_route() {
         None,
         CorsOptions::Permissive,
         vec![Arc::new(
-            CacheEndpoint::new(
-                &*cache_manager,
-                test_utils::get_schema().0,
-                endpoint.clone(),
-                test_utils::get_log_path().as_path(),
-                None,
-                None,
-            )
-            .unwrap()
-            .0,
+            CacheEndpoint::open(&*cache_manager, endpoint.clone()).unwrap(),
         )],
     );
     let app = actix_web::test::init_service(api_server).await;

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -1,5 +1,3 @@
-use std::path::{Path, PathBuf};
-
 use dozer_types::serde_json::{json, Value};
 use dozer_types::types::{Field, Record, SchemaWithIndex, SourceDefinition};
 use dozer_types::{
@@ -148,8 +146,4 @@ pub fn get_sample_records(schema: Schema) -> Vec<CacheRecord> {
         }
     }
     records
-}
-
-pub fn get_log_path() -> PathBuf {
-    Path::new("./.dozer/pipeline/films").to_path_buf()
 }


### PR DESCRIPTION
Otherwise one of the tokio worker threads is blocked and can't be used for other tasks.

Also, tokio runtime will block forever when shutdown because we never yield.