### PR TITLE
feat: Add metrics for cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,6 +2160,7 @@ dependencies = [
  "handlebars",
  "hyper",
  "jsonwebtoken",
+ "metrics",
  "openapiv3",
  "prost",
  "prost-build",
@@ -2187,6 +2188,7 @@ dependencies = [
  "dozer-types",
  "futures",
  "itertools",
+ "metrics",
  "rand 0.8.5",
  "rayon",
  "roaring",
@@ -2380,6 +2382,7 @@ name = "dozer-tracing"
 version = "0.1.20"
 dependencies = [
  "dozer-types",
+ "metrics-exporter-prometheus",
  "opentelemetry",
  "opentelemetry-jaeger",
  "tokio",
@@ -3837,6 +3840,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,6 +3928,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+dependencies = [
+ "base64 0.21.0",
+ "hyper",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "metrics-macros"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,6 +3954,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.2",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -5118,6 +5163,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
 
 [[package]]
+name = "quanta"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc73c42f9314c4bdce450c77e6f09ecbddefbeddb1b5979ded332a3913ded33"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5229,6 +5290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6163,6 +6233,12 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -225,7 +225,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -622,7 +622,7 @@ checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1162,7 +1162,7 @@ dependencies = [
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1173,7 +1173,7 @@ checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1258,7 +1258,7 @@ checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1779,7 +1779,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1796,7 +1796,7 @@ checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1828,7 +1828,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1839,7 +1839,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2077,7 +2077,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2090,7 +2090,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2403,6 +2403,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "log",
+ "metrics",
  "ordered-float 3.4.0",
  "parking_lot",
  "prettytable-rs",
@@ -2457,7 +2458,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2502,7 +2503,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2516,7 +2517,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2528,7 +2529,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2808,7 +2809,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3328,7 +3329,7 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3369,7 +3370,7 @@ checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
  "number_prefix",
- "portable-atomic",
+ "portable-atomic 0.3.19",
  "unicode-width",
 ]
 
@@ -3792,7 +3793,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.28",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3901,6 +3902,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa8ebbd1a9e57bbab77b9facae7f5136aea44c356943bf9a198f647da64285d6"
+dependencies = [
+ "ahash 0.8.3",
+ "metrics-macros",
+ "portable-atomic 1.3.2",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4046,7 +4069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7288eac8b54af7913c60e0eb0e2a7683020dffa342ab3fd15e28f035ba897cf"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
  "syn-mid",
 ]
 
@@ -4317,7 +4340,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4498,7 +4521,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4630,7 +4653,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4698,7 +4721,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4752,6 +4775,12 @@ name = "portable-atomic"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+
+[[package]]
+name = "portable-atomic"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
 
 [[package]]
 name = "postgres"
@@ -4811,7 +4840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4869,7 +4898,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -4892,9 +4921,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -4947,7 +4976,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
@@ -4962,7 +4991,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5006,7 +5035,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5068,7 +5097,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5079,7 +5108,7 @@ checksum = "dc1f43d8e30460f36350d18631ccf85ded64c059829208fe680904c65bcd0a4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5112,9 +5141,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -5406,7 +5435,7 @@ checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5739,7 +5768,7 @@ checksum = "8218eaf5d960e3c478a1b0f129fa888dd3d8d22eb3de097e9af14c1ab4438024"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5923,7 +5952,7 @@ checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5969,7 +5998,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6007,7 +6036,7 @@ checksum = "079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6169,7 +6198,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6268,7 +6297,7 @@ checksum = "55fe75cb4a364c7f7ae06c7dbbc8d84bddd85d6cdf9975963c3935bc1991761e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6321,7 +6350,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6342,6 +6371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-mid"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6349,7 +6389,7 @@ checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6442,7 +6482,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6598,7 +6638,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6769,7 +6809,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6910,7 +6950,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7046,7 +7086,7 @@ checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7261,7 +7301,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -7295,7 +7335,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7664,7 +7704,7 @@ checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/dozer-api/Cargo.toml
+++ b/dozer-api/Cargo.toml
@@ -38,6 +38,7 @@ tower = "0.4.13"
 hyper = "0.14.24"
 tower-http = {version = "0.3.5", features = ["full"]}
 arc-swap = "1.6.0"
+metrics = "0.21.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-api/src/errors.rs
+++ b/dozer-api/src/errors.rs
@@ -5,6 +5,7 @@ use actix_web::http::header::ContentType;
 use actix_web::http::StatusCode;
 use actix_web::HttpResponse;
 use dozer_cache::dozer_log::errors::SchemaError;
+use dozer_types::labels::Labels;
 use dozer_types::thiserror::Error;
 use dozer_types::{serde_json, thiserror};
 
@@ -21,7 +22,7 @@ pub enum ApiError {
     #[error("Failed to open or create cache: {0}")]
     OpenOrCreateCache(#[source] CacheError),
     #[error("Failed to find cache: {0}")]
-    CacheNotFound(String),
+    CacheNotFound(Labels),
     #[error("Get by primary key is not supported when there is no primary key")]
     NoPrimaryKey,
     #[error("Get by primary key is not supported when it is composite: {0:?}")]

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -1,3 +1,4 @@
+use dozer_types::labels::Labels;
 use dozer_types::serde_json::{json, Value};
 use dozer_types::types::{Field, Record, SchemaWithIndex, SourceDefinition};
 use dozer_types::{
@@ -107,9 +108,16 @@ pub fn initialize_cache(
     schema: Option<SchemaWithIndex>,
 ) -> Box<LmdbRwCacheManager> {
     let cache_manager = LmdbRwCacheManager::new(Default::default()).unwrap();
+    let mut labels = Labels::new();
+    labels.push(schema_name.to_string(), schema_name.to_string());
     let (schema, secondary_indexes) = schema.unwrap_or_else(get_schema);
     let mut cache = cache_manager
-        .create_cache(schema.clone(), secondary_indexes, Default::default())
+        .create_cache(
+            labels,
+            schema.clone(),
+            secondary_indexes,
+            Default::default(),
+        )
         .unwrap();
     let records = get_sample_records(schema);
     for mut record in records {
@@ -118,9 +126,6 @@ pub fn initialize_cache(
     cache.commit().unwrap();
     cache_manager.wait_until_indexing_catchup();
 
-    cache_manager
-        .create_alias(cache.name(), schema_name)
-        .unwrap();
     Box::new(cache_manager)
 }
 

--- a/dozer-cache/Cargo.toml
+++ b/dozer-cache/Cargo.toml
@@ -20,6 +20,7 @@ roaring = "0.10.1"
 uuid = { version = "1.3.0", features = ["v4"] }
 rayon = "1.7.0"
 ahash = "0.8.3"
+metrics = "0.21.0"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -57,7 +57,12 @@ fn cache(c: &mut Criterion) {
     .unwrap();
     let cache = Mutex::new(
         cache_manager
-            .create_cache(schema.clone(), secondary_indexes, Default::default())
+            .create_cache(
+                Default::default(),
+                schema.clone(),
+                secondary_indexes,
+                Default::default(),
+            )
             .unwrap(),
     );
 

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
@@ -4,6 +4,7 @@ use dozer_storage::{
     LmdbCounter, LmdbEnvironment, LmdbMultimap, LmdbOption,
 };
 use dozer_types::{borrow::IntoOwned, labels::Labels, log::debug, types::IndexDefinition};
+use metrics::increment_counter;
 
 use crate::{
     cache::lmdb::utils::{create_env, open_env},
@@ -108,6 +109,8 @@ impl RwSecondaryEnvironment {
         &mut self,
         log_txn: &T,
         operation_log: OperationLog,
+        counter_name: &'static str,
+        labels: &Labels,
     ) -> Result<bool, CacheError> {
         let main_env_next_operation_id = operation_log.next_operation_id(log_txn)?;
 
@@ -156,6 +159,8 @@ impl RwSecondaryEnvironment {
                 }
             }
             self.next_operation_id.store(txn, operation_id + 1)?;
+
+            increment_counter!(counter_name, labels.clone());
         }
     }
 

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
@@ -3,7 +3,7 @@ use dozer_storage::{
     lmdb_storage::{RoLmdbEnvironment, RwLmdbEnvironment},
     LmdbCounter, LmdbEnvironment, LmdbMultimap, LmdbOption,
 };
-use dozer_types::{borrow::IntoOwned, log::debug, types::IndexDefinition};
+use dozer_types::{borrow::IntoOwned, labels::Labels, log::debug, types::IndexDefinition};
 
 use crate::{
     cache::lmdb::utils::{create_env, open_env},
@@ -209,10 +209,12 @@ impl RoSecondaryEnvironment {
 }
 
 fn get_cache_options(name: String, options: &CacheOptions) -> CacheOptions {
-    let path = options
-        .path
-        .as_ref()
-        .map(|(base_path, main_name)| (base_path.join(format!("{main_name}_index")), name));
+    let path = options.path.as_ref().map(|(main_base_path, main_labels)| {
+        let base_path = main_base_path.join(format!("{}_index", main_labels));
+        let mut labels = Labels::empty();
+        labels.push("secondary_index", name);
+        (base_path, labels)
+    });
     CacheOptions { path, ..*options }
 }
 

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -12,7 +12,7 @@ use tempdir::TempDir;
 #[test]
 fn read_and_write() {
     let path = TempDir::new("dozer").unwrap();
-    let path = (path.path().to_path_buf(), "cache".to_string());
+    let path = (path.path().to_path_buf(), Default::default());
 
     // write and read from cache from two different threads.
 

--- a/dozer-cache/src/cache/lmdb/utils.rs
+++ b/dozer-cache/src/cache/lmdb/utils.rs
@@ -1,6 +1,5 @@
 use std::{
     fs,
-    ops::Deref,
     path::{Path, PathBuf},
 };
 
@@ -11,6 +10,7 @@ use dozer_storage::{
         LmdbEnvironmentManager, LmdbEnvironmentOptions, RoLmdbEnvironment, RwLmdbEnvironment,
     },
 };
+use dozer_types::labels::Labels;
 use tempdir::TempDir;
 
 use super::cache::CacheOptions;
@@ -18,20 +18,18 @@ use super::cache::CacheOptions;
 #[allow(clippy::type_complexity)]
 pub fn create_env(
     options: &CacheOptions,
-) -> Result<(RwLmdbEnvironment, (PathBuf, String), Option<TempDir>), CacheError> {
-    let (base_path, name, temp_dir) = match &options.path {
+) -> Result<(RwLmdbEnvironment, (PathBuf, Labels), Option<TempDir>), CacheError> {
+    let (base_path, labels, temp_dir) = match &options.path {
         None => {
             let base_path =
                 TempDir::new("dozer").map_err(|e| CacheError::Io("tempdir".into(), e))?;
-            (
-                base_path.path().to_path_buf(),
-                "dozer-cache",
-                Some(base_path),
-            )
+            let mut labels = Labels::empty();
+            labels.push("cache_name", "temp");
+            (base_path.path().to_path_buf(), labels, Some(base_path))
         }
-        Some((base_path, name)) => {
+        Some((base_path, labels)) => {
             fs::create_dir_all(base_path).map_err(|e| CacheError::Io(base_path.clone(), e))?;
-            (base_path.clone(), name.deref(), None)
+            (base_path.clone(), labels.clone(), None)
         }
     };
 
@@ -43,8 +41,8 @@ pub fn create_env(
     );
 
     Ok((
-        LmdbEnvironmentManager::create_rw(&base_path, name, options)?,
-        (base_path, name.to_string()),
+        LmdbEnvironmentManager::create_rw(&base_path, &labels.to_non_empty_string(), options)?,
+        (base_path, labels),
         temp_dir,
     ))
 }
@@ -52,8 +50,8 @@ pub fn create_env(
 #[allow(clippy::type_complexity)]
 pub fn open_env(
     options: &CacheOptions,
-) -> Result<(RoLmdbEnvironment, (&Path, &str), Option<TempDir>), CacheError> {
-    let (base_path, name) = options
+) -> Result<(RoLmdbEnvironment, (&Path, &Labels), Option<TempDir>), CacheError> {
+    let (base_path, labels) = options
         .path
         .as_ref()
         .ok_or(CacheError::PathNotInitialized)?;
@@ -66,8 +64,8 @@ pub fn open_env(
     );
 
     Ok((
-        LmdbEnvironmentManager::create_ro(base_path, name, env_options)?,
-        (base_path, name),
+        LmdbEnvironmentManager::create_ro(base_path, &labels.to_non_empty_string(), env_options)?,
+        (base_path, labels),
         None,
     ))
 }

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 
 use self::expression::QueryExpression;
 use crate::errors::CacheError;
+use dozer_types::labels::Labels;
 use dozer_types::models::api_endpoint::{
     OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes,
 };
@@ -35,10 +36,8 @@ impl CacheRecord {
 }
 
 pub trait RoCacheManager: Send + Sync + Debug {
-    /// Opens a cache in read-only mode with given name or an alias with that name.
-    ///
-    /// If the name is both an alias and a real name, it's treated as an alias.
-    fn open_ro_cache(&self, name: &str) -> Result<Option<Box<dyn RoCache>>, CacheError>;
+    /// Opens a cache in read-only mode with given labels.
+    fn open_ro_cache(&self, labels: Labels) -> Result<Option<Box<dyn RoCache>>, CacheError>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -50,12 +49,10 @@ pub struct CacheWriteOptions {
 }
 
 pub trait RwCacheManager: RoCacheManager {
-    /// Opens a cache in read-write mode with given name or an alias with that name.
-    ///
-    /// If the name is both an alias and a real name, it's treated as an alias.
+    /// Opens a cache in read-write mode with given labels.
     fn open_rw_cache(
         &self,
-        name: &str,
+        labels: Labels,
         write_options: CacheWriteOptions,
     ) -> Result<Option<Box<dyn RwCache>>, CacheError>;
 
@@ -63,9 +60,10 @@ pub trait RwCacheManager: RoCacheManager {
     ///
     /// Schemas cannot be changed after the cache is created.
     ///
-    /// The cache's name is unique.
+    /// The labels must be unique.
     fn create_cache(
         &self,
+        labels: Labels,
         schema: Schema,
         indexes: Vec<IndexDefinition>,
         write_options: CacheWriteOptions,
@@ -78,8 +76,8 @@ pub trait RwCacheManager: RoCacheManager {
 }
 
 pub trait RoCache: Send + Sync + Debug {
-    /// Returns the name of the cache.
-    fn name(&self) -> &str;
+    /// Returns the labels of the cache.
+    fn labels(&self) -> &Labels;
 
     // Schema Operations
     fn get_schema(&self) -> &SchemaWithIndex;

--- a/dozer-log-js/src/lib.rs
+++ b/dozer-log-js/src/lib.rs
@@ -87,7 +87,7 @@ fn runtime_create_reader(mut cx: FunctionContext) -> JsResult<JsPromise> {
             .and_then(|parent| parent.file_name().and_then(|file_name| file_name.to_str()))
             .unwrap_or("unknown".as_ref())
             .to_string();
-        let reader = RustLogReader::new(log_path.as_ref(), &name, 0, None).await;
+        let reader = RustLogReader::new(log_path.as_ref(), name, 0, None).await;
 
         // Resolve the promise.
         deferred.settle_with(&channel, move |mut cx| match reader {

--- a/dozer-log-python/src/lib.rs
+++ b/dozer-log-python/src/lib.rs
@@ -39,7 +39,8 @@ impl LogReader {
             let name = log_path
                 .parent()
                 .and_then(|parent| parent.file_name().and_then(|file_name| file_name.to_str()))
-                .unwrap_or("unknown");
+                .unwrap_or("unknown")
+                .to_string();
             let reader_result = DozerLogReader::new(&log_path, name, 0, None).await;
             let reader = reader_result.map_err(|e| PyException::new_err(e.to_string()))?;
             Ok(LogReader {

--- a/dozer-log/examples/reader.rs
+++ b/dozer-log/examples/reader.rs
@@ -10,7 +10,7 @@ async fn main() {
     if args.len() == 2 {
         path = &args[1];
     };
-    let mut log_reader = LogReader::new(Path::new(path), "logs", 0, None)
+    let mut log_reader = LogReader::new(Path::new(path), "logs".to_string(), 0, None)
         .await
         .unwrap();
 

--- a/dozer-log/src/reader.rs
+++ b/dozer-log/src/reader.rs
@@ -20,7 +20,7 @@ const SLEEP_TIME_MS: u16 = 300;
 impl LogReader {
     pub async fn new(
         path: &Path,
-        name: &str,
+        name: String,
         pos: u64,
         multi_pb: Option<MultiProgress>,
     ) -> Result<Self, ReaderError> {
@@ -35,14 +35,14 @@ impl LogReader {
         reader
             .seek(SeekFrom::Start(pos))
             .await
-            .map_err(|e| ReaderError::SeekError(name.to_string(), pos, e))?;
+            .map_err(|e| ReaderError::SeekError(name.clone(), pos, e))?;
 
         let pb = attach_progress(multi_pb);
         pb.set_message(format!("reader: {}", name));
 
         Ok(Self {
             reader,
-            name: name.to_string(),
+            name,
             pos,
             pb,
             count: 0,

--- a/dozer-tracing/Cargo.toml
+++ b/dozer-tracing/Cargo.toml
@@ -15,3 +15,4 @@ opentelemetry-jaeger = {version = "0.17.0", features = ["rt-tokio", "rt-tokio-cu
 tracing-opentelemetry = "0.18.0"
 tokio = { version = "1", features = ["full"] }
 tracing-appender = "0.2.2"
+metrics-exporter-prometheus = "0.12.1"

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -31,6 +31,7 @@ prost-types = "0.11.1"
 prost = "0.11.8"
 arrow = { version = "33.0.0"}
 arrow-schema = { version = "33.0.0", features=["serde"]}
+metrics = "0.21.0"
 
 
 [build-dependencies]

--- a/dozer-types/src/labels.rs
+++ b/dozer-types/src/labels.rs
@@ -1,0 +1,50 @@
+use std::{
+    borrow::Cow,
+    fmt::{self, Display, Formatter},
+};
+
+use metrics::{IntoLabels, Label, SharedString};
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Labels(Vec<Label>);
+
+impl IntoLabels for Labels {
+    fn into_labels(self) -> Vec<Label> {
+        self.0
+    }
+}
+
+impl Display for Labels {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if let Some((last, labels)) = self.0.split_last() {
+            for label in labels {
+                write!(f, "{}_{}", label.key(), label.value())?;
+                write!(f, "_")?;
+            }
+            write!(f, "{}_{}", last.key(), last.value())?;
+        }
+        Ok(())
+    }
+}
+
+impl Labels {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, key: impl Into<SharedString>, value: impl Into<SharedString>) {
+        self.0.push(Label::new(key, value))
+    }
+
+    pub fn to_non_empty_string(&self) -> Cow<'static, str> {
+        if self.0.is_empty() {
+            Cow::Borrowed("empty")
+        } else {
+            Cow::Owned(self.to_string())
+        }
+    }
+}

--- a/dozer-types/src/lib.rs
+++ b/dozer-types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod field_type;
 pub mod helper;
 pub mod ingestion_types;
 pub mod json_types;
+pub mod labels;
 pub mod models;
 pub mod node;
 #[cfg(test)]

--- a/dozer-types/src/models/telemetry.rs
+++ b/dozer-types/src/models/telemetry.rs
@@ -45,4 +45,7 @@ fn default_sample_ratio() -> u32 {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, prost::Oneof)]
-pub enum TelemetryMetricsConfig {}
+pub enum TelemetryMetricsConfig {
+    #[prost(message, tag = "1")]
+    Prometheus(()),
+}


### PR DESCRIPTION
# Summary

In this PR we support collecting metrics and exporting to Prometheus.

It works by enable it in the configuration:

```yaml
telemetry:
  metrics: !Prometheus
```

When enabled, a server listens to `http://0.0.0.0:9000` and returns Prometheus metrics on whatever path.

Example output:

`GET http://0.0.0.0:9000`

```text
# HELP build_index Number of operations built into indexes
# TYPE build_index counter
build_index{endpoint="trips_cache",migration="v0008",secondary_index="3"} 6869025
build_index{endpoint="trips_cache",migration="v0008",secondary_index="4"} 6868029
build_index{endpoint="trips_cache",migration="v0008",secondary_index="2"} 6869730
build_index{endpoint="trips_cache",migration="v0008",secondary_index="1"} 6870207
build_index{endpoint="trips_cache",migration="v0008",secondary_index="0"} 6870145

# HELP build_cache Number of operations processed by cache builder
# TYPE build_cache counter
build_cache{endpoint="trips_cache",migration="v0008"} 3440478
```

The metrics collected are based on https://github.com/getdozer/dozer/discussions/1535.

Closes #1550 