### PR TITLE
feat(ingestion): properly support postgres with SSL OFF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,7 +2434,9 @@ dependencies = [
  "kafka",
  "object_store",
  "odbc",
+ "openssl",
  "parquet 33.0.0",
+ "postgres-openssl",
  "postgres-protocol",
  "postgres-types",
  "prost",
@@ -4985,6 +4987,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-openssl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de0ea6504e07ca78355a6fb88ad0f36cafe9e696cbc6717f16a207f3a60be72"
+dependencies = [
+ "futures",
+ "openssl",
+ "tokio",
+ "tokio-openssl",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.4"
 source = "git+https://github.com/getdozer/rust-postgres#0ecaeddecbba32600e8ecc2026ebdc663170551e"
@@ -6820,6 +6835,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
  "tokio",
 ]
 

--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -17,6 +17,9 @@ crossbeam = "0.8.2"
 postgres-protocol = "0.6.4"
 postgres-types = { version = "0.2.4", features = ["with-serde_json-1", "with-uuid-1"] }
 tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4", "with-geo-types-0_7", "with-uuid-1"] }
+postgres-openssl = {version = "0.5"}
+openssl = {version = "0.10"}
+
 # DataFusion connector
 object_store = { version = "0.5", features = ["aws"] }
 # Eth connector

--- a/dozer-ingestion/src/errors.rs
+++ b/dozer-ingestion/src/errors.rs
@@ -205,6 +205,12 @@ pub enum PostgresConnectorError {
 
     #[error("Failed to send message on snapshot read channel")]
     SnapshotReadError,
+
+    #[error("Unsupported ssl mode")]
+    UnsupportedSSLMode,
+
+    #[error("Unexpected ssl error: {0}")]
+    SSLError(#[source] std::io::Error),
 }
 
 #[derive(Error, Debug, Eq, PartialEq)]


### PR DESCRIPTION
currently if you try to connect to certain postgres instances, even with SSL off, you will get the following error message

```
ERROR Failed to connect to postgres with the specified configuration. db error: FATAL: no pg_hba.conf entry for host "_", user "_", database "_", SSL off
```

Now if ssl is disabled (which it always is) it will not verify.  

As a follow up, I think we should also expose some configuration params on the `PostgresConfig` struct for supporting various ssl modes. 

The implementation was largely inspired by the [connectorx](https://github.com/sfu-db/connector-x/blob/main/connectorx/src/sources/postgres/connection.rs) postgres connector. 


## Additional notes.
I didn't really know how to go about creating a test for this specific case. I manually tested it, and the above issue is gone when connecting to my pg instance. _(and it's pretty much the same as the connectorx implementation)._