### PR TITLE
chore: Add dozer-log-python CI

### DIFF
--- a/.github/workflows/dozer-log-python.yml
+++ b/.github/workflows/dozer-log-python.yml
@@ -9,26 +9,33 @@ on:
   push:
     branches:
       - main
+      - dozer-log-python-ci-dev
     tags:
       - '*'
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: dozer-log-python/${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-
-defaults:
-  run:
-    working-directory: dozer-log-python
 
 jobs:
   linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -39,11 +46,13 @@ jobs:
           args: --release --out dist --find-interpreter --features python-extension-module
           sccache: 'true'
           manylinux: auto
+          container: off
+          working-directory: dozer-log-python
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: dozer-log-python/dist
 
   windows:
     runs-on: windows-latest
@@ -52,6 +61,12 @@ jobs:
         target: [x64, x86]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -60,13 +75,14 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --find-interpreter --features python-extension-module
           sccache: 'true'
+          working-directory: dozer-log-python
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: dozer-log-python/dist
 
   macos:
     runs-on: macos-latest
@@ -75,6 +91,12 @@ jobs:
         target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -82,34 +104,20 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --find-interpreter --features python-extension-module
           sccache: 'true'
+          working-directory: dozer-log-python
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
-
-  sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build sdist
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out dist
-      - name: Upload sdist
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
+          path: dozer-log-python/dist
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, windows, macos, sdist]
+    needs: [linux, windows, macos]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/dozer-log-python/Cargo.toml
+++ b/dozer-log-python/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [lib]
 name = "dozer_log"
+crate-type = ["cdylib"]
 
 [dependencies]
 dozer-log = { path = "../dozer-log", optional = true }

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -29,4 +29,4 @@ tempdir = "0.3.7"
 proptest = "1.1.0"
 
 [features]
-python = []
+python = ["dozer-types/python-auto-initialize"]

--- a/dozer-tests/Cargo.toml
+++ b/dozer-tests/Cargo.toml
@@ -56,5 +56,4 @@ tempdir = "0.3.7"
 
 [features]
 mongodb = ["dep:bson", "dep:mongodb", "dep:futures"]
-python=["dozer-types/python", "dozer-sql/python"]
-
+python=["dozer-sql/python"]

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -26,7 +26,7 @@ fp_rust = "0.3.5"
 prettytable-rs = "0.10.0"
 indicatif = "0.17.3"
 geo = {version = "0.24.0", features = ["use-serde"]}
-pyo3 = {version = "0.18.1", features = ["auto-initialize"],  optional = true}
+pyo3 = {version = "0.18.1", optional = true}
 tonic = {version = "0.8.3"}
 prost-types = "0.11.1"
 prost = "0.11.8"
@@ -38,6 +38,6 @@ arrow-schema = { version = "33.0.0", features=["serde"]}
 tonic-build = "0.8.2"
 
 [features]
-python = ["dep:pyo3"]
-python-extension-module = ["python", "pyo3?/extension-module"]
+python-extension-module = ["dep:pyo3", "pyo3?/extension-module"]
+python-auto-initialize = ["dep:pyo3", "pyo3?/auto-initialize"]
 snowflake=[]

--- a/dozer-types/src/lib.rs
+++ b/dozer-types/src/lib.rs
@@ -36,7 +36,10 @@ pub use tonic;
 #[macro_use]
 pub extern crate prettytable;
 
-#[cfg(feature = "python")]
+#[cfg(any(
+    feature = "python-auto-initialize",
+    feature = "python-extension-module"
+))]
 pub use pyo3;
 pub use rust_decimal;
 pub use serde;

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -762,7 +762,10 @@ pub fn field_test_cases() -> impl Iterator<Item = Field> {
     .into_iter()
 }
 
-#[cfg(feature = "python")]
+#[cfg(any(
+    feature = "python-auto-initialize",
+    feature = "python-extension-module"
+))]
 impl pyo3::ToPyObject for Field {
     fn to_object(&self, py: pyo3::Python<'_>) -> pyo3::PyObject {
         match self {


### PR DESCRIPTION
Linux cross compilation doesn't work yet. We're able to build for linux x86_64, all windows and macos now.