### PR TITLE
chore: Make `AccessFilter::fields` optional

### DIFF
--- a/dozer-cache/src/reader.rs
+++ b/dozer-cache/src/reader.rs
@@ -17,6 +17,7 @@ pub struct AccessFilter {
     pub filter: Option<FilterExpression>,
 
     /// Fields to be restricted
+    #[serde(default)]
     pub fields: Vec<String>,
 }
 


### PR DESCRIPTION
So users don't have to write `{ "fields": [] }` when generating a token.