### PR TITLE
feat: Make secondary index configurable

### DIFF
--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -2,12 +2,16 @@ use std::{path::Path, sync::Arc};
 
 use crate::grpc::types_helper;
 use dozer_cache::dozer_log::reader::LogReader;
+use dozer_cache::errors::IndexError;
 use dozer_cache::{
     cache::{CacheRecord, CacheWriteOptions, RwCache, RwCacheManager, UpsertResult},
     errors::CacheError,
 };
 use dozer_core::executor::ExecutorOperation;
 use dozer_types::indicatif::MultiProgress;
+use dozer_types::models::api_endpoint::{
+    FullText, SecondaryIndex, SecondaryIndexConfig, SortedInverted,
+};
 use dozer_types::{
     grpc_types::types::Operation as GrpcOperation,
     log::error,
@@ -23,6 +27,7 @@ use tokio::{runtime::Runtime, sync::broadcast::Sender};
 pub async fn create_cache(
     cache_manager: &dyn RwCacheManager,
     schema: Schema,
+    secondary_index_config: &SecondaryIndexConfig,
     runtime: Arc<Runtime>,
     cancel: impl Future<Output = ()> + Unpin,
     log_path: &Path,
@@ -30,8 +35,8 @@ pub async fn create_cache(
     operations_sender: Option<(String, Sender<GrpcOperation>)>,
     multi_pb: Option<MultiProgress>,
 ) -> Result<(String, impl FnOnce() -> Result<(), CacheError>), CacheError> {
-    // Automatically create secondary indexes
-    let secondary_indexes = generate_secondary_indexes(&schema.fields);
+    // Create secondary indexes
+    let secondary_indexes = generate_secondary_indexes(&schema.fields, secondary_index_config)?;
     // Create the cache.
     let cache = cache_manager.create_cache(schema.clone(), secondary_indexes, write_options)?;
     let name = cache.name().to_string();
@@ -125,11 +130,19 @@ fn build_cache(
     Ok(())
 }
 
-fn generate_secondary_indexes(fields: &[FieldDefinition]) -> Vec<IndexDefinition> {
-    fields
-        .iter()
-        .enumerate()
-        .flat_map(|(idx, f)| match f.typ {
+fn generate_secondary_indexes(
+    field_definitions: &[FieldDefinition],
+    config: &SecondaryIndexConfig,
+) -> Result<Vec<IndexDefinition>, CacheError> {
+    let mut result = vec![];
+
+    // Create default indexes unless skipped.
+    for (index, field) in field_definitions.iter().enumerate() {
+        if config.skip_default.contains(&field.name) {
+            continue;
+        }
+
+        match field.typ {
             // Create sorted inverted indexes for these fields
             FieldType::UInt
             | FieldType::U128
@@ -141,22 +154,48 @@ fn generate_secondary_indexes(fields: &[FieldDefinition]) -> Vec<IndexDefinition
             | FieldType::Timestamp
             | FieldType::Date
             | FieldType::Point
-            | FieldType::Duration => vec![IndexDefinition::SortedInverted(vec![idx])],
+            | FieldType::Duration => result.push(IndexDefinition::SortedInverted(vec![index])),
 
             // Create sorted inverted and full text indexes for string fields.
-            FieldType::String => vec![
-                IndexDefinition::SortedInverted(vec![idx]),
-                IndexDefinition::FullText(idx),
-            ],
-
-            // Create full text indexes for text fields
-            // FieldType::Text => vec![IndexDefinition::FullText(idx)],
-            FieldType::Text => vec![],
+            FieldType::String => {
+                result.push(IndexDefinition::SortedInverted(vec![index]));
+                result.push(IndexDefinition::FullText(index));
+            }
 
             // Skip creating indexes
-            FieldType::Binary | FieldType::Bson => vec![],
-        })
-        .collect()
+            FieldType::Text | FieldType::Binary | FieldType::Bson => (),
+        }
+    }
+
+    // Create requested indexes.
+    fn field_index_from_field_name(
+        fields: &[FieldDefinition],
+        field_name: &str,
+    ) -> Result<usize, IndexError> {
+        fields
+            .iter()
+            .position(|field| field.name == field_name)
+            .ok_or(IndexError::UnknownFieldName(field_name.to_string()))
+    }
+    for create in &config.create {
+        if let Some(index) = &create.index {
+            match index {
+                SecondaryIndex::SortedInverted(SortedInverted { fields }) => {
+                    let fields = fields
+                        .iter()
+                        .map(|field| field_index_from_field_name(field_definitions, field))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    result.push(IndexDefinition::SortedInverted(fields));
+                }
+                SecondaryIndex::FullText(FullText { field }) => {
+                    let field = field_index_from_field_name(field_definitions, field)?;
+                    result.push(IndexDefinition::FullText(field));
+                }
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 async fn next_op_with_cancel<F: Future<Output = ()> + Unpin>(

--- a/dozer-api/src/lib.rs
+++ b/dozer-api/src/lib.rs
@@ -9,11 +9,17 @@ use dozer_types::{
     log::info,
     models::api_endpoint::{
         ApiEndpoint, OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes,
+        SecondaryIndexConfig,
     },
     types::Schema,
 };
 use futures_util::Future;
-use std::{ops::Deref, path::Path, sync::Arc};
+use std::{
+    borrow::{Borrow, Cow},
+    ops::Deref,
+    path::Path,
+    sync::Arc,
+};
 
 mod api_helper;
 
@@ -51,6 +57,7 @@ impl CacheEndpoint {
             let (cache_name, task) = cache_builder::create_cache(
                 cache_manager,
                 schema,
+                get_secondary_index_config(&endpoint).borrow(),
                 runtime,
                 cancel,
                 log_path,
@@ -123,6 +130,18 @@ fn open_existing_cache_reader(
     name: &str,
 ) -> Result<CacheReader, ApiError> {
     open_cache_reader(cache_manager, name)?.ok_or_else(|| ApiError::CacheNotFound(name.to_string()))
+}
+
+fn get_secondary_index_config(api_endpoint: &ApiEndpoint) -> Cow<SecondaryIndexConfig> {
+    if let Some(config) = api_endpoint
+        .index
+        .as_ref()
+        .and_then(|index| index.secondary.as_ref())
+    {
+        Cow::Borrowed(config)
+    } else {
+        Cow::Owned(SecondaryIndexConfig::default())
+    }
 }
 
 // Exports

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -64,6 +64,7 @@ pub fn get_endpoint() -> ApiEndpoint {
         path: "/films".to_string(),
         index: Some(ApiIndex {
             primary_key: vec!["film_id".to_string()],
+            secondary: None,
         }),
         table_name: "film".to_string(),
         conflict_resolution: None,

--- a/dozer-cache/src/errors.rs
+++ b/dozer-cache/src/errors.rs
@@ -7,6 +7,7 @@ use dozer_types::thiserror::Error;
 use dozer_log::errors::ReaderError;
 use dozer_types::errors::types::{DeserializationError, SerializationError, TypeError};
 use dozer_types::types::{IndexDefinition, SchemaWithIndex};
+
 #[derive(Error, Debug)]
 pub enum CacheError {
     #[error("Io error on {0:?}: {1}")]
@@ -131,6 +132,6 @@ pub enum PlanError {
     ConflictingSortOptions,
     #[error("Cannot have more than one range query")]
     RangeQueryLimit,
-    #[error("Matching index not found")]
-    MatchingIndexNotFound,
+    #[error("Matching index not found. Try to add following secondary index configuration:\n{0}")]
+    MatchingIndexNotFound(String),
 }

--- a/dozer-cache/src/errors.rs
+++ b/dozer-cache/src/errors.rs
@@ -115,6 +115,8 @@ pub enum IndexError {
     UnsupportedMultiRangeIndex,
     #[error("Compound_index is required for fields: {0}")]
     MissingCompoundIndex(String),
+    #[error("Unknown filed name {0} in secondary index config")]
+    UnknownFieldName(String),
 }
 
 #[derive(Error, Debug)]

--- a/dozer-types/src/lib.rs
+++ b/dozer-types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod helper;
 pub mod ingestion_types;
 pub mod models;
 pub mod node;
+#[cfg(test)]
 mod tests;
 pub mod types;
 

--- a/dozer-types/src/models/api_endpoint.rs
+++ b/dozer-types/src/models/api_endpoint.rs
@@ -7,7 +7,47 @@ use serde_yaml::Value;
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Message)]
 pub struct ApiIndex {
     #[prost(string, repeated, tag = "1")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub primary_key: Vec<String>,
+    #[prost(message, tag = "2")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secondary: Option<SecondaryIndexConfig>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Message)]
+pub struct SecondaryIndexConfig {
+    #[prost(string, repeated, tag = "1")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skip_default: Vec<String>,
+    #[prost(message, repeated, tag = "2")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub create: Vec<CreateSecondaryIndex>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Message)]
+pub struct CreateSecondaryIndex {
+    #[prost(oneof = "SecondaryIndex", tags = "1,2")]
+    pub index: Option<SecondaryIndex>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Oneof)]
+pub enum SecondaryIndex {
+    #[prost(message, tag = "1")]
+    SortedInverted(SortedInverted),
+    #[prost(message, tag = "2")]
+    FullText(FullText),
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Message)]
+pub struct SortedInverted {
+    #[prost(string, repeated, tag = "1")]
+    pub fields: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Message)]
+pub struct FullText {
+    #[prost(string, tag = "1")]
+    pub field: String,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, ::prost::Enumeration)]

--- a/dozer-types/src/tests.rs
+++ b/dozer-types/src/tests.rs
@@ -1,12 +1,7 @@
-#[cfg(test)]
 mod api_config_yaml_deserialize;
-#[cfg(test)]
 mod dozer_yaml_deserialize;
-#[cfg(test)]
 mod eth_yaml_deserialize;
-#[cfg(test)]
 mod field_serialize_test;
-#[cfg(test)]
 mod flags_config_yaml_deserialize;
-#[cfg(test)]
 mod postgres_yaml_deserialize;
+mod secondary_index_yaml_deserialize;

--- a/dozer-types/src/tests/secondary_index_yaml_deserialize.rs
+++ b/dozer-types/src/tests/secondary_index_yaml_deserialize.rs
@@ -1,0 +1,43 @@
+use crate::models::api_endpoint::{
+    CreateSecondaryIndex, FullText, SecondaryIndex, SecondaryIndexConfig, SortedInverted,
+};
+
+#[test]
+fn standard() {
+    let secondary = r#"skip_default:
+  - field1
+  - field2
+create:
+    - index: !SortedInverted
+        fields:
+            - field1
+            - field2
+    - index: !FullText
+        field: field3
+"#;
+    let config: SecondaryIndexConfig = serde_yaml::from_str(secondary).unwrap();
+    assert_eq!(config.skip_default, vec!["field1", "field2"]);
+    assert_eq!(
+        config.create,
+        vec![
+            CreateSecondaryIndex {
+                index: Some(SecondaryIndex::SortedInverted(SortedInverted {
+                    fields: vec!["field1".to_string(), "field2".to_string()]
+                }))
+            },
+            CreateSecondaryIndex {
+                index: Some(SecondaryIndex::FullText(FullText {
+                    field: "field3".to_string()
+                }))
+            }
+        ]
+    );
+}
+
+#[test]
+fn empty() {
+    let secondary = "";
+    let config: SecondaryIndexConfig = serde_yaml::from_str(secondary).unwrap();
+    assert_eq!(config.skip_default, Vec::<String>::new());
+    assert_eq!(config.create, vec![]);
+}


### PR DESCRIPTION
This PR adds to the configuration file the option of skip default secondary indexes and create new indexes.

The configuration format is not as nice as we wanted because protobuf doesn't support `repeated oneof` or `repeated` within `oneof`. On that note, I think it's time to consider decoupling our configuration format and protobuf.

Closes #1445.

Tested with data in https://github.com/getdozer/dozer-samples/tree/main/sql/join, and query:

```json
POST localhost:8080/trips/query
{
    "$filter": {
        "hvfhs_license_num": "HV0003"
    },
    "$order_by": {
        "trip_miles": "desc"
    }
}
```

# Error message format

With configuration:

```yaml
connections:    
  - config : !LocalStorage
      details:
        path: data
      tables:
        - !Table
          name: trips
          prefix: /trips
          file_type: parquet
          extension: .parquet
    name: ny_taxi

endpoints:
  - name: trips
    path: /trips
    table_name: trips
    index:
      secondary:
        create:

cache_max_map_size: 10000000000
```

We get 500:

```yaml
Failed to query cache: Plan error: Matching index not found. Try to add following secondary index configuration:
- index: !SortedInverted
    fields:
    - hvfhs_license_num
    - trip_miles
```

# After index creation

If we add the configuration:

```yaml
connections:    
  - config : !LocalStorage
      details:
        path: data
      tables:
        - !Table
          name: trips
          prefix: /trips
          file_type: parquet
          extension: .parquet
    name: ny_taxi

endpoints:
  - name: trips
    path: /trips
    table_name: trips
    index:
      secondary:
        create:
          - index: !SortedInverted
              fields:
              - hvfhs_license_num
              - trip_miles

cache_max_map_size: 10000000000
```

We get query results:

```json
[
    {
        "hvfhs_license_num": "HV0003",
        "dispatching_base_num": "B03404",
        "originating_base_num": "B03404",
        "request_datetime": "2022-01-01T00:13:51.000Z",
        "on_scene_datetime": "2022-01-01T00:19:52.000Z",
        "pickup_datetime": "2022-01-01T00:19:52.000Z",
        "dropoff_datetime": "2022-01-01T01:34:54.000Z",
        "PULocationID": 138,
        "DOLocationID": 265,
        "trip_miles": 63.33,
        "trip_time": 4502,
        "base_passenger_fare": 166.66,
        "tolls": 26.55,
        "bcf": 5.87,
        "sales_tax": 0.0,
        "congestion_surcharge": 0.0,
        "airport_fee": 2.5,
        "tips": 0.0,
        "driver_pay": 127.05,
        "shared_request_flag": "N",
        "shared_match_flag": "N",
        "access_a_ride_flag": " ",
        "wav_request_flag": "N",
        "wav_match_flag": "N",
        "__dozer_record_id": 8283,
        "__dozer_record_version": 1
    },
    {
        "hvfhs_license_num": "HV0003",
        "dispatching_base_num": "B03404",
        "originating_base_num": "B03404",
        "request_datetime": "2022-01-01T00:37:13.000Z",
        "on_scene_datetime": "2022-01-01T00:52:47.000Z",
        "pickup_datetime": "2022-01-01T00:53:17.000Z",
        "dropoff_datetime": "2022-01-01T02:01:14.000Z",
        "PULocationID": 168,
        "DOLocationID": 265,
        "trip_miles": 61.04,
        "trip_time": 4077,
        "base_passenger_fare": 156.82,
        "tolls": 20.0,
        "bcf": 5.45,
        "sales_tax": 16.14,
        "congestion_surcharge": 0.0,
        "airport_fee": 0.0,
        "tips": 0.0,
        "driver_pay": 121.03,
        "shared_request_flag": "N",
        "shared_match_flag": "N",
        "access_a_ride_flag": " ",
        "wav_request_flag": "N",
        "wav_match_flag": "N",
        "__dozer_record_id": 20654,
        "__dozer_record_version": 1
    },
    ...
]
```