### PR TITLE
chore: Move log related code to `dozer-types` and `dozer-log`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,6 @@ dependencies = [
 name = "dozer-log"
 version = "0.1.18"
 dependencies = [
- "dozer-core",
  "dozer-types",
  "futures-util",
  "tokio",
@@ -2469,10 +2468,7 @@ dependencies = [
 name = "dozer-log-js"
 version = "0.1.18"
 dependencies = [
- "dozer-api",
- "dozer-core",
  "dozer-log",
- "dozer-orchestrator",
  "dozer-types",
  "neon",
 ]
@@ -2481,9 +2477,7 @@ dependencies = [
 name = "dozer-log-python"
 version = "0.1.18"
 dependencies = [
- "dozer-core",
  "dozer-log",
- "dozer-orchestrator",
  "dozer-types",
  "pyo3-asyncio",
 ]

--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -7,7 +7,7 @@ use dozer_cache::{
     cache::{CacheRecord, CacheWriteOptions, RwCache, RwCacheManager, UpsertResult},
     errors::CacheError,
 };
-use dozer_core::executor::ExecutorOperation;
+use dozer_types::epoch::ExecutorOperation;
 use dozer_types::indicatif::MultiProgress;
 use dozer_types::models::api_endpoint::{
     FullText, SecondaryIndex, SecondaryIndexConfig, SortedInverted,

--- a/dozer-api/src/rest/api_generator.rs
+++ b/dozer-api/src/rest/api_generator.rs
@@ -5,13 +5,12 @@ use actix_web::{web, HttpResponse};
 use dozer_cache::cache::expression::{default_limit_for_query, QueryExpression, Skip};
 use dozer_cache::cache::CacheRecord;
 use dozer_cache::CacheReader;
-use dozer_types::chrono::SecondsFormat;
 use dozer_types::errors::types::TypeError;
 use dozer_types::indexmap::IndexMap;
+use dozer_types::json_types::field_to_json_value;
 use dozer_types::log::warn;
 use dozer_types::models::api_endpoint::ApiEndpoint;
-use dozer_types::ordered_float::OrderedFloat;
-use dozer_types::types::{DozerDuration, Field, Schema, DATE_FORMAT};
+use dozer_types::types::{Field, Schema};
 use openapiv3::OpenAPI;
 
 use crate::api_helper::{get_record, get_records, get_records_count};
@@ -20,7 +19,7 @@ use crate::CacheEndpoint;
 use crate::{auth::Access, errors::ApiError};
 use dozer_types::grpc_types::health::health_check_response::ServingStatus;
 use dozer_types::serde_json;
-use dozer_types::serde_json::{json, Map, Value};
+use dozer_types::serde_json::{json, Value};
 
 fn generate_oapi3(reader: &CacheReader, endpoint: ApiEndpoint) -> Result<OpenAPI, ApiError> {
     let (schema, secondary_indexes) = reader.get_schema();
@@ -183,110 +182,4 @@ fn record_to_map(
     );
 
     Ok(map)
-}
-
-fn convert_x_y_to_object((x, y): &(OrderedFloat<f64>, OrderedFloat<f64>)) -> Value {
-    let mut m = Map::new();
-    m.insert("x".to_string(), Value::from(x.0));
-    m.insert("y".to_string(), Value::from(y.0));
-    Value::Object(m)
-}
-
-fn convert_duration_to_object(d: &DozerDuration) -> Value {
-    let mut m = Map::new();
-    m.insert("value".to_string(), Value::from(d.0.as_nanos().to_string()));
-    m.insert("time_unit".to_string(), Value::from(d.1.to_string()));
-    Value::Object(m)
-}
-
-/// Used in REST APIs for converting raw value back and forth.
-///
-/// Should be consistent with `convert_cache_type_to_schema_type`.
-pub fn field_to_json_value(field: Field) -> Value {
-    match field {
-        Field::UInt(n) => Value::from(n),
-        Field::U128(n) => Value::String(n.to_string()),
-        Field::Int(n) => Value::from(n),
-        Field::I128(n) => Value::String(n.to_string()),
-        Field::Float(n) => Value::from(n.0),
-        Field::Boolean(b) => Value::from(b),
-        Field::String(s) => Value::from(s),
-        Field::Text(n) => Value::from(n),
-        Field::Binary(b) => Value::from(b),
-        Field::Decimal(n) => Value::String(n.to_string()),
-        Field::Timestamp(ts) => Value::String(ts.to_rfc3339_opts(SecondsFormat::Millis, true)),
-        Field::Date(n) => Value::String(n.format(DATE_FORMAT).to_string()),
-        Field::Bson(b) => Value::from(b),
-        Field::Point(point) => convert_x_y_to_object(&point.0.x_y()),
-        Field::Duration(d) => convert_duration_to_object(&d),
-        Field::Null => Value::Null,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use dozer_types::types::TimeUnit;
-    use dozer_types::{
-        chrono::{NaiveDate, Offset, TimeZone, Utc},
-        json_value_to_field,
-        ordered_float::OrderedFloat,
-        rust_decimal::Decimal,
-        types::{DozerPoint, Field, FieldType},
-    };
-    use std::time::Duration;
-
-    use super::*;
-
-    fn test_field_conversion(field_type: FieldType, field: Field) {
-        // Convert the field to a JSON value.
-        let value = field_to_json_value(field.clone());
-
-        // Convert the JSON value back to a Field.
-        let deserialized = json_value_to_field(value, field_type, true).unwrap();
-
-        assert_eq!(deserialized, field, "must be equal");
-    }
-
-    #[test]
-    fn test_field_types_json_conversion() {
-        let fields = vec![
-            (FieldType::Int, Field::Int(-1)),
-            (FieldType::UInt, Field::UInt(1)),
-            (FieldType::Float, Field::Float(OrderedFloat(1.1))),
-            (FieldType::Boolean, Field::Boolean(true)),
-            (FieldType::String, Field::String("a".to_string())),
-            (FieldType::Binary, Field::Binary(b"asdf".to_vec())),
-            (FieldType::Decimal, Field::Decimal(Decimal::new(202, 2))),
-            (
-                FieldType::Timestamp,
-                Field::Timestamp(Utc.fix().with_ymd_and_hms(2001, 1, 1, 0, 4, 0).unwrap()),
-            ),
-            (
-                FieldType::Date,
-                Field::Date(NaiveDate::from_ymd_opt(2022, 11, 24).unwrap()),
-            ),
-            (
-                FieldType::Bson,
-                Field::Bson(vec![
-                    // BSON representation of `{"abc":"foo"}`
-                    123, 34, 97, 98, 99, 34, 58, 34, 102, 111, 111, 34, 125,
-                ]),
-            ),
-            (FieldType::Text, Field::Text("lorem ipsum".to_string())),
-            (
-                FieldType::Point,
-                Field::Point(DozerPoint::from((3.234, 4.567))),
-            ),
-            (
-                FieldType::Duration,
-                Field::Duration(DozerDuration(
-                    Duration::from_nanos(123_u64),
-                    TimeUnit::Nanoseconds,
-                )),
-            ),
-        ];
-        for (field_type, field) in fields {
-            test_field_conversion(field_type, field);
-        }
-    }
 }

--- a/dozer-api/src/rest/mod.rs
+++ b/dozer-api/src/rest/mod.rs
@@ -25,8 +25,6 @@ use tracing_actix_web::TracingLogger;
 
 mod api_generator;
 
-pub use api_generator::field_to_json_value;
-
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[serde(crate = "self::serde")]
 enum CorsOptions {

--- a/dozer-core/src/epoch.rs
+++ b/dozer-core/src/epoch.rs
@@ -1,43 +1,9 @@
-use dozer_types::node::{NodeHandle, OpIdentifier, SourceStates};
 use dozer_types::parking_lot::Mutex;
-use dozer_types::serde::{self, Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
 use std::sync::{Arc, Barrier};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(crate = "self::serde")]
-pub struct Epoch {
-    pub id: u64,
-    pub details: SourceStates,
-}
-
-impl Epoch {
-    pub fn new(id: u64, details: SourceStates) -> Self {
-        Self { id, details }
-    }
-
-    pub fn from(id: u64, node_handle: NodeHandle, txid: u64, seq_in_tx: u64) -> Self {
-        Self {
-            id,
-            details: [(node_handle, OpIdentifier::new(txid, seq_in_tx))]
-                .into_iter()
-                .collect(),
-        }
-    }
-}
-
-impl Display for Epoch {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let details_str = self
-            .details
-            .iter()
-            .map(|e| format!("{} -> {}:{}", e.0, e.1.txid, e.1.seq_in_tx))
-            .fold(String::new(), |a, b| a + ", " + b.as_str());
-        f.write_str(format!("epoch: {}, details: {}", self.id, details_str).as_str())
-    }
-}
+pub use dozer_types::epoch::Epoch;
 
 #[derive(Debug)]
 enum EpochManagerState {

--- a/dozer-core/src/executor.rs
+++ b/dozer-core/src/executor.rs
@@ -5,9 +5,6 @@ use crate::Dag;
 
 use daggy::petgraph::visit::IntoNodeIdentifiers;
 use dozer_types::node::NodeHandle;
-use dozer_types::types::Operation;
-
-use crate::epoch::Epoch;
 
 use dozer_types::serde::{self, Deserialize, Serialize};
 use std::collections::hash_map::Entry;
@@ -43,15 +40,6 @@ impl Default for ExecutorOptions {
 pub(crate) enum InputPortState {
     Open,
     Terminated,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(crate = "self::serde")]
-pub enum ExecutorOperation {
-    Op { op: Operation },
-    Commit { epoch: Epoch },
-    Terminate,
-    SnapshottingDone {},
 }
 
 mod execution_dag;

--- a/dozer-core/src/executor/execution_dag.rs
+++ b/dozer-core/src/executor/execution_dag.rs
@@ -20,8 +20,7 @@ use daggy::petgraph::{
     visit::{EdgeRef, IntoEdges, IntoEdgesDirected, IntoNodeIdentifiers},
     Direction,
 };
-
-use super::ExecutorOperation;
+use dozer_types::epoch::ExecutorOperation;
 
 pub type SharedRecordWriter = Rc<RefCell<Option<Box<dyn RecordWriter>>>>;
 

--- a/dozer-core/src/executor/processor_node.rs
+++ b/dozer-core/src/executor/processor_node.rs
@@ -2,8 +2,9 @@ use std::{borrow::Cow, mem::swap};
 
 use crossbeam::channel::Receiver;
 use daggy::NodeIndex;
-use dozer_types::log::warn;
+use dozer_types::epoch::Epoch;
 use dozer_types::node::NodeHandle;
+use dozer_types::{epoch::ExecutorOperation, log::warn};
 
 use crate::{
     builder_dag::NodeKind,
@@ -12,9 +13,7 @@ use crate::{
     node::{PortHandle, Processor},
 };
 
-use super::{
-    execution_dag::ExecutionDag, name::Name, receiver_loop::ReceiverLoop, ExecutorOperation,
-};
+use super::{execution_dag::ExecutionDag, name::Name, receiver_loop::ReceiverLoop};
 
 /// A processor in the execution DAG.
 #[derive(Debug)]
@@ -96,7 +95,7 @@ impl ReceiverLoop for ProcessorNode {
         Ok(())
     }
 
-    fn on_commit(&mut self, epoch: &crate::epoch::Epoch) -> Result<(), ExecutionError> {
+    fn on_commit(&mut self, epoch: &Epoch) -> Result<(), ExecutionError> {
         self.processor.commit(epoch)?;
         self.channel_manager.store_and_send_commit(epoch)
     }

--- a/dozer-core/src/executor/receiver_loop.rs
+++ b/dozer-core/src/executor/receiver_loop.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
 
 use crossbeam::channel::{Receiver, Select};
-use dozer_types::log::debug;
+use dozer_types::epoch::Epoch;
 use dozer_types::types::Operation;
+use dozer_types::{epoch::ExecutorOperation, log::debug};
 
-use crate::{epoch::Epoch, errors::ExecutionError};
+use crate::errors::ExecutionError;
 
-use super::{name::Name, ExecutorOperation, InputPortState};
+use super::{name::Name, InputPortState};
 
 /// Common code for processor and sink nodes.
 ///

--- a/dozer-core/src/executor/sink_node.rs
+++ b/dozer-core/src/executor/sink_node.rs
@@ -2,18 +2,21 @@ use std::{borrow::Cow, collections::HashMap, mem::swap};
 
 use crossbeam::channel::Receiver;
 use daggy::NodeIndex;
-use dozer_types::{log::debug, node::NodeHandle};
+use dozer_types::{
+    epoch::{Epoch, ExecutorOperation},
+    log::debug,
+    node::NodeHandle,
+};
 
 use crate::{
     builder_dag::NodeKind,
-    epoch::Epoch,
     errors::ExecutionError,
     forwarder::StateWriter,
     node::{PortHandle, Sink},
 };
 
 use super::execution_dag::ExecutionDag;
-use super::{name::Name, receiver_loop::ReceiverLoop, ExecutorOperation};
+use super::{name::Name, receiver_loop::ReceiverLoop};
 
 /// A sink in the execution DAG.
 #[derive(Debug)]

--- a/dozer-core/src/forwarder.rs
+++ b/dozer-core/src/forwarder.rs
@@ -1,12 +1,12 @@
 use crate::channels::ProcessorChannelForwarder;
-use crate::epoch::{Epoch, EpochManager};
+use crate::epoch::EpochManager;
 use crate::errors::ExecutionError;
 use crate::errors::ExecutionError::InvalidPortHandle;
-use crate::executor::ExecutorOperation;
 use crate::node::PortHandle;
 use crate::record_store::RecordWriter;
 
 use crossbeam::channel::Sender;
+use dozer_types::epoch::{Epoch, ExecutorOperation};
 use dozer_types::ingestion_types::{IngestionMessage, IngestionMessageKind};
 use dozer_types::log::debug;
 use dozer_types::node::NodeHandle;

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -1,7 +1,7 @@
 use crate::channels::{ProcessorChannelForwarder, SourceChannelForwarder};
-use crate::epoch::Epoch;
 use crate::errors::ExecutionError;
 
+use dozer_types::epoch::Epoch;
 use dozer_types::types::{Operation, Schema};
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -10,6 +10,7 @@ use crate::tests::dag_base_run::NoopProcessorFactory;
 use crate::tests::sinks::{CountingSinkFactory, COUNTING_SINK_INPUT_PORT};
 use crate::tests::sources::{GeneratorSourceFactory, GENERATOR_SOURCE_OUTPUT_PORT};
 use crate::{Dag, Endpoint, DEFAULT_PORT_HANDLE};
+use dozer_types::epoch::Epoch;
 use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::{
@@ -21,8 +22,6 @@ use std::panic;
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-
-use crate::epoch::Epoch;
 
 use crate::tests::app::NoneContext;
 use tempdir::TempDir;

--- a/dozer-core/src/tests/dag_base_run.rs
+++ b/dozer-core/src/tests/dag_base_run.rs
@@ -11,6 +11,7 @@ use crate::tests::sources::{
     GENERATOR_SOURCE_OUTPUT_PORT,
 };
 use crate::{Dag, Endpoint, DEFAULT_PORT_HANDLE};
+use dozer_types::epoch::Epoch;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::{Operation, Schema};
 
@@ -20,7 +21,6 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use crate::epoch::Epoch;
 use crate::tests::app::NoneContext;
 use tempdir::TempDir;
 

--- a/dozer-log-js/Cargo.toml
+++ b/dozer-log-js/Cargo.toml
@@ -13,10 +13,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dozer-api = { path = "../dozer-api" }
-dozer-core = { path = "../dozer-core" }
 dozer-log = { path = "../dozer-log" }
-dozer-orchestrator = { path = "../dozer-orchestrator" }
 dozer-types = { path = "../dozer-types" }
 
 [dependencies.neon]

--- a/dozer-log-js/src/lib.rs
+++ b/dozer-log-js/src/lib.rs
@@ -1,10 +1,11 @@
 use std::{path::Path, sync::Arc};
 
 use dozer_log::{
+    get_endpoint_log_path,
     reader::LogReader as RustLogReader,
+    schemas::load_schema,
     tokio::{runtime::Runtime as TokioRuntime, sync::Mutex},
 };
-use dozer_orchestrator::{simple::load_schema, utils::get_endpoint_log_path};
 use dozer_types::types::Schema;
 use neon::prelude::*;
 

--- a/dozer-log-js/src/mapper.rs
+++ b/dozer-log-js/src/mapper.rs
@@ -1,6 +1,6 @@
-use dozer_api::rest::field_to_json_value;
-use dozer_core::executor::ExecutorOperation;
 use dozer_types::{
+    epoch::ExecutorOperation,
+    json_types::field_to_json_value,
     serde_json::Value,
     types::{Field, Operation, Record, Schema},
 };

--- a/dozer-log-python/Cargo.toml
+++ b/dozer-log-python/Cargo.toml
@@ -9,11 +9,9 @@ edition = "2021"
 name = "dozer_log"
 
 [dependencies]
-dozer-core = { path = "../dozer-core", optional = true }
 dozer-log = { path = "../dozer-log", optional = true }
-dozer-orchestrator = { path = "../dozer-orchestrator", optional = true }
 dozer-types = { path = "../dozer-types", features = ["python-extension-module"], optional = true }
 pyo3-asyncio = { version = "0.18.0", optional = true, features = ["tokio-runtime"] }
 
 [features]
-python-extension-module = ["dozer-core", "dozer-log", "dozer-orchestrator", "dozer-types", "pyo3-asyncio"]
+python-extension-module = ["dozer-log", "dozer-types", "pyo3-asyncio"]

--- a/dozer-log-python/src/lib.rs
+++ b/dozer-log-python/src/lib.rs
@@ -2,8 +2,10 @@
 
 use std::sync::Arc;
 
-use ::dozer_log::{reader::LogReader as DozerLogReader, tokio::sync::Mutex};
-use dozer_orchestrator::{simple::load_schema, utils::get_endpoint_log_path};
+use ::dozer_log::{
+    get_endpoint_log_path, reader::LogReader as DozerLogReader, schemas::load_schema,
+    tokio::sync::Mutex,
+};
 use dozer_types::{
     pyo3::{exceptions::PyException, prelude::*},
     types::Schema,

--- a/dozer-log-python/src/mapper.rs
+++ b/dozer-log-python/src/mapper.rs
@@ -1,5 +1,5 @@
-use dozer_core::executor::ExecutorOperation;
 use dozer_types::{
+    epoch::ExecutorOperation,
     pyo3::{types::PyDict, Py, PyAny, PyResult, Python, ToPyObject},
     types::{DozerPoint, Field, Operation, Record, Schema},
 };

--- a/dozer-log/Cargo.toml
+++ b/dozer-log/Cargo.toml
@@ -8,6 +8,5 @@ edition = "2021"
 
 [dependencies]
 dozer-types = {path = "../dozer-types"}
-dozer-core = {path = "../dozer-core"}
 futures-util = "0.3.27"
 tokio = { version = "1", features = ["full"] }

--- a/dozer-log/src/errors.rs
+++ b/dozer-log/src/errors.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use dozer_types::thiserror::Error;
-use dozer_types::{bincode, thiserror};
+use dozer_types::{bincode, serde_json, thiserror};
 
 #[derive(Error, Debug)]
 pub enum ReaderError {
@@ -15,4 +15,20 @@ pub enum ReaderError {
     SeekError(String, u64, #[source] std::io::Error),
     #[error("Error deserializing log: {0}")]
     DeserializationError(#[from] bincode::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum SchemaError {
+    #[error("Filesystem error: {0:?} - {1:?}")]
+    Filesystem(PathBuf, #[source] std::io::Error),
+    #[error("Error deserializing schema: {0:?}")]
+    Json(#[from] serde_json::Error),
+    #[error("Got mismatching primary key for `{endpoint_name}`. Expected: `{expected:?}`, got: `{actual:?}`")]
+    MismatchPrimaryKey {
+        endpoint_name: String,
+        expected: Vec<String>,
+        actual: Vec<String>,
+    },
+    #[error("Field not found at position {0}")]
+    FieldNotFound(String),
 }

--- a/dozer-log/src/lib.rs
+++ b/dozer-log/src/lib.rs
@@ -1,5 +1,23 @@
-pub mod reader;
-
 pub mod errors;
+pub mod reader;
+pub mod schemas;
+
+use std::path::{Path, PathBuf};
 
 pub use tokio;
+
+fn get_logs_path(pipeline_dir: &Path) -> PathBuf {
+    pipeline_dir.join("logs")
+}
+
+fn get_endpoint_log_dir(pipeline_dir: &Path, endpoint_name: &str) -> PathBuf {
+    get_logs_path(pipeline_dir).join(endpoint_name.to_lowercase())
+}
+
+pub fn get_endpoint_log_path(pipeline_dir: &Path, endpoint_name: &str) -> PathBuf {
+    get_endpoint_log_dir(pipeline_dir, endpoint_name).join("log")
+}
+
+pub fn get_endpoint_schema_path(pipeline_dir: &Path, endpoint_name: &str) -> PathBuf {
+    get_endpoint_log_dir(pipeline_dir, endpoint_name).join("schema.json")
+}

--- a/dozer-log/src/reader.rs
+++ b/dozer-log/src/reader.rs
@@ -1,7 +1,7 @@
 use std::{io::SeekFrom, path::Path, time::Duration};
 
 use super::errors::ReaderError;
-use dozer_core::executor::ExecutorOperation;
+use dozer_types::epoch::ExecutorOperation;
 use dozer_types::indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use dozer_types::{bincode, log::trace};
 use tokio::{

--- a/dozer-log/src/schemas.rs
+++ b/dozer-log/src/schemas.rs
@@ -4,23 +4,20 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use dozer_core::{dag_schemas::DagSchemas, DEFAULT_PORT_HANDLE};
-use dozer_sql::pipeline::builder::SchemaSQLContext;
 use dozer_types::{
     models::api_endpoint::{ApiEndpoint, ApiIndex},
+    serde_json,
     types::{Schema, SchemaIdentifier},
 };
 use std::io::Write;
 
-use crate::{errors::OrchestrationError, utils::get_endpoint_schema_path};
+use crate::{errors::SchemaError, get_endpoint_schema_path};
 
 pub fn write_schemas(
-    dag_schemas: &DagSchemas<SchemaSQLContext>,
+    mut schemas: HashMap<String, Schema>,
     pipeline_dir: PathBuf,
     api_endpoints: &[ApiEndpoint],
-) -> Result<HashMap<String, Schema>, OrchestrationError> {
-    let mut schemas = dag_schemas.get_sink_schemas();
-
+) -> Result<HashMap<String, Schema>, SchemaError> {
     for api_endpoint in api_endpoints {
         let schema = schemas
             .get(&api_endpoint.name)
@@ -30,16 +27,16 @@ pub fn write_schemas(
         let schema_path = get_endpoint_schema_path(&pipeline_dir, &api_endpoint.name);
         if let Some(schema_dir) = schema_path.parent() {
             std::fs::create_dir_all(schema_dir)
-                .map_err(|e| OrchestrationError::InternalError(Box::new(e)))?;
+                .map_err(|e| SchemaError::Filesystem(schema_dir.to_path_buf(), e))?;
         }
 
         let mut file = OpenOptions::new()
             .create(true)
             .write(true)
             .open(&schema_path)
-            .map_err(|e| OrchestrationError::InternalError(Box::new(e)))?;
+            .map_err(|e| SchemaError::Filesystem(schema_path.clone(), e))?;
         writeln!(file, "{}", serde_json::to_string(&schema).unwrap())
-            .map_err(|e| OrchestrationError::InternalError(Box::new(e)))?;
+            .map_err(|e| SchemaError::Filesystem(schema_path, e))?;
 
         schemas.insert(api_endpoint.name.clone(), schema);
     }
@@ -47,19 +44,16 @@ pub fn write_schemas(
     Ok(schemas)
 }
 
-pub fn load_schema(pipeline_dir: &Path, endpoint_name: &str) -> Result<Schema, OrchestrationError> {
+pub fn load_schema(pipeline_dir: &Path, endpoint_name: &str) -> Result<Schema, SchemaError> {
     let path = get_endpoint_schema_path(pipeline_dir, endpoint_name);
 
-    let schema_str = std::fs::read_to_string(&path)
-        .map_err(|_| OrchestrationError::SchemasNotInitializedPath(path.clone()))?;
+    let schema_str =
+        std::fs::read_to_string(&path).map_err(|e| SchemaError::Filesystem(path, e))?;
 
-    serde_json::from_str(&schema_str).map_err(|_| OrchestrationError::DeserializeSchema(path))
+    serde_json::from_str(&schema_str).map_err(Into::into)
 }
 
-fn modify_schema(
-    schema: &Schema,
-    api_endpoint: &ApiEndpoint,
-) -> Result<Schema, OrchestrationError> {
+fn modify_schema(schema: &Schema, api_endpoint: &ApiEndpoint) -> Result<Schema, SchemaError> {
     let mut schema = schema.clone();
     // Generated Cache index based on api_index
     let configured_index =
@@ -73,7 +67,7 @@ fn modify_schema(
         (false, true) => configured_index,
         (false, false) => {
             if !upstream_index.eq(&configured_index) {
-                return Err(OrchestrationError::MismatchPrimaryKey {
+                return Err(SchemaError::MismatchPrimaryKey {
                     endpoint_name: api_endpoint.name.clone(),
                     expected: get_field_names(&schema, &upstream_index),
                     actual: get_field_names(&schema, &configured_index),
@@ -85,10 +79,7 @@ fn modify_schema(
 
     schema.primary_index = index;
 
-    schema.identifier = Some(SchemaIdentifier {
-        id: DEFAULT_PORT_HANDLE as u32,
-        version: 1,
-    });
+    schema.identifier = Some(SchemaIdentifier { id: 0, version: 1 });
     Ok(schema)
 }
 
@@ -102,14 +93,14 @@ fn get_field_names(schema: &Schema, indexes: &[usize]) -> Vec<String> {
 fn create_primary_indexes(
     schema: &Schema,
     api_index: &ApiIndex,
-) -> Result<Vec<usize>, OrchestrationError> {
+) -> Result<Vec<usize>, SchemaError> {
     let mut primary_index = Vec::new();
     for name in api_index.primary_key.iter() {
         let idx = schema
             .fields
             .iter()
-            .position(|fd| fd.name == name.clone())
-            .map_or(Err(OrchestrationError::FieldNotFound(name.to_owned())), Ok)?;
+            .position(|fd: &dozer_types::types::FieldDefinition| fd.name == name.clone())
+            .map_or(Err(SchemaError::FieldNotFound(name.to_owned())), Ok)?;
 
         primary_index.push(idx);
     }

--- a/dozer-orchestrator/src/errors.rs
+++ b/dozer-orchestrator/src/errors.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use dozer_api::errors::{ApiError, GenerationError, GrpcError};
+use dozer_cache::dozer_log::errors::SchemaError;
 use dozer_cache::errors::CacheError;
 use dozer_core::errors::ExecutionError;
 use dozer_ingestion::errors::ConnectorError;
@@ -62,20 +63,8 @@ pub enum OrchestrationError {
     DuplicateTable(String),
     #[error("Configuration Error: {0:?}")]
     ConfigError(String),
-    #[error("Loading Schema failed: {0:?}")]
-    SchemaLoadFailed(#[source] CacheError),
-    #[error("Schemas not found in Path specified {0:?}")]
-    SchemasNotInitializedPath(PathBuf),
-    #[error("Cannot convert Schema in Path specified {0:?}")]
-    DeserializeSchema(PathBuf),
-    #[error("Got mismatching primary key for `{endpoint_name}`. Expected: `{expected:?}`, got: `{actual:?}`")]
-    MismatchPrimaryKey {
-        endpoint_name: String,
-        expected: Vec<String>,
-        actual: Vec<String>,
-    },
-    #[error("Field not found at position {0}")]
-    FieldNotFound(String),
+    #[error("Schema IO Error: {0}")]
+    SchemaIOError(#[from] SchemaError),
 }
 
 #[derive(Error, Debug)]

--- a/dozer-orchestrator/src/pipeline/log_sink.rs
+++ b/dozer-orchestrator/src/pipeline/log_sink.rs
@@ -6,24 +6,22 @@ use std::{
 };
 
 use dozer_api::grpc::internal::internal_pipeline_server::PipelineEventSenders;
+use dozer_cache::dozer_log::get_endpoint_log_path;
 use dozer_core::{
     epoch::Epoch,
     errors::ExecutionError,
-    executor::ExecutorOperation,
     node::{PortHandle, Sink, SinkFactory},
     DEFAULT_PORT_HANDLE,
 };
 use dozer_sql::pipeline::builder::SchemaSQLContext;
-use dozer_types::grpc_types::internal::StatusUpdate;
 use dozer_types::indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use dozer_types::{
     bytes::{BufMut, BytesMut},
     models::api_endpoint::ApiEndpoint,
     types::{Operation, Schema},
 };
+use dozer_types::{epoch::ExecutorOperation, grpc_types::internal::StatusUpdate};
 use std::fs::OpenOptions;
-
-use crate::utils::get_endpoint_log_path;
 
 #[derive(Debug, Clone)]
 pub struct LogSinkSettings {

--- a/dozer-orchestrator/src/simple/mod.rs
+++ b/dozer-orchestrator/src/simple/mod.rs
@@ -2,6 +2,3 @@ mod executor;
 pub mod orchestrator;
 pub use orchestrator::SimpleOrchestrator;
 mod helper;
-mod schemas;
-
-pub use schemas::load_schema;

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -1,21 +1,21 @@
 use super::executor::Executor;
-use super::schemas::load_schema;
 use crate::console_helper::get_colored_text;
 use crate::errors::{DeployError, OrchestrationError};
 use crate::pipeline::{LogSinkSettings, PipelineBuilder};
 use crate::shutdown::ShutdownReceiver;
 use crate::simple::helper::validate_config;
-use crate::simple::schemas::write_schemas;
 use crate::utils::{
     get_api_dir, get_api_security_config, get_cache_dir, get_cache_manager_options,
-    get_endpoint_log_path, get_executor_options, get_file_buffer_capacity, get_grpc_config,
-    get_pipeline_dir, get_rest_config,
+    get_executor_options, get_file_buffer_capacity, get_grpc_config, get_pipeline_dir,
+    get_rest_config,
 };
 use crate::{flatten_join_handle, Orchestrator};
 use dozer_api::auth::{Access, Authorizer};
 use dozer_api::generator::protoc::generator::ProtoGenerator;
 use dozer_api::{grpc, rest, CacheEndpoint};
 use dozer_cache::cache::LmdbRwCacheManager;
+use dozer_cache::dozer_log::get_endpoint_log_path;
+use dozer_cache::dozer_log::schemas::{load_schema, write_schemas};
 use dozer_core::app::AppPipeline;
 use dozer_core::dag_schemas::DagSchemas;
 
@@ -296,7 +296,7 @@ impl Orchestrator for SimpleOrchestrator {
 
         // Write schemas to pipeline_dir and generate proto files.
         let schemas = write_schemas(
-            &dag_schemas,
+            dag_schemas.get_sink_schemas(),
             pipeline_home_dir.clone(),
             &self.config.endpoints,
         )?;

--- a/dozer-orchestrator/src/utils.rs
+++ b/dozer-orchestrator/src/utils.rs
@@ -17,24 +17,8 @@ pub fn get_pipeline_dir(config: &Config) -> PathBuf {
     AsRef::<Path>::as_ref(&config.home_dir).join("pipeline")
 }
 
-fn get_endpoint_log_dir(pipeline_dir: &Path, endpoint_name: &str) -> PathBuf {
-    get_logs_path(pipeline_dir).join(endpoint_name.to_lowercase())
-}
-
-pub fn get_endpoint_log_path(pipeline_dir: &Path, endpoint_name: &str) -> PathBuf {
-    get_endpoint_log_dir(pipeline_dir, endpoint_name).join("log")
-}
-
-pub fn get_endpoint_schema_path(pipeline_dir: &Path, endpoint_name: &str) -> PathBuf {
-    get_endpoint_log_dir(pipeline_dir, endpoint_name).join("schema.json")
-}
-
 pub fn get_cache_dir(config: &Config) -> PathBuf {
     config.cache_dir.clone().into()
-}
-
-fn get_logs_path(pipeline_dir: &Path) -> PathBuf {
-    pipeline_dir.join("logs")
 }
 
 fn get_cache_max_map_size(config: &Config) -> u64 {

--- a/dozer-types/src/epoch.rs
+++ b/dozer-types/src/epoch.rs
@@ -1,0 +1,48 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    node::{NodeHandle, OpIdentifier, SourceStates},
+    types::Operation,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Epoch {
+    pub id: u64,
+    pub details: SourceStates,
+}
+
+impl Epoch {
+    pub fn new(id: u64, details: SourceStates) -> Self {
+        Self { id, details }
+    }
+
+    pub fn from(id: u64, node_handle: NodeHandle, txid: u64, seq_in_tx: u64) -> Self {
+        Self {
+            id,
+            details: [(node_handle, OpIdentifier::new(txid, seq_in_tx))]
+                .into_iter()
+                .collect(),
+        }
+    }
+}
+
+impl Display for Epoch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let details_str = self
+            .details
+            .iter()
+            .map(|e| format!("{} -> {}:{}", e.0, e.1.txid, e.1.seq_in_tx))
+            .fold(String::new(), |a, b| a + ", " + b.as_str());
+        f.write_str(format!("epoch: {}, details: {}", self.id, details_str).as_str())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutorOperation {
+    Op { op: Operation },
+    Commit { epoch: Epoch },
+    Terminate,
+    SnapshottingDone {},
+}

--- a/dozer-types/src/json_types.rs
+++ b/dozer-types/src/json_types.rs
@@ -1,0 +1,108 @@
+use chrono::SecondsFormat;
+use ordered_float::OrderedFloat;
+use serde_json::{Map, Value};
+
+use crate::types::{DozerDuration, Field, DATE_FORMAT};
+
+fn convert_x_y_to_object((x, y): &(OrderedFloat<f64>, OrderedFloat<f64>)) -> Value {
+    let mut m = Map::new();
+    m.insert("x".to_string(), Value::from(x.0));
+    m.insert("y".to_string(), Value::from(y.0));
+    Value::Object(m)
+}
+
+fn convert_duration_to_object(d: &DozerDuration) -> Value {
+    let mut m = Map::new();
+    m.insert("value".to_string(), Value::from(d.0.as_nanos().to_string()));
+    m.insert("time_unit".to_string(), Value::from(d.1.to_string()));
+    Value::Object(m)
+}
+
+/// Should be consistent with `convert_cache_type_to_schema_type`.
+pub fn field_to_json_value(field: Field) -> Value {
+    match field {
+        Field::UInt(n) => Value::from(n),
+        Field::U128(n) => Value::String(n.to_string()),
+        Field::Int(n) => Value::from(n),
+        Field::I128(n) => Value::String(n.to_string()),
+        Field::Float(n) => Value::from(n.0),
+        Field::Boolean(b) => Value::from(b),
+        Field::String(s) => Value::from(s),
+        Field::Text(n) => Value::from(n),
+        Field::Binary(b) => Value::from(b),
+        Field::Decimal(n) => Value::String(n.to_string()),
+        Field::Timestamp(ts) => Value::String(ts.to_rfc3339_opts(SecondsFormat::Millis, true)),
+        Field::Date(n) => Value::String(n.format(DATE_FORMAT).to_string()),
+        Field::Bson(b) => Value::from(b),
+        Field::Point(point) => convert_x_y_to_object(&point.0.x_y()),
+        Field::Duration(d) => convert_duration_to_object(&d),
+        Field::Null => Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        chrono::{NaiveDate, Offset, TimeZone, Utc},
+        json_value_to_field,
+        ordered_float::OrderedFloat,
+        rust_decimal::Decimal,
+        types::{DozerPoint, Field, FieldType, TimeUnit},
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    fn test_field_conversion(field_type: FieldType, field: Field) {
+        // Convert the field to a JSON value.
+        let value = field_to_json_value(field.clone());
+
+        // Convert the JSON value back to a Field.
+        let deserialized = json_value_to_field(value, field_type, true).unwrap();
+
+        assert_eq!(deserialized, field, "must be equal");
+    }
+
+    #[test]
+    fn test_field_types_json_conversion() {
+        let fields = vec![
+            (FieldType::Int, Field::Int(-1)),
+            (FieldType::UInt, Field::UInt(1)),
+            (FieldType::Float, Field::Float(OrderedFloat(1.1))),
+            (FieldType::Boolean, Field::Boolean(true)),
+            (FieldType::String, Field::String("a".to_string())),
+            (FieldType::Binary, Field::Binary(b"asdf".to_vec())),
+            (FieldType::Decimal, Field::Decimal(Decimal::new(202, 2))),
+            (
+                FieldType::Timestamp,
+                Field::Timestamp(Utc.fix().with_ymd_and_hms(2001, 1, 1, 0, 4, 0).unwrap()),
+            ),
+            (
+                FieldType::Date,
+                Field::Date(NaiveDate::from_ymd_opt(2022, 11, 24).unwrap()),
+            ),
+            (
+                FieldType::Bson,
+                Field::Bson(vec![
+                    // BSON representation of `{"abc":"foo"}`
+                    123, 34, 97, 98, 99, 34, 58, 34, 102, 111, 111, 34, 125,
+                ]),
+            ),
+            (FieldType::Text, Field::Text("lorem ipsum".to_string())),
+            (
+                FieldType::Point,
+                Field::Point(DozerPoint::from((3.234, 4.567))),
+            ),
+            (
+                FieldType::Duration,
+                Field::Duration(DozerDuration(
+                    Duration::from_nanos(123_u64),
+                    TimeUnit::Nanoseconds,
+                )),
+            ),
+        ];
+        for (field_type, field) in fields {
+            test_field_conversion(field_type, field);
+        }
+    }
+}

--- a/dozer-types/src/lib.rs
+++ b/dozer-types/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod borrow;
 pub mod constants;
+pub mod epoch;
 pub mod errors;
 pub mod field_type;
 pub mod helper;
 pub mod ingestion_types;
+pub mod json_types;
 pub mod models;
 pub mod node;
 #[cfg(test)]


### PR DESCRIPTION
So `dozer-log-js` and `dozer-log-python` only depend on those two crates.