### PR TITLE
feat: Add `dozer cloud version status {version}` command

### DIFF
--- a/dozer-orchestrator/src/cli/cloud.rs
+++ b/dozer-orchestrator/src/cli/cloud.rs
@@ -50,6 +50,14 @@ pub struct ListCommandArgs {
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum VersionCommand {
+    /// Inspects the status of a version, compared to the current version if it's not current.
+    Status {
+        /// The version to inspect
+        version: u32,
+        /// The application id.
+        #[clap(short, long)]
+        app_id: String,
+    },
     /// Creates a new version of the application with the given deployment
     Create {
         /// The deployment of the application to create a new version from

--- a/dozer-orchestrator/src/simple/cloud/mod.rs
+++ b/dozer-orchestrator/src/simple/cloud/mod.rs
@@ -1,2 +1,3 @@
 pub mod deployer;
 pub mod monitor;
+pub mod version;

--- a/dozer-orchestrator/src/simple/cloud/version.rs
+++ b/dozer-orchestrator/src/simple/cloud/version.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+
+use dozer_cache::Phase;
+use dozer_types::prettytable::{row, table};
+
+#[derive(Debug)]
+pub struct EndpointStatus {
+    count: usize,
+    phase: Phase,
+}
+
+pub async fn get_version_status(
+    endpoint: &str,
+    version: u32,
+) -> Result<HashMap<String, EndpointStatus>, reqwest::Error> {
+    let client = reqwest::Client::default();
+
+    let response = client
+        .get(format!("http://{}/v{}/", endpoint, version))
+        .send()
+        .await?
+        .error_for_status()?;
+    let paths = response.json::<Vec<String>>().await?;
+    let mut result = HashMap::default();
+
+    for path in paths {
+        let count = client
+            .post(format!("http://{}/v{}{}/count", endpoint, version, path))
+            .send()
+            .await?
+            .error_for_status()?;
+        let count = count.json::<usize>().await?;
+
+        let phase = client
+            .post(format!("http://{}/v{}{}/phase", endpoint, version, path))
+            .send()
+            .await?
+            .error_for_status()?;
+        let phase = phase.json::<Phase>().await?;
+
+        result.insert(path, EndpointStatus { count, phase });
+    }
+
+    Ok(result)
+}
+
+pub fn version_status_table(
+    status: &Result<HashMap<String, EndpointStatus>, reqwest::Error>,
+) -> String {
+    if let Ok(status) = status {
+        let mut table = table!();
+        for (path, EndpointStatus { count, phase }) in status {
+            let phase = serde_json::to_string(phase).expect("Should always succeed");
+            table.add_row(row![path, count, phase]);
+        }
+        table.to_string()
+    } else {
+        "Unavailable".to_string()
+    }
+}
+
+pub fn version_is_up_to_date(
+    status: &Result<HashMap<String, EndpointStatus>, reqwest::Error>,
+    current_status: &Result<HashMap<String, EndpointStatus>, reqwest::Error>,
+) -> bool {
+    if let Ok(status) = status {
+        if let Ok(current_status) = current_status {
+            version_is_up_to_date_impl(status, current_status)
+        } else {
+            true
+        }
+    } else {
+        false
+    }
+}
+
+fn version_is_up_to_date_impl(
+    status: &HashMap<String, EndpointStatus>,
+    current_status: &HashMap<String, EndpointStatus>,
+) -> bool {
+    for (path, status) in status {
+        if !endpoint_is_up_to_date(status, current_status.get(path)) {
+            return false;
+        }
+    }
+    true
+}
+
+fn endpoint_is_up_to_date(
+    status: &EndpointStatus,
+    current_status: Option<&EndpointStatus>,
+) -> bool {
+    if let Some(current_status) = current_status {
+        status.phase == Phase::Streaming
+            || (current_status.phase == Phase::Snapshotting && status.count >= current_status.count)
+    } else {
+        true
+    }
+}


### PR DESCRIPTION
If we're querying the current version:

```text
+--------------+-------------------------------------------+
| v1 (current) | +-------------+--------+----------------+ |
|              | | /trips_data | 202237 | "Snapshotting" | |
|              | +-------------+--------+----------------+ |
+--------------+-------------------------------------------+
```

If we're querying a non-current version:

```text
+--------------+-------------------------------------------+
| v2           | +-------------+--------+----------------+ |
|              | | /trips_data | 531186 | "Snapshotting" | |
|              | +-------------+--------+----------------+ |
+--------------+-------------------------------------------+
| v1 (current) | +-------------+--------+----------------+ |
|              | | /trips_data | 233705 | "Snapshotting" | |
|              | +-------------+--------+----------------+ |
+--------------+-------------------------------------------+
2023-05-23T06:22:16.447849Z  INFO Version 2 is up to date    
```

Command prints if the queried version is more up to date compared to the current version.