### PR TITLE
feat: Support loading dozer config from an url.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,31 +1895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,7 +2527,6 @@ dependencies = [
  "prost-reflect",
  "rand 0.8.5",
  "regex",
- "reqwest",
  "schema_registry_converter",
  "serial_test",
  "tempdir",
@@ -2603,7 +2577,6 @@ name = "dozer-orchestrator"
 version = "0.1.17"
 dependencies = [
  "clap 4.1.11",
- "crossterm",
  "ctrlc",
  "dotenvy",
  "dozer-api",
@@ -2618,6 +2591,7 @@ dependencies = [
  "handlebars",
  "include_dir",
  "page_size",
+ "reqwest",
  "rustyline",
  "rustyline-derive",
  "serde",
@@ -5842,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -6635,27 +6609,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
 
 [[package]]
 name = "signal-hook-registry"

--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -26,7 +26,6 @@ kafka = {version = "0.9.0", optional = true }
 # odbc connector
 odbc = { version = "0.17.0", optional = true }
 base64 = "0.21.0"
-reqwest = { version = "0.11.14", features = ["blocking", "rustls-tls"], default-features = false }
 include_dir = {version = "0.7.3", optional = true }
 schema_registry_converter = { version = "3.1.0", features = ["blocking", "avro"], optional = true }
 regex = "1"

--- a/dozer-orchestrator/Cargo.toml
+++ b/dozer-orchestrator/Cargo.toml
@@ -33,9 +33,9 @@ include_dir = "0.7.3"
 handlebars = "4.3.6"
 rustyline = "10.1.1"
 rustyline-derive = "0.8.0"
-crossterm = "0.26.0"
 futures = "0.3.26"
 page_size = "0.5.0"
+reqwest = "0.11.16"
 
 [[bin]]
 edition = "2021"

--- a/dozer-orchestrator/src/cli/helper.rs
+++ b/dozer-orchestrator/src/cli/helper.rs
@@ -6,10 +6,13 @@ use dozer_types::models::app_config::default_cache_max_map_size;
 use dozer_types::prettytable::{row, Table};
 use dozer_types::{models::app_config::Config, serde_yaml};
 use handlebars::Handlebars;
+use std::sync::Arc;
 use std::{collections::BTreeMap, fs};
+use tokio::runtime::Runtime;
 
 pub fn init_dozer(config_path: String) -> Result<Dozer, CliError> {
-    let mut config = load_config(config_path)?;
+    let runtime = Runtime::new().map_err(CliError::FailedToCreateTokioRuntime)?;
+    let mut config = runtime.block_on(load_config(&config_path))?;
 
     let cache_max_map_size = config
         .cache_max_map_size
@@ -17,7 +20,7 @@ pub fn init_dozer(config_path: String) -> Result<Dozer, CliError> {
     let page_size = page_size::get() as u64;
     config.cache_max_map_size = Some(cache_max_map_size / page_size * page_size);
 
-    Ok(Dozer::new(config))
+    Ok(Dozer::new(config, Arc::new(runtime)))
 }
 
 pub fn list_sources(config_path: &str) -> Result<(), OrchestrationError> {
@@ -42,13 +45,30 @@ pub fn list_sources(config_path: &str) -> Result<(), OrchestrationError> {
     Ok(())
 }
 
-pub fn load_config(config_path: String) -> Result<Config, CliError> {
-    let contents = fs::read_to_string(config_path.clone())
-        .map_err(|_| CliError::FailedToLoadFile(config_path))?;
+async fn load_config(config_url_or_path: &str) -> Result<Config, CliError> {
+    if config_url_or_path.starts_with("https://") || config_url_or_path.starts_with("http://") {
+        load_config_from_http_url(config_url_or_path).await
+    } else {
+        load_config_from_file(config_url_or_path)
+    }
+}
 
+async fn load_config_from_http_url(config_url: &str) -> Result<Config, CliError> {
+    let response = reqwest::get(config_url).await?.error_for_status()?;
+    let contents = response.text().await?;
+    parse_config(&contents)
+}
+
+pub fn load_config_from_file(config_path: &str) -> Result<Config, CliError> {
+    let contents = fs::read_to_string(config_path)
+        .map_err(|e| CliError::FileSystem(config_path.to_string().into(), e))?;
+    parse_config(&contents)
+}
+
+fn parse_config(config_template: &str) -> Result<Config, CliError> {
     let mut handlebars = Handlebars::new();
     handlebars
-        .register_template_string("config", contents)
+        .register_template_string("config", config_template)
         .map_err(|e| CliError::FailedToParseYaml(Box::new(e)))?;
 
     let mut data = BTreeMap::new();
@@ -61,11 +81,12 @@ pub fn load_config(config_path: String) -> Result<Config, CliError> {
         .render("config", &data)
         .map_err(|e| CliError::FailedToParseYaml(Box::new(e)))?;
 
-    let config: Config =
-        serde_yaml::from_str(&config_str).map_err(|e| CliError::FailedToParseYaml(Box::new(e)))?;
+    let config: Config = serde_yaml::from_str(&config_str)
+        .map_err(|e: serde_yaml::Error| CliError::FailedToParseYaml(Box::new(e)))?;
 
     // Create home_dir if not exists.
-    let _res = fs::create_dir_all(&config.home_dir);
+    fs::create_dir_all(&config.home_dir)
+        .map_err(|e| CliError::FileSystem(config.home_dir.clone().into(), e))?;
 
     Ok(config)
 }

--- a/dozer-orchestrator/src/cli/init.rs
+++ b/dozer-orchestrator/src/cli/init.rs
@@ -172,7 +172,10 @@ pub fn generate_config_repl() -> Result<(), OrchestrationError> {
                     .write(true)
                     .open(yaml_path)
                     .map_err(|e| {
-                        OrchestrationError::CliError(CliError::InternalError(Box::new(e)))
+                        OrchestrationError::CliError(CliError::FileSystem(
+                            yaml_path.to_string().into(),
+                            e,
+                        ))
                     })?;
                 serde_yaml::to_writer(f, &config)
                     .map_err(OrchestrationError::FailedToWriteConfigYaml)?;

--- a/dozer-orchestrator/src/cli/mod.rs
+++ b/dozer-orchestrator/src/cli/mod.rs
@@ -1,5 +1,5 @@
 mod helper;
 mod init;
 pub mod types;
-pub use helper::{init_dozer, list_sources, load_config, LOGO};
+pub use helper::{init_dozer, list_sources, load_config_from_file, LOGO};
 pub use init::{generate_config_repl, generate_connection};

--- a/dozer-orchestrator/src/errors.rs
+++ b/dozer-orchestrator/src/errors.rs
@@ -86,10 +86,12 @@ pub enum CliError {
     FailedToParseYaml(#[source] BoxedError),
     #[error("Failed to validate dozer config: {0:?}")]
     FailedToParseValidateYaml(#[source] BoxedError),
-    #[error(transparent)]
+    #[error("Failed to read line: {0}")]
     ReadlineError(#[from] rustyline::error::ReadlineError),
-    #[error(transparent)]
-    InternalError(#[from] BoxedError),
-    #[error(transparent)]
-    TerminalError(#[from] crossterm::ErrorKind),
+    #[error("File system error {0:?}: {1}")]
+    FileSystem(PathBuf, #[source] std::io::Error),
+    #[error("Failed to create tokio runtime: {0}")]
+    FailedToCreateTokioRuntime(#[source] std::io::Error),
+    #[error("Reqwest error: {0}")]
+    Reqwest(#[from] reqwest::Error),
 }

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -48,8 +48,7 @@ pub struct SimpleOrchestrator {
 }
 
 impl SimpleOrchestrator {
-    pub fn new(config: Config) -> Self {
-        let runtime = Arc::new(Runtime::new().expect("Failed to initialize tokio runtime"));
+    pub fn new(config: Config, runtime: Arc<Runtime>) -> Self {
         Self {
             config,
             runtime,

--- a/dozer-tests/src/e2e_tests/case.rs
+++ b/dozer-tests/src/e2e_tests/case.rs
@@ -1,4 +1,4 @@
-use dozer_orchestrator::cli::load_config;
+use dozer_orchestrator::cli::load_config_from_file;
 use std::{
     collections::HashMap,
     fs::read_to_string,
@@ -36,7 +36,7 @@ pub struct Case {
 impl Case {
     pub fn load_from_case_dir(case_dir: PathBuf, connections_dir: PathBuf) -> Self {
         let dozer_config_path = find_dozer_config_path(&case_dir);
-        let dozer_config = load_config(dozer_config_path.clone())
+        let dozer_config = load_config_from_file(&dozer_config_path)
             .unwrap_or_else(|e| panic!("Cannot read file: {}: {:?}", &dozer_config_path, e));
         let mut connections = HashMap::new();
         for connection in &dozer_config.connections {

--- a/dozer-tests/src/tests/e2e/mod.rs
+++ b/dozer-tests/src/tests/e2e/mod.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, thread::JoinHandle, time::Duration};
+use std::{future::Future, sync::Arc, thread::JoinHandle, time::Duration};
 
 use dozer_api::tonic::transport::Channel;
 use dozer_orchestrator::{
@@ -15,6 +15,7 @@ use dozer_types::{
     serde_yaml,
 };
 use tempdir::TempDir;
+use tokio::runtime::Runtime;
 
 mod basic;
 mod basic_sql;
@@ -49,7 +50,8 @@ impl DozerE2eTest {
             }
         }
 
-        let mut dozer = SimpleOrchestrator::new(config);
+        let runtime = Runtime::new().expect("Failed to create runtime");
+        let mut dozer = SimpleOrchestrator::new(config, Arc::new(runtime));
         let (shutdown_sender, shutdown_receiver) = shutdown::new(&dozer.runtime);
         let dozer_thread = std::thread::spawn(move || {
             dozer.run_all(shutdown_receiver).unwrap();


### PR DESCRIPTION
Part of #1408 

Tested with

```bash
cargo run -- -c https://raw.githubusercontent.com/getdozer/dozer-samples/main/connectors/local-storage/dozer-config.yaml
```

Also fixes #1345.