### PR TITLE
chore: Remove `FieldBorrow`

### DIFF
--- a/dozer-cache/src/cache/index/mod.rs
+++ b/dozer-cache/src/cache/index/mod.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use dozer_types::types::{FieldBorrow, IndexDefinition, Record};
+use dozer_types::types::{IndexDefinition, Record};
 
 pub trait CacheIndex {
     // Builds one index based on index definition and record
@@ -101,7 +101,7 @@ impl<'a> CompositeSecondaryIndexKey<'a> {
         Self { buf, offset: 0 }
     }
 
-    fn decode_one(&mut self) -> Result<FieldBorrow<'a>, CompareError> {
+    fn decode_one(&mut self) -> Result<Field, CompareError> {
         if self.offset + 8 > self.buf.len() {
             return Err(CompareError::CannotReadFieldLength);
         }
@@ -115,14 +115,14 @@ impl<'a> CompositeSecondaryIndexKey<'a> {
             return Err(CompareError::CannotReadField);
         }
 
-        let field = Field::decode_borrow(&self.buf[self.offset + 8..self.offset + field_len])?;
+        let field = Field::decode(&self.buf[self.offset + 8..self.offset + field_len])?;
         self.offset += field_len;
         Ok(field)
     }
 }
 
 impl<'a> Iterator for CompositeSecondaryIndexKey<'a> {
-    type Item = Result<FieldBorrow<'a>, CompareError>;
+    type Item = Result<Field, CompareError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.offset >= self.buf.len() {

--- a/dozer-cache/src/cache/index/tests.rs
+++ b/dozer-cache/src/cache/index/tests.rs
@@ -15,7 +15,7 @@ fn test_composite_key_encode_roundtrip() {
     for field in field_test_cases() {
         let key = get_composite_secondary_index(&[&field]);
         let mut key = CompositeSecondaryIndexKey::new(&key);
-        assert_eq!(key.next().unwrap().unwrap(), field.borrow());
+        assert_eq!(key.next().unwrap().unwrap(), field);
         assert!(key.next().is_none());
     }
 
@@ -24,8 +24,8 @@ fn test_composite_key_encode_roundtrip() {
         for field2 in field_test_cases() {
             let key = get_composite_secondary_index(&[&field1, &field2]);
             let mut key = CompositeSecondaryIndexKey::new(&key);
-            assert_eq!(key.next().unwrap().unwrap(), field1.borrow());
-            assert_eq!(key.next().unwrap().unwrap(), field2.borrow());
+            assert_eq!(key.next().unwrap().unwrap(), field1);
+            assert_eq!(key.next().unwrap().unwrap(), field2);
             assert!(key.next().is_none());
         }
     }

--- a/dozer-types/src/tests/field_serialize_test.rs
+++ b/dozer-types/src/tests/field_serialize_test.rs
@@ -29,13 +29,6 @@ fn field_serialization_should_never_be_empty() {
 }
 
 #[test]
-fn test_borrow_roundtrip() {
-    for field in field_test_cases() {
-        assert_eq!(field.borrow().to_owned(), field);
-    }
-}
-
-#[test]
 fn encoding_len_must_agree_with_encode() {
     for field in field_test_cases() {
         let bytes = field.encode();

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -32,26 +32,6 @@ pub enum Field {
     Null,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
-pub enum FieldBorrow<'a> {
-    UInt(u64),
-    U128(u128),
-    Int(i64),
-    I128(i128),
-    Float(OrderedFloat<f64>),
-    Boolean(bool),
-    String(&'a str),
-    Text(&'a str),
-    Binary(&'a [u8]),
-    Decimal(Decimal),
-    Timestamp(DateTime<FixedOffset>),
-    Date(NaiveDate),
-    Bson(&'a [u8]),
-    Point(DozerPoint),
-    Duration(DozerDuration),
-    Null,
-}
-
 impl Field {
     pub(crate) fn data_encoding_len(&self) -> usize {
         match self {
@@ -112,60 +92,35 @@ impl Field {
         result
     }
 
-    pub fn borrow(&self) -> FieldBorrow {
-        match self {
-            Field::UInt(i) => FieldBorrow::UInt(*i),
-            Field::U128(i) => FieldBorrow::U128(*i),
-            Field::Int(i) => FieldBorrow::Int(*i),
-            Field::I128(i) => FieldBorrow::I128(*i),
-            Field::Float(f) => FieldBorrow::Float(*f),
-            Field::Boolean(b) => FieldBorrow::Boolean(*b),
-            Field::String(s) => FieldBorrow::String(s),
-            Field::Text(s) => FieldBorrow::Text(s),
-            Field::Binary(b) => FieldBorrow::Binary(b),
-            Field::Decimal(d) => FieldBorrow::Decimal(*d),
-            Field::Timestamp(t) => FieldBorrow::Timestamp(*t),
-            Field::Date(t) => FieldBorrow::Date(*t),
-            Field::Bson(b) => FieldBorrow::Bson(b),
-            Field::Point(p) => FieldBorrow::Point(*p),
-            Field::Duration(d) => FieldBorrow::Duration(*d),
-            Field::Null => FieldBorrow::Null,
-        }
-    }
-
     pub fn decode(buf: &[u8]) -> Result<Field, DeserializationError> {
-        Self::decode_borrow(buf).map(|field| field.to_owned())
-    }
-
-    pub fn decode_borrow(buf: &[u8]) -> Result<FieldBorrow, DeserializationError> {
         let first_byte = *buf.first().ok_or(DeserializationError::EmptyInput)?;
         let val = &buf[1..];
         match first_byte {
-            0 => Ok(FieldBorrow::UInt(u64::from_be_bytes(
+            0 => Ok(Field::UInt(u64::from_be_bytes(
                 val.try_into()
                     .map_err(|_| DeserializationError::BadDataLength)?,
             ))),
-            1 => Ok(FieldBorrow::U128(u128::from_be_bytes(
+            1 => Ok(Field::U128(u128::from_be_bytes(
                 val.try_into()
                     .map_err(|_| DeserializationError::BadDataLength)?,
             ))),
-            2 => Ok(FieldBorrow::Int(i64::from_be_bytes(
+            2 => Ok(Field::Int(i64::from_be_bytes(
                 val.try_into()
                     .map_err(|_| DeserializationError::BadDataLength)?,
             ))),
-            3 => Ok(FieldBorrow::I128(i128::from_be_bytes(
+            3 => Ok(Field::I128(i128::from_be_bytes(
                 val.try_into()
                     .map_err(|_| DeserializationError::BadDataLength)?,
             ))),
-            4 => Ok(FieldBorrow::Float(OrderedFloat(f64::from_be_bytes(
+            4 => Ok(Field::Float(OrderedFloat(f64::from_be_bytes(
                 val.try_into()
                     .map_err(|_| DeserializationError::BadDataLength)?,
             )))),
-            5 => Ok(FieldBorrow::Boolean(val[0] == 1)),
-            6 => Ok(FieldBorrow::String(std::str::from_utf8(val)?)),
-            7 => Ok(FieldBorrow::Text(std::str::from_utf8(val)?)),
-            8 => Ok(FieldBorrow::Binary(val)),
-            9 => Ok(FieldBorrow::Decimal(Decimal::deserialize(
+            5 => Ok(Field::Boolean(val[0] == 1)),
+            6 => Ok(Field::String(std::str::from_utf8(val)?.to_string())),
+            7 => Ok(Field::Text(std::str::from_utf8(val)?.to_string())),
+            8 => Ok(Field::Binary(val.to_vec())),
+            9 => Ok(Field::Decimal(Decimal::deserialize(
                 val.try_into()
                     .map_err(|_| DeserializationError::BadDataLength)?,
             ))),
@@ -176,7 +131,7 @@ impl Field {
                 ));
 
                 match timestamp {
-                    LocalResult::Single(v) => Ok(FieldBorrow::Timestamp(DateTime::from(v))),
+                    LocalResult::Single(v) => Ok(Field::Timestamp(DateTime::from(v))),
                     LocalResult::Ambiguous(_, _) => Err(DeserializationError::Custom(Box::new(
                         TypeError::AmbiguousTimestamp,
                     ))),
@@ -185,18 +140,18 @@ impl Field {
                     ))),
                 }
             }
-            11 => Ok(FieldBorrow::Date(NaiveDate::parse_from_str(
+            11 => Ok(Field::Date(NaiveDate::parse_from_str(
                 std::str::from_utf8(val)?,
                 DATE_FORMAT,
             )?)),
-            12 => Ok(FieldBorrow::Bson(val)),
-            13 => Ok(FieldBorrow::Point(
+            12 => Ok(Field::Bson(val.to_vec())),
+            13 => Ok(Field::Point(
                 DozerPoint::from_bytes(val).map_err(|_| DeserializationError::BadDataLength)?,
             )),
-            14 => Ok(FieldBorrow::Duration(
+            14 => Ok(Field::Duration(
                 DozerDuration::from_bytes(val).map_err(|_| DeserializationError::BadDataLength)?,
             )),
-            15 => Ok(FieldBorrow::Null),
+            15 => Ok(Field::Null),
             other => Err(DeserializationError::UnrecognisedFieldType(other)),
         }
     }
@@ -611,29 +566,6 @@ impl Display for Field {
             Field::Point(v) => f.write_str(&format!("{v} (Point)")),
             Field::Duration(d) => f.write_str(&format!("{:?} {:?} (Duration)", d.0, d.1)),
             Field::Null => f.write_str("NULL"),
-        }
-    }
-}
-
-impl<'a> FieldBorrow<'a> {
-    pub fn to_owned(self) -> Field {
-        match self {
-            FieldBorrow::UInt(i) => Field::UInt(i),
-            FieldBorrow::U128(i) => Field::U128(i),
-            FieldBorrow::Int(i) => Field::Int(i),
-            FieldBorrow::I128(i) => Field::I128(i),
-            FieldBorrow::Float(f) => Field::Float(f),
-            FieldBorrow::Decimal(d) => Field::Decimal(d),
-            FieldBorrow::Boolean(b) => Field::Boolean(b),
-            FieldBorrow::String(s) => Field::String(s.to_owned()),
-            FieldBorrow::Text(s) => Field::Text(s.to_owned()),
-            FieldBorrow::Binary(b) => Field::Binary(b.to_owned()),
-            FieldBorrow::Timestamp(t) => Field::Timestamp(t),
-            FieldBorrow::Date(d) => Field::Date(d),
-            FieldBorrow::Bson(b) => Field::Bson(b.to_owned()),
-            FieldBorrow::Point(p) => Field::Point(p),
-            FieldBorrow::Duration(d) => Field::Duration(DozerDuration(d.0, d.1)),
-            FieldBorrow::Null => Field::Null,
         }
     }
 }

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -16,7 +16,7 @@ mod tests;
 
 use crate::errors::internal::BoxedError;
 use crate::errors::types::TypeError::InvalidFieldValue;
-pub use field::{field_test_cases, Field, FieldBorrow, FieldType, DATE_FORMAT};
+pub use field::{field_test_cases, Field, FieldType, DATE_FORMAT};
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum SourceDefinition {


### PR DESCRIPTION
Because it won't work with `Field::Json` or nested types.

Now composite sorted inverted key comparison is more expensive, we'll introduce other ways of zero-copy deserialization in the future.