### PR TITLE
chore: Rename pyproject name from `dozer-log-python` to `pydozer_log`

### DIFF
--- a/dozer-log-python/pyproject.toml
+++ b/dozer-log-python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 
 [project]
-name = "dozer-log-python"
+name = "pydozer_log"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
to be consistent with the library name.