### PR TITLE
feat: allow disabling of grpc & rest apis via config

### DIFF
--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -102,29 +102,37 @@ impl Orchestrator for SimpleOrchestrator {
 
             // Initialize API Server
             let rest_config = get_rest_config(self.config.to_owned());
-            let security = get_api_security_config(self.config.to_owned());
-            let cache_endpoints_for_rest = cache_endpoints.clone();
-            let shutdown_for_rest = shutdown.create_shutdown_future();
-            let rest_handle = tokio::spawn(async move {
-                let api_server = rest::ApiServer::new(rest_config, security);
-                api_server
-                    .run(cache_endpoints_for_rest, shutdown_for_rest)
-                    .await
-                    .map_err(OrchestrationError::ApiServerFailed)
-            });
+            let rest_handle = if rest_config.enabled {
+                let security = get_api_security_config(self.config.to_owned());
+                let cache_endpoints_for_rest = cache_endpoints.clone();
+                let shutdown_for_rest = shutdown.create_shutdown_future();
+                tokio::spawn(async move {
+                    let api_server = rest::ApiServer::new(rest_config, security);
+                    api_server
+                        .run(cache_endpoints_for_rest, shutdown_for_rest)
+                        .await
+                        .map_err(OrchestrationError::ApiServerFailed)
+                })
+            } else {
+                tokio::spawn(async move { Ok::<(), OrchestrationError>(()) })
+            };
 
             // Initialize gRPC Server
-            let api_dir = get_api_dir(&self.config);
             let grpc_config = get_grpc_config(self.config.to_owned());
-            let api_security = get_api_security_config(self.config.to_owned());
-            let grpc_server = grpc::ApiServer::new(grpc_config, api_dir, api_security, flags);
-            let shutdown = shutdown.create_shutdown_future();
-            let grpc_handle = tokio::spawn(async move {
-                grpc_server
-                    .run(cache_endpoints, shutdown, operations_receiver)
-                    .await
-                    .map_err(OrchestrationError::GrpcServerFailed)
-            });
+            let grpc_handle = if grpc_config.enabled {
+                let api_dir = get_api_dir(&self.config);
+                let api_security = get_api_security_config(self.config.to_owned());
+                let grpc_server = grpc::ApiServer::new(grpc_config, api_dir, api_security, flags);
+                let shutdown = shutdown.create_shutdown_future();
+                tokio::spawn(async move {
+                    grpc_server
+                        .run(cache_endpoints, shutdown, operations_receiver)
+                        .await
+                        .map_err(OrchestrationError::GrpcServerFailed)
+                })
+            } else {
+                tokio::spawn(async move { Ok::<(), OrchestrationError>(()) })
+            };
 
             futures.push(flatten_join_handle(rest_handle));
             futures.push(flatten_join_handle(grpc_handle));

--- a/dozer-types/src/models/api_config.rs
+++ b/dozer-types/src/models/api_config.rs
@@ -74,7 +74,7 @@ pub(crate) fn default_api_rest() -> Option<RestApiOptions> {
         port: default_rest_port(),
         host: default_host(),
         cors: default_cors(),
-        enabled: true
+        enabled: true,
     })
 }
 pub(crate) fn default_api_grpc() -> Option<GrpcApiOptions> {

--- a/dozer-types/src/models/api_config.rs
+++ b/dozer-types/src/models/api_config.rs
@@ -30,6 +30,9 @@ pub struct RestApiOptions {
     #[prost(bool, tag = "3")]
     #[serde(default = "default_cors")]
     pub cors: bool,
+    #[prost(bool, tag = "4")]
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
 }
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, prost::Message)]
 pub struct GrpcApiOptions {
@@ -45,6 +48,9 @@ pub struct GrpcApiOptions {
     #[prost(bool, tag = "4")]
     #[serde(default = "default_enable_web")]
     pub web: bool,
+    #[prost(bool, tag = "5")]
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
 }
 
 fn default_app_grpc_port() -> u32 {
@@ -60,6 +66,7 @@ pub(crate) fn default_app_grpc() -> Option<GrpcApiOptions> {
         host: default_app_grpc_host(),
         cors: false,
         web: false,
+        enabled: true,
     })
 }
 pub(crate) fn default_api_rest() -> Option<RestApiOptions> {
@@ -67,6 +74,7 @@ pub(crate) fn default_api_rest() -> Option<RestApiOptions> {
         port: default_rest_port(),
         host: default_host(),
         cors: default_cors(),
+        enabled: true
     })
 }
 pub(crate) fn default_api_grpc() -> Option<GrpcApiOptions> {
@@ -75,6 +83,7 @@ pub(crate) fn default_api_grpc() -> Option<GrpcApiOptions> {
         host: default_host(),
         cors: default_cors(),
         web: default_enable_web(),
+        enabled: true,
     })
 }
 fn default_grpc_port() -> u32 {
@@ -87,6 +96,9 @@ fn default_enable_web() -> bool {
     true
 }
 fn default_cors() -> bool {
+    true
+}
+fn default_enabled() -> bool {
     true
 }
 

--- a/dozer-types/src/tests/api_config_yaml_deserialize.rs
+++ b/dozer-types/src/tests/api_config_yaml_deserialize.rs
@@ -32,6 +32,7 @@ fn override_rest_port() {
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), default_api_grpc);
 }
+
 #[test]
 fn override_rest_host() {
     let input_config = r#"
@@ -58,6 +59,7 @@ fn override_rest_host() {
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), default_api_grpc);
 }
+
 #[test]
 fn override_rest_enabled() {
     let input_config = r#"
@@ -84,6 +86,7 @@ fn override_rest_enabled() {
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), default_api_grpc);
 }
+
 #[test]
 fn override_grpc_port() {
     let input_config = r#"
@@ -219,6 +222,7 @@ fn override_grpc_and_rest_port_jwt() {
     let expected_api_security = ApiSecurity::Jwt("Vv44T1GugX".to_owned());
     assert_eq!(api_security, expected_api_security);
 }
+
 #[test]
 fn override_grpc_and_rest_port_jwt_pipeline_home_dir() {
     let input_config = r#"

--- a/dozer-types/src/tests/api_config_yaml_deserialize.rs
+++ b/dozer-types/src/tests/api_config_yaml_deserialize.rs
@@ -27,6 +27,7 @@ fn override_rest_port() {
         port: 9876,
         host: default_api_rest.host,
         cors: default_api_rest.cors,
+        enabled: true,
     };
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), default_api_grpc);
@@ -52,6 +53,33 @@ fn override_rest_host() {
         port: default_api_rest.port,
         host: "localhost".to_owned(),
         cors: default_api_rest.cors,
+        enabled: true,
+    };
+    assert_eq!(api_config.rest.unwrap(), expected_rest_config);
+    assert_eq!(api_config.grpc.unwrap(), default_api_grpc);
+}
+#[test]
+fn override_rest_enabled() {
+    let input_config = r#"
+    app_name: working_app
+    api:
+      rest:
+        enabled: false
+    home_dir: './.dozer' 
+  "#;
+    let deserialize_result = serde_yaml::from_str::<Config>(input_config);
+    assert!(deserialize_result.is_ok());
+    let api_config = deserialize_result.unwrap().api;
+    assert!(api_config.is_some());
+    let api_config = api_config.unwrap();
+    assert!(api_config.rest.is_some());
+    let default_api_rest = default_api_rest().unwrap();
+    let default_api_grpc = default_api_grpc().unwrap();
+    let expected_rest_config = RestApiOptions {
+        port: default_api_rest.port,
+        host: default_api_rest.host,
+        cors: default_api_rest.cors,
+        enabled: false,
     };
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), default_api_grpc);
@@ -78,6 +106,36 @@ fn override_grpc_port() {
         host: default_api_grpc.host,
         cors: default_api_grpc.cors,
         web: default_api_grpc.web,
+        enabled: true,
+    };
+    assert_eq!(api_config.rest.unwrap(), default_api_rest);
+    assert_eq!(api_config.grpc.unwrap(), expected_grpc_config);
+}
+
+#[test]
+fn override_grpc_enabled() {
+    let input_config = r#"
+  app_name: working_app
+  api:
+    grpc:
+      enabled: false
+  home_dir: './.dozer' 
+"#;
+    let deserialize_result = serde_yaml::from_str::<Config>(input_config);
+    assert!(deserialize_result.is_ok());
+    let api_config = deserialize_result.unwrap().api;
+    assert!(api_config.is_some());
+    let api_config = api_config.unwrap();
+    assert!(api_config.rest.is_some());
+    let default_api_rest = default_api_rest().unwrap();
+    let default_api_grpc = default_api_grpc().unwrap();
+    let expected_grpc_config = GrpcApiOptions {
+        enabled: false,
+        port: default_api_grpc.port,
+        host: default_api_grpc.host,
+        cors: default_api_grpc.cors,
+        web: default_api_grpc.web,
+        ..Default::default()
     };
     assert_eq!(api_config.rest.unwrap(), default_api_rest);
     assert_eq!(api_config.grpc.unwrap(), expected_grpc_config);
@@ -107,11 +165,13 @@ fn override_grpc_and_rest_port() {
         host: default_api_grpc.host,
         cors: default_api_grpc.cors,
         web: default_api_grpc.web,
+        enabled: true,
     };
     let expected_rest_config = RestApiOptions {
         port: 3324,
         host: default_api_rest.host,
         cors: default_api_rest.cors,
+        enabled: true,
     };
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), expected_grpc_config);
@@ -143,11 +203,13 @@ fn override_grpc_and_rest_port_jwt() {
         host: default_api_grpc.host,
         cors: default_api_grpc.cors,
         web: default_api_grpc.web,
+        enabled: true,
     };
     let expected_rest_config = RestApiOptions {
         port: 3324,
         host: default_api_rest.host,
         cors: default_api_rest.cors,
+        enabled: true,
     };
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), expected_grpc_config);
@@ -188,11 +250,13 @@ fn override_grpc_and_rest_port_jwt_pipeline_home_dir() {
         host: default_api_grpc.host,
         cors: default_api_grpc.cors,
         web: default_api_grpc.web,
+        enabled: true,
     };
     let expected_rest_config = RestApiOptions {
         port: 3324,
         host: default_api_rest.host,
         cors: default_api_rest.cors,
+        enabled: true,
     };
     assert_eq!(api_config.rest.unwrap(), expected_rest_config);
     assert_eq!(api_config.grpc.unwrap(), expected_grpc_config);

--- a/dozer-types/src/tests/postgres_yaml_deserialize.rs
+++ b/dozer-types/src/tests/postgres_yaml_deserialize.rs
@@ -20,6 +20,7 @@ fn standard() {
     let expected = ConnectionConfig::Postgres(postgres_auth);
     assert_eq!(expected, deserializer_result);
 }
+
 #[test]
 fn error_missing_field() {
     let posgres_config = r#"


### PR DESCRIPTION
There didn't seem to be any way of disabling either the rest or gRPC apis, this PR adds a new `enabled` flag to both `rest` and `grpc`. If `enabled: false`, the service will not be started at all. 