### PR TITLE
chore(orchestrator): put the table prints behind info

### DIFF
--- a/dozer-ingestion/src/connectors/ethereum/trace/tests.rs
+++ b/dozer-ingestion/src/connectors/ethereum/trace/tests.rs
@@ -67,7 +67,7 @@ async fn test_trace_iterator() {
 
         let (tables, schemas) = connector.list_all_schemas().await.unwrap();
         for s in schemas {
-            s.schema.print().printstd();
+            info!("\n{}", s.schema.print());
         }
         connector.start(&ingestor, tables).await.unwrap();
     });

--- a/dozer-orchestrator/src/pipeline/builder.rs
+++ b/dozer-orchestrator/src/pipeline/builder.rs
@@ -81,8 +81,7 @@ impl<'a> PipelineBuilder<'a> {
             let connector = get_connector(connection.clone())?;
 
             if let Some(info_table) = get_connector_info_table(connection) {
-                info!("[{}] Connection parameters", connection.name);
-                info_table.printstd();
+                info!("[{}] Connection parameters\n{info_table}", connection.name);
             }
 
             let connector_tables = connector.list_tables().await?;

--- a/dozer-orchestrator/src/pipeline/connector_source.rs
+++ b/dozer-orchestrator/src/pipeline/connector_source.rs
@@ -147,9 +147,11 @@ impl SourceFactory<SchemaSQLContext> for ConnectorSourceFactory {
             };
         }
 
-        use std::println as info;
-        info!("Source: Initializing input schema: {table_name}");
-        schema.print().printstd();
+        info!(
+            "Source: Initializing input schema: {}\n{}",
+            table_name,
+            schema.print()
+        );
 
         Ok((schema, SchemaSQLContext::default()))
     }

--- a/dozer-orchestrator/src/pipeline/validate.rs
+++ b/dozer-orchestrator/src/pipeline/validate.rs
@@ -20,8 +20,10 @@ pub async fn validate_grouped_connections(
             let connector = get_connector(connection.clone())?;
 
             if let Some(info_table) = get_connector_info_table(connection) {
-                info!("[{}] Connection parameters", connection.name);
-                info_table.printstd();
+                info!(
+                    "[{}] Connection parameters\n{}",
+                    connection.name, info_table
+                );
             }
 
             let tables = sources_group

--- a/dozer-orchestrator/src/simple/helper.rs
+++ b/dozer-orchestrator/src/simple/helper.rs
@@ -27,7 +27,6 @@ pub fn validate_endpoints(endpoints: &[ApiEndpoint]) -> Result<(), Orchestration
 }
 
 fn print_api_config(api_config: &ApiConfig) {
-    info!("[API] {}", get_colored_text("Configuration", "35"));
     let mut table_parent = Table::new();
 
     table_parent.add_row(row!["Type", "IP", "Port"]);
@@ -38,18 +37,23 @@ fn print_api_config(api_config: &ApiConfig) {
     if let Some(grpc_config) = &api_config.grpc {
         table_parent.add_row(row!["GRPC", grpc_config.host, grpc_config.port]);
     }
-
-    table_parent.printstd();
+    info!(
+        "[API] {}\n{}",
+        get_colored_text("Configuration", "35"),
+        table_parent
+    );
 }
 
 pub fn print_api_endpoints(endpoints: &Vec<ApiEndpoint>) {
-    info!("[API] {}", get_colored_text("Endpoints", "35"));
     let mut table_parent = Table::new();
 
     table_parent.add_row(row!["Path", "Name"]);
     for endpoint in endpoints {
         table_parent.add_row(row![endpoint.path, endpoint.name]);
     }
-
-    table_parent.printstd();
+    info!(
+        "[API] {}\n{}",
+        get_colored_text("Endpoints", "35"),
+        table_parent
+    );
 }


### PR DESCRIPTION
currently when running the dozer cli, the tables get printed directly to stdout, so they don't respect env logging via `RUST_LOG`. This updates them to use the correct `info!` macro. 

## Main Branch
![image](https://user-images.githubusercontent.com/21327470/234970441-048d2ff1-945a-42bb-8314-7e7ce00db319.png)


## Feature Branch `RUST_LOG='error'`
![image](https://user-images.githubusercontent.com/21327470/234970613-58332282-3dd9-426b-b46e-51ad7bd59200.png)

## Feature Branch `RUST_LOG='info'`
![image](https://user-images.githubusercontent.com/21327470/234971183-555b460c-c472-4013-9425-c3520086c716.png)
