### PR TITLE
refactor: Start a new migration when dozer restarts

### DIFF
--- a/dozer-api/src/errors.rs
+++ b/dozer-api/src/errors.rs
@@ -42,6 +42,8 @@ pub enum ApiError {
     FailedToBindToAddress(String, #[source] std::io::Error),
     #[error("Failed to load schema: {0}")]
     FailedToLoadSchema(#[from] SchemaError),
+    #[error("Failed to find migration for endpoint {0}")]
+    NoMigrationFound(String),
 }
 
 impl ApiError {
@@ -154,7 +156,8 @@ impl actix_web::error::ResponseError for ApiError {
             | ApiError::QueryFailed(_)
             | ApiError::CountFailed(_)
             | ApiError::FailedToBindToAddress(_, _)
-            | ApiError::FailedToLoadSchema(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            | ApiError::FailedToLoadSchema(_)
+            | ApiError::NoMigrationFound(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/dozer-log/src/home_dir.rs
+++ b/dozer-log/src/home_dir.rs
@@ -1,10 +1,16 @@
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
+#[derive(Debug, Clone)]
 pub struct HomeDir {
     api_dir: PathBuf,
     cache_dir: PathBuf,
     log_dir: PathBuf,
 }
+
+pub type Error = (PathBuf, std::io::Error);
 
 impl HomeDir {
     pub fn new(home_dir: &Path, cache_dir: PathBuf) -> Self {
@@ -17,43 +23,132 @@ impl HomeDir {
         }
     }
 
-    pub fn exists(&self) -> bool {
-        self.api_dir.exists() || self.cache_dir.exists() || self.log_dir.exists()
-    }
-
-    pub fn create_dir_all<'a>(
-        &self,
-        endpoint_names: impl IntoIterator<Item = &'a str>,
-    ) -> Result<(), (PathBuf, std::io::Error)> {
+    pub fn create_new_migration(&self, endpoint_name: &str) -> Result<MigrationPath, Error> {
         std::fs::create_dir_all(&self.cache_dir).map_err(|e| (self.cache_dir.clone(), e))?;
 
-        for endpoint_name in endpoint_names {
-            let api_dir = self.get_endpoint_api_dir(endpoint_name);
-            std::fs::create_dir_all(&api_dir).map_err(|e| (api_dir, e))?;
-            let log_dir = self.get_endpoint_log_dir(endpoint_name);
-            std::fs::create_dir_all(&log_dir).map_err(|e| (log_dir, e))?;
+        let id = self
+            .find_latest_migration_id(endpoint_name)?
+            .map(|migration_id| migration_id.id)
+            .unwrap_or(0);
+        let migration_id = MigrationId::from_id(id + 1);
+        let migration_path = self.get_migration_path(endpoint_name, &migration_id);
+
+        std::fs::create_dir_all(&migration_path.api_dir)
+            .map_err(|e| (migration_path.api_dir.clone(), e))?;
+        std::fs::create_dir_all(&migration_path.log_dir)
+            .map_err(|e: std::io::Error| (migration_path.log_dir.clone(), e))?;
+
+        Ok(migration_path)
+    }
+
+    pub fn find_latest_migration_path(
+        &self,
+        endpoint_name: &str,
+    ) -> Result<Option<MigrationPath>, Error> {
+        Ok(self
+            .find_latest_migration_id(endpoint_name)?
+            .map(|migration_id| self.get_migration_path(endpoint_name, &migration_id)))
+    }
+
+    fn find_latest_migration_id(&self, endpoint_name: &str) -> Result<Option<MigrationId>, Error> {
+        let api_dir = self.get_endpoint_api_dir(endpoint_name);
+        let migration1 = find_latest_migration_id(&api_dir)?;
+        let log_dir = self.get_endpoint_log_dir(endpoint_name);
+        let migration2 = find_latest_migration_id(&log_dir)?;
+
+        match (migration1, migration2) {
+            (Some(migration1), Some(migration2)) => {
+                if migration1.id > migration2.id {
+                    Ok(Some(migration1))
+                } else {
+                    Ok(Some(migration2))
+                }
+            }
+            (Some(migration1), None) => Ok(Some(migration1)),
+            (None, Some(migration2)) => Ok(Some(migration2)),
+            (None, None) => Ok(None),
         }
-        Ok(())
     }
 
-    pub fn get_endpoint_api_dir(&self, endpoint_name: &str) -> PathBuf {
+    fn get_migration_path(&self, endpoint_name: &str, migration_id: &MigrationId) -> MigrationPath {
+        let api_dir = self
+            .get_endpoint_api_dir(endpoint_name)
+            .join(&migration_id.name);
+        let descriptor_path = api_dir.join("file_descriptor_set.bin");
+        let log_dir = self
+            .get_endpoint_log_dir(endpoint_name)
+            .join(&migration_id.name);
+        let schema_path = log_dir.join("schema.json");
+        let log_path = log_dir.join("log");
+        MigrationPath {
+            api_dir,
+            descriptor_path,
+            log_dir,
+            schema_path,
+            log_path,
+        }
+    }
+
+    fn get_endpoint_api_dir(&self, endpoint_name: &str) -> PathBuf {
         self.api_dir.join(endpoint_name)
-    }
-
-    pub fn get_endpoint_descriptor_path(&self, endpoint_name: &str) -> PathBuf {
-        self.get_endpoint_api_dir(endpoint_name)
-            .join("file_descriptor_set.bin")
     }
 
     fn get_endpoint_log_dir(&self, endpoint_name: &str) -> PathBuf {
         self.log_dir.join(endpoint_name)
     }
+}
 
-    pub fn get_endpoint_schema_path(&self, endpoint_name: &str) -> PathBuf {
-        self.get_endpoint_log_dir(endpoint_name).join("schema.json")
+#[derive(Debug, Clone)]
+pub struct MigrationId {
+    id: u32,
+    name: OsString,
+}
+
+impl MigrationId {
+    fn from_id(id: u32) -> Self {
+        Self {
+            id,
+            name: OsString::from(format!("v{:04}", id)),
+        }
     }
 
-    pub fn get_endpoint_log_path(&self, endpoint_name: &str) -> PathBuf {
-        self.get_endpoint_log_dir(endpoint_name).join("log")
+    fn from_name(name: OsString) -> Option<Self> {
+        let id = name
+            .to_str()
+            .and_then(|s| s.strip_prefix('v'))
+            .and_then(|s| s.parse::<u32>().ok())?;
+        Some(Self { id, name })
     }
+}
+
+fn find_latest_migration_id(dir: &Path) -> Result<Option<MigrationId>, Error> {
+    if !dir.exists() {
+        return Ok(None);
+    }
+
+    let mut result = None;
+    for entry in std::fs::read_dir(dir).map_err(|e| (dir.to_path_buf(), e))? {
+        let entry = entry.map_err(|e| (dir.to_path_buf(), e))?;
+        if entry.path().is_dir() {
+            if let Some(migration) = MigrationId::from_name(entry.file_name()) {
+                if let Some(MigrationId { id, .. }) = result {
+                    if migration.id > id {
+                        result = Some(migration);
+                    }
+                } else {
+                    result = Some(migration);
+                }
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[derive(Debug, Clone)]
+pub struct MigrationPath {
+    pub api_dir: PathBuf,
+    pub descriptor_path: PathBuf,
+    log_dir: PathBuf,
+    pub schema_path: PathBuf,
+    pub log_path: PathBuf,
 }

--- a/dozer-orchestrator/src/errors.rs
+++ b/dozer-orchestrator/src/errors.rs
@@ -16,18 +16,16 @@ use dozer_types::{serde_yaml, thiserror};
 pub enum OrchestrationError {
     #[error("Failed to write config yaml: {0:?}")]
     FailedToWriteConfigYaml(#[source] serde_yaml::Error),
-    #[error("Failed to initialize. {0} is not empty. Use -f to clean the directory and overwrite. Warning! there will be data loss.")]
-    InitializationFailed(String),
-    #[error("Failed to create directory {0:?}: {1}")]
-    FailedToCreateDir(PathBuf, #[source] std::io::Error),
+    #[error("Failed to create migration {0:?}: {1}")]
+    FailedToCreateMigration(PathBuf, #[source] std::io::Error),
     #[error("Failed to write schema: {0}")]
     FailedToWriteSchema(#[source] SchemaError),
     #[error("Failed to generate proto files: {0:?}")]
     FailedToGenerateProtoFiles(#[from] GenerationError),
-    #[error("Failed to initialize pipeline_dir. Is the path {0:?} accessible?: {1}")]
-    PipelineDirectoryInitFailed(String, #[source] std::io::Error),
-    #[error("Can't locate pipeline_dir. Have you run `dozer migrate`?")]
-    PipelineDirectoryNotFound(String),
+    #[error("File system error {0:?}: {1}")]
+    FileSystem(PathBuf, std::io::Error),
+    #[error("Failed to find migration for endpoint {0}")]
+    NoMigrationFound(String),
     #[error("Failed to generate token: {0:?}")]
     GenerateTokenFailed(String),
     #[error("Failed to deploy dozer application: {0:?}")]

--- a/dozer-orchestrator/src/pipeline/tests/builder.rs
+++ b/dozer-orchestrator/src/pipeline/tests/builder.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use crate::pipeline::source_builder::SourceBuilder;
 use crate::pipeline::PipelineBuilder;
-use dozer_cache::dozer_log::home_dir::HomeDir;
 use dozer_types::ingestion_types::{GrpcConfig, GrpcConfigSchemas};
 use dozer_types::models::app_config::Config;
 
@@ -60,13 +59,15 @@ fn load_multi_sources() {
         .map(|s| s.name.clone())
         .collect::<Vec<_>>();
 
-    let home_dir = HomeDir::new("".as_ref(), Default::default());
     let builder = PipelineBuilder::new(
-        &home_dir,
         &config.connections,
         &config.sources,
         config.sql.as_deref(),
-        &config.endpoints,
+        config
+            .endpoints
+            .into_iter()
+            .map(|endpoint| (endpoint, Default::default()))
+            .collect(),
         MultiProgress::new(),
     );
 

--- a/dozer-orchestrator/src/simple/orchestrator.rs
+++ b/dozer-orchestrator/src/simple/orchestrator.rs
@@ -14,7 +14,7 @@ use dozer_api::generator::protoc::generator::ProtoGenerator;
 use dozer_api::{grpc, rest, CacheEndpoint};
 use dozer_cache::cache::LmdbRwCacheManager;
 use dozer_cache::dozer_log::home_dir::HomeDir;
-use dozer_cache::dozer_log::schemas::write_schemas;
+use dozer_cache::dozer_log::schemas::write_schema;
 use dozer_core::app::AppPipeline;
 use dozer_core::dag_schemas::DagSchemas;
 
@@ -187,7 +187,7 @@ impl Orchestrator for SimpleOrchestrator {
             &self.config.endpoints,
             shutdown.get_running_flag(),
             self.multi_pb.clone(),
-        );
+        )?;
         let settings = LogSinkSettings {
             file_buffer_capacity: get_file_buffer_capacity(&self.config),
         };
@@ -247,35 +247,37 @@ impl Orchestrator for SimpleOrchestrator {
             "Initiating app: {}",
             get_colored_text(&self.config.app_name, "35")
         );
-        if home_dir.exists() {
-            if force {
-                self.clean()?;
-            } else {
-                return Err(OrchestrationError::InitializationFailed(
-                    self.config.home_dir.to_string(),
-                ));
-            }
+        if force {
+            self.clean()?;
         }
         validate_config(&self.config)?;
 
+        // Always create new migration for now.
+        let mut endpoint_and_migration_paths = vec![];
+        for endpoint in &self.config.endpoints {
+            let migration_path =
+                home_dir
+                    .create_new_migration(&endpoint.name)
+                    .map_err(|(path, error)| {
+                        OrchestrationError::FailedToCreateMigration(path, error)
+                    })?;
+            endpoint_and_migration_paths.push((endpoint, migration_path));
+        }
+
+        // Calculate schemas.
+        let endpoint_and_log_paths = endpoint_and_migration_paths
+            .iter()
+            .map(|(endpoint, migration_path)| {
+                ((*endpoint).clone(), migration_path.log_path.clone())
+            })
+            .collect();
         let builder = PipelineBuilder::new(
-            &home_dir,
             &self.config.connections,
             &self.config.sources,
             self.config.sql.as_deref(),
-            &self.config.endpoints,
+            endpoint_and_log_paths,
             self.multi_pb.clone(),
         );
-
-        home_dir
-            .create_dir_all(
-                self.config
-                    .endpoints
-                    .iter()
-                    .map(|endpoint| endpoint.name.as_str()),
-            )
-            .map_err(|(path, error)| OrchestrationError::FailedToCreateDir(path, error))?;
-
         let settings = LogSinkSettings {
             file_buffer_capacity: get_file_buffer_capacity(&self.config),
         };
@@ -284,20 +286,22 @@ impl Orchestrator for SimpleOrchestrator {
         let dag_schemas = DagSchemas::new(dag)?;
 
         // Write schemas to pipeline_dir and generate proto files.
-        let schemas = write_schemas(
-            dag_schemas.get_sink_schemas(),
-            &home_dir,
-            &self.config.endpoints,
-        )
-        .map_err(OrchestrationError::FailedToWriteSchema)?;
+        let schemas = dag_schemas.get_sink_schemas();
         let api_config = self.config.api.clone().unwrap_or_default();
         for (endpoint_name, schema) in &schemas {
-            let endpoint_api_dir = home_dir.get_endpoint_api_dir(endpoint_name);
+            let (endpoint, migration_path) = endpoint_and_migration_paths
+                .iter()
+                .find(|e| e.0.name == *endpoint_name)
+                .expect("Sink name must be the same as endpoint name");
 
+            let schema = write_schema(schema, endpoint, &migration_path.schema_path)
+                .map_err(OrchestrationError::FailedToWriteSchema)?;
+
+            let proto_folder_path = &migration_path.api_dir;
             ProtoGenerator::generate(
-                &endpoint_api_dir,
+                proto_folder_path,
                 endpoint_name,
-                schema,
+                &schema,
                 &api_config.api_security,
                 &self.config.flags,
             )?;
@@ -305,16 +309,19 @@ impl Orchestrator for SimpleOrchestrator {
             let mut resources = Vec::new();
             resources.push(endpoint_name);
 
-            let common_resources = ProtoGenerator::copy_common(&endpoint_api_dir)
+            let common_resources = ProtoGenerator::copy_common(proto_folder_path)
                 .map_err(|e| OrchestrationError::InternalError(Box::new(e)))?;
 
             // Copy common service to be included in descriptor.
             resources.extend(common_resources.iter());
 
             // Generate a descriptor based on all proto files generated within sink.
-            let descriptor_path = home_dir.get_endpoint_descriptor_path(endpoint_name);
-            ProtoGenerator::generate_descriptor(&endpoint_api_dir, &descriptor_path, &resources)
-                .map_err(|e| OrchestrationError::InternalError(Box::new(e)))?;
+            ProtoGenerator::generate_descriptor(
+                proto_folder_path,
+                &migration_path.descriptor_path,
+                &resources,
+            )
+            .map_err(|e| OrchestrationError::InternalError(Box::new(e)))?;
         }
 
         Ok(())
@@ -340,23 +347,12 @@ impl Orchestrator for SimpleOrchestrator {
 
     fn run_all(&mut self, shutdown: ShutdownReceiver) -> Result<(), OrchestrationError> {
         let shutdown_api = shutdown.clone();
-        // TODO: remove this after checkpointing
-        self.clean()?;
 
         let mut dozer_api = self.clone();
 
         let (tx, rx) = channel::unbounded::<bool>();
 
-        if let Err(e) = self.migrate(false) {
-            if let OrchestrationError::InitializationFailed(_) = e {
-                warn!(
-                    "{} is already present. Skipping initialisation..",
-                    self.config.home_dir.to_owned()
-                )
-            } else {
-                return Err(e);
-            }
-        }
+        self.migrate(false)?;
 
         let mut dozer_pipeline = self.clone();
         let pipeline_thread = thread::spawn(move || dozer_pipeline.run_apps(shutdown, Some(tx)));


### PR DESCRIPTION
Closes #1493 

# Summary

In this PR we don't remove the dozer home dir when dozer runs, instead, we create a new migration directory for every endpoint, and app and api writes to and reads from that directory.

The directory structure is shown in #1488 