### PR TITLE
feat: Support version management

### DIFF
--- a/dozer-orchestrator/src/cli/cloud.rs
+++ b/dozer-orchestrator/src/cli/cloud.rs
@@ -25,6 +25,9 @@ pub enum CloudCommands {
     Status(AppCommand),
     Monitor(AppCommand),
     Logs(AppCommand),
+    /// Application version management
+    #[command(subcommand)]
+    Version(VersionCommand),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -43,4 +46,26 @@ pub struct ListCommandArgs {
     pub name: Option<String>,
     #[arg(short = 'u', long)]
     pub uuid: Option<String>,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum VersionCommand {
+    /// Creates a new version of the application with the given revision
+    Create {
+        /// The revision of the application to create a new version from
+        revision: u32,
+        /// The application id.
+        #[clap(short, long)]
+        app_id: String,
+    },
+    /// Sets a version as the "current" version of the application
+    ///
+    /// Current version of an application can be visited without the "/v<version>" prefix.
+    SetCurrent {
+        /// The version to set as current
+        version: u32,
+        /// The application id.
+        #[clap(short, long)]
+        app_id: String,
+    },
 }

--- a/dozer-orchestrator/src/lib.rs
+++ b/dozer-orchestrator/src/lib.rs
@@ -44,7 +44,7 @@ pub trait CloudOrchestrator {
     fn deploy(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
     fn update(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;
     fn delete(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;
-    fn list(&mut self, cloud: Cloud, list: &ListCommandArgs) -> Result<(), OrchestrationError>;
+    fn list(&mut self, cloud: Cloud, list: ListCommandArgs) -> Result<(), OrchestrationError>;
     fn status(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;
     fn monitor(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;
     fn trace_logs(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;

--- a/dozer-orchestrator/src/main.rs
+++ b/dozer-orchestrator/src/main.rs
@@ -159,12 +159,13 @@ fn run() -> Result<(), OrchestrationError> {
             #[cfg(feature = "cloud")]
             Commands::Cloud(cloud) => match cloud.command.clone() {
                 CloudCommands::Deploy => dozer.deploy(cloud),
-                CloudCommands::List(ref list) => dozer.list(cloud, list),
-                CloudCommands::Status(ref app) => dozer.status(cloud, app.app_id.clone()),
-                CloudCommands::Monitor(ref app) => dozer.monitor(cloud, app.app_id.clone()),
-                CloudCommands::Update(ref app) => dozer.update(cloud, app.app_id.clone()),
-                CloudCommands::Delete(ref app) => dozer.delete(cloud, app.app_id.clone()),
-                CloudCommands::Logs(ref app) => dozer.trace_logs(cloud, app.app_id.clone()),
+                CloudCommands::List(list) => dozer.list(cloud, list),
+                CloudCommands::Status(app) => dozer.status(cloud, app.app_id),
+                CloudCommands::Monitor(app) => dozer.monitor(cloud, app.app_id),
+                CloudCommands::Update(app) => dozer.update(cloud, app.app_id),
+                CloudCommands::Delete(app) => dozer.delete(cloud, app.app_id),
+                CloudCommands::Logs(app) => dozer.trace_logs(cloud, app.app_id),
+                CloudCommands::Version(version) => dozer.version(cloud, version),
             },
             Commands::Init => {
                 panic!("This should not happen as it is handled in parse_and_generate");

--- a/dozer-types/protos/cloud.proto
+++ b/dozer-types/protos/cloud.proto
@@ -29,6 +29,8 @@ service DozerCloud {
   rpc StartDozer(StartRequest) returns (stream StartUpdate);
   rpc stop_dozer(StopRequest) returns (StopResponse);
   rpc get_status(GetStatusRequest) returns (GetStatusResponse);
+  rpc upsert_version(UpsertVersionRequest) returns (UpsertVersionResponse);
+  rpc set_current_version(SetCurrentVersionRequest) returns (SetCurrentVersionResponse);
 
   rpc list_files(ListFilesRequest) returns (ListFilesResponse);
   rpc update_files(UpdateFileRequest) returns (UpdateFileResponse);
@@ -108,6 +110,21 @@ message RevisionStatus {
   bool app_running = 1;
   bool api_running = 2;
 }
+
+message UpsertVersionRequest {
+  string app_id = 1;
+  uint32 version = 2;
+  uint32 revision = 3;
+}
+
+message UpsertVersionResponse {}
+
+message SetCurrentVersionRequest {
+  string app_id = 1;
+  uint32 version = 2;
+}
+
+message SetCurrentVersionResponse {}
 
 message CreateAppRequest {
   repeated File files = 3;


### PR DESCRIPTION
Added commands:

`dozer cloud version create -a app_id revision`: Creates a new version using given revision
`dozer cloud version set-current -a app_id version`: Sets given version as current