### PR TITLE
refactor: Traits in `dozer-core` return `BoxedError` instead of `ExecutionError`

### DIFF
--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -13,6 +13,8 @@ use dozer_types::errors::internal::BoxedError;
 use dozer_types::thiserror::Error;
 use dozer_types::{serde_yaml, thiserror};
 
+use crate::pipeline::connector_source::ConnectorSourceFactoryError;
+
 #[derive(Error, Debug)]
 pub enum OrchestrationError {
     #[error("Failed to write config yaml: {0:?}")]
@@ -41,6 +43,8 @@ pub enum OrchestrationError {
     CacheBuildFailed(#[source] CacheError),
     #[error("Internal thread panic: {0}")]
     JoinError(#[source] tokio::task::JoinError),
+    #[error("Connector source factory error: {0}")]
+    ConnectorSourceFactory(#[from] ConnectorSourceFactoryError),
     #[error(transparent)]
     ExecutionError(#[from] ExecutionError),
     #[error(transparent)]

--- a/dozer-cli/src/pipeline/builder.rs
+++ b/dozer-cli/src/pipeline/builder.rs
@@ -245,15 +245,13 @@ impl<'a> PipelineBuilder<'a> {
                 OutputTableInfo::Transformed(table_info) => {
                     pipeline.add_sink(snk_factory, api_endpoint.name.as_str());
 
-                    pipeline
-                        .connect_nodes(
-                            &table_info.node,
-                            Some(table_info.port),
-                            api_endpoint.name.as_str(),
-                            Some(DEFAULT_PORT_HANDLE),
-                            true,
-                        )
-                        .map_err(ExecutionError)?;
+                    pipeline.connect_nodes(
+                        &table_info.node,
+                        Some(table_info.port),
+                        api_endpoint.name.as_str(),
+                        Some(DEFAULT_PORT_HANDLE),
+                        true,
+                    );
                 }
                 OutputTableInfo::Original(table_info) => {
                     pipeline.add_sink(snk_factory, api_endpoint.name.as_str());
@@ -265,15 +263,13 @@ impl<'a> PipelineBuilder<'a> {
                         ))
                         .expect("port should be present based on source mapping");
 
-                    pipeline
-                        .connect_nodes(
-                            &table_info.connection_name,
-                            Some(*conn_port),
-                            api_endpoint.name.as_str(),
-                            Some(DEFAULT_PORT_HANDLE),
-                            false,
-                        )
-                        .map_err(ExecutionError)?;
+                    pipeline.connect_nodes(
+                        &table_info.connection_name,
+                        Some(*conn_port),
+                        api_endpoint.name.as_str(),
+                        Some(DEFAULT_PORT_HANDLE),
+                        false,
+                    );
                 }
             }
         }

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -1,28 +1,19 @@
-use std::{
-    collections::HashMap,
-    fs::File,
-    io::{BufWriter, Write},
-    path::PathBuf,
-};
+use std::{collections::HashMap, path::PathBuf};
 
+use dozer_cache::dozer_log::{errors::WriterError, writer::LogWriter};
 use dozer_core::{
     epoch::Epoch,
-    errors::ExecutionError,
     node::{PortHandle, Sink, SinkFactory},
     DEFAULT_PORT_HANDLE,
 };
 use dozer_sql::pipeline::builder::SchemaSQLContext;
-use dozer_types::indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use dozer_types::{
-    bytes::{BufMut, BytesMut},
-    types::{Operation, Schema},
-};
+use dozer_types::indicatif::MultiProgress;
+use dozer_types::types::{Operation, Schema};
 use dozer_types::{epoch::ExecutorOperation, errors::internal::BoxedError};
-use std::fs::OpenOptions;
 
 #[derive(Debug, Clone)]
 pub struct LogSinkSettings {
-    pub file_buffer_capacity: u64,
+    pub file_buffer_capacity: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -76,100 +67,42 @@ impl SinkFactory<SchemaSQLContext> for LogSinkFactory {
 }
 
 #[derive(Debug)]
-pub struct LogSink {
-    pb: ProgressBar,
-    buffered_file: BufWriter<File>,
-    counter: usize,
-}
+pub struct LogSink(LogWriter);
 
 impl LogSink {
     pub fn new(
         multi_pb: Option<MultiProgress>,
         log_path: PathBuf,
-        file_buffer_capacity: u64,
+        file_buffer_capacity: usize,
         endpoint_name: String,
-    ) -> Result<Self, ExecutionError> {
-        let file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .append(true)
-            .open(log_path)
-            .map_err(|e| ExecutionError::InternalError(Box::new(e)))?;
-
-        let buffered_file = std::io::BufWriter::with_capacity(file_buffer_capacity as usize, file);
-
-        let pb = attach_progress(multi_pb);
-        pb.set_message(endpoint_name);
-
-        Ok(Self {
-            pb,
-            buffered_file,
-            counter: 0,
-        })
+    ) -> Result<Self, WriterError> {
+        Ok(Self(LogWriter::new(
+            log_path,
+            file_buffer_capacity,
+            endpoint_name,
+            multi_pb,
+        )?))
     }
 }
 
 impl Sink for LogSink {
-    fn process(&mut self, _from_port: PortHandle, op: Operation) -> Result<(), ExecutionError> {
-        let msg = ExecutorOperation::Op { op };
-        self.counter += 1;
-        self.pb.set_position(self.counter as u64);
-        write_msg_to_file(&mut self.buffered_file, &msg)
+    fn process(&mut self, _from_port: PortHandle, op: Operation) -> Result<(), BoxedError> {
+        self.0
+            .write_op(&ExecutorOperation::Op { op })
+            .map_err(Into::into)
     }
 
-    fn commit(&mut self) -> Result<(), ExecutionError> {
-        let msg = ExecutorOperation::Commit {
+    fn commit(&mut self) -> Result<(), BoxedError> {
+        self.0.write_op(&ExecutorOperation::Commit {
             epoch: Epoch::new(0, Default::default()),
-        };
-
-        write_msg_to_file(&mut self.buffered_file, &msg)?;
-        self.buffered_file
-            .flush()
-            .map_err(|e| ExecutionError::InternalError(Box::new(e)))?;
+        })?;
+        self.0.flush()?;
         Ok(())
     }
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        connection_name: String,
-    ) -> Result<(), ExecutionError> {
-        let msg = ExecutorOperation::SnapshottingDone { connection_name };
-        write_msg_to_file(&mut self.buffered_file, &msg)
+    fn on_source_snapshotting_done(&mut self, connection_name: String) -> Result<(), BoxedError> {
+        self.0
+            .write_op(&ExecutorOperation::SnapshottingDone { connection_name })
+            .map_err(Into::into)
     }
-}
-
-fn write_msg_to_file(
-    file: &mut BufWriter<File>,
-    msg: &ExecutorOperation,
-) -> Result<(), ExecutionError> {
-    let msg = dozer_types::bincode::serialize(msg)
-        .map_err(|e| ExecutionError::InternalError(Box::new(e)))?;
-
-    let mut buf = BytesMut::with_capacity(msg.len() + 4);
-    buf.put_u64_le(msg.len() as u64);
-    buf.put_slice(&msg);
-
-    file.write_all(&buf)
-        .map_err(|e| ExecutionError::InternalError(Box::new(e)))
-}
-
-fn attach_progress(multi_pb: Option<MultiProgress>) -> ProgressBar {
-    let pb = ProgressBar::new_spinner();
-    multi_pb.as_ref().map(|m| m.add(pb.clone()));
-    pb.set_style(
-        ProgressStyle::with_template("{spinner:.blue} {msg}: {pos}: {per_sec}")
-            .unwrap()
-            // For more spinners check out the cli-spinners project:
-            // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
-            .tick_strings(&[
-                "▹▹▹▹▹",
-                "▸▹▹▹▹",
-                "▹▸▹▹▹",
-                "▹▹▸▹▹",
-                "▹▹▹▸▹",
-                "▹▹▹▹▸",
-                "▪▪▪▪▪",
-            ]),
-    );
-    pb
 }

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -123,7 +123,9 @@ impl Sink for LogSink {
         };
 
         write_msg_to_file(&mut self.buffered_file, &msg)?;
-        self.buffered_file.flush()?;
+        self.buffered_file
+            .flush()
+            .map_err(|e| ExecutionError::InternalError(Box::new(e)))?;
         Ok(())
     }
 

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -12,12 +12,12 @@ use dozer_core::{
     DEFAULT_PORT_HANDLE,
 };
 use dozer_sql::pipeline::builder::SchemaSQLContext;
-use dozer_types::epoch::ExecutorOperation;
 use dozer_types::indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use dozer_types::{
     bytes::{BufMut, BytesMut},
     types::{Operation, Schema},
 };
+use dozer_types::{epoch::ExecutorOperation, errors::internal::BoxedError};
 use std::fs::OpenOptions;
 
 #[derive(Debug, Clone)]
@@ -57,7 +57,7 @@ impl SinkFactory<SchemaSQLContext> for LogSinkFactory {
     fn prepare(
         &self,
         input_schemas: HashMap<PortHandle, (Schema, SchemaSQLContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         debug_assert!(input_schemas.len() == 1);
         Ok(())
     }
@@ -65,7 +65,7 @@ impl SinkFactory<SchemaSQLContext> for LogSinkFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         Ok(Box::new(LogSink::new(
             Some(self.multi_pb.clone()),
             self.log_path.clone(),

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -186,7 +186,7 @@ impl Orchestrator for SimpleOrchestrator {
             self.multi_pb.clone(),
         )?;
         let settings = LogSinkSettings {
-            file_buffer_capacity: get_file_buffer_capacity(&self.config),
+            file_buffer_capacity: get_file_buffer_capacity(&self.config) as usize,
         };
         let dag_executor = executor.create_dag_executor(
             self.runtime.clone(),
@@ -258,7 +258,7 @@ impl Orchestrator for SimpleOrchestrator {
             self.multi_pb.clone(),
         );
         let settings = LogSinkSettings {
-            file_buffer_capacity: get_file_buffer_capacity(&self.config),
+            file_buffer_capacity: get_file_buffer_capacity(&self.config) as usize,
         };
         let dag = builder.build(self.runtime.clone(), settings)?;
         // Populate schemas.

--- a/dozer-core/src/app.rs
+++ b/dozer-core/src/app.rs
@@ -86,7 +86,7 @@ impl<T> AppPipeline<T> {
         to: &str,
         to_port: Option<PortHandle>,
         namespaced: bool,
-    ) -> Result<(), ExecutionError> {
+    ) {
         let edge = Edge::new(
             Endpoint::new(
                 NodeHandle::new(None, from.to_string()),
@@ -106,7 +106,6 @@ impl<T> AppPipeline<T> {
             ),
         );
         self.edges.push(NamespacedEdge { edge, namespaced });
-        Ok(())
     }
 
     pub fn new() -> Self {

--- a/dozer-core/src/builder_dag.rs
+++ b/dozer-core/src/builder_dag.rs
@@ -55,7 +55,9 @@ impl BuilderDag {
             let kind = match &node.kind {
                 CheckpointNodeKind::Source(_) => None,
                 CheckpointNodeKind::Processor(processor) => {
-                    let processor = processor.build(input_schemas, output_schemas)?;
+                    let processor = processor
+                        .build(input_schemas, output_schemas)
+                        .map_err(ExecutionError::Factory)?;
                     Some(NodeKind::Processor(processor))
                 }
                 CheckpointNodeKind::Sink(sink) => {

--- a/dozer-core/src/builder_dag.rs
+++ b/dozer-core/src/builder_dag.rs
@@ -59,7 +59,7 @@ impl BuilderDag {
                     Some(NodeKind::Processor(processor))
                 }
                 CheckpointNodeKind::Sink(sink) => {
-                    let sink = sink.build(input_schemas)?;
+                    let sink = sink.build(input_schemas).map_err(ExecutionError::Factory)?;
                     Some(NodeKind::Sink(sink))
                 }
             };

--- a/dozer-core/src/dag_checkpoint.rs
+++ b/dozer-core/src/dag_checkpoint.rs
@@ -46,7 +46,9 @@ impl<T> DagCheckpoint<T> {
             match &node.kind {
                 DagNodeKind::Source(source) => {
                     let output_schemas = dag_schemas.get_node_output_schemas(node_index);
-                    let source = source.build(output_schemas)?;
+                    let source = source
+                        .build(output_schemas)
+                        .map_err(ExecutionError::Factory)?;
                     sources.push(Some(source));
                 }
                 DagNodeKind::Processor(_) | DagNodeKind::Sink(_) => {

--- a/dozer-core/src/dag_schemas.rs
+++ b/dozer-core/src/dag_schemas.rs
@@ -268,7 +268,8 @@ fn populate_schemas<T: Clone>(
             NodeKind::Sink(sink) => {
                 let input_schemas =
                     validate_input_schemas(&dag, &edges, node_index, sink.get_input_ports())?;
-                sink.prepare(input_schemas)?;
+                sink.prepare(input_schemas)
+                    .map_err(ExecutionError::Factory)?;
             }
         }
     }

--- a/dozer-core/src/dag_schemas.rs
+++ b/dozer-core/src/dag_schemas.rs
@@ -244,7 +244,9 @@ fn populate_schemas<T: Clone>(
 
                 for edge in dag.graph().edges(node_index) {
                     let port = find_output_port_def(&ports, edge);
-                    let (schema, ctx) = source.get_output_schema(&port.handle)?;
+                    let (schema, ctx) = source
+                        .get_output_schema(&port.handle)
+                        .map_err(ExecutionError::Factory)?;
                     create_edge(&mut edges, edge, port, schema, ctx);
                 }
             }

--- a/dozer-core/src/dag_schemas.rs
+++ b/dozer-core/src/dag_schemas.rs
@@ -259,8 +259,9 @@ fn populate_schemas<T: Clone>(
 
                 for edge in dag.graph().edges(node_index) {
                     let port = find_output_port_def(&ports, edge);
-                    let (schema, ctx) =
-                        processor.get_output_schema(&port.handle, &input_schemas)?;
+                    let (schema, ctx) = processor
+                        .get_output_schema(&port.handle, &input_schemas)
+                        .map_err(ExecutionError::Factory)?;
                     create_edge(&mut edges, edge, port, schema, ctx);
                 }
             }

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -17,8 +17,6 @@ pub enum ExecutionError {
     MissingInput { node: NodeHandle, port: PortHandle },
     #[error("Duplicate input for node {node} on port {port}")]
     DuplicateInput { node: NodeHandle, port: PortHandle },
-    #[error("Invalid type: {0}")]
-    InvalidType(String),
     #[error("Record not found")]
     RecordNotFound(),
     #[error("Cannot send to channel")]
@@ -39,34 +37,8 @@ pub enum ExecutionError {
     Source(#[source] BoxedError),
     #[error("Processor or sink error: {0}")]
     ProcessorOrSink(#[source] BoxedError),
-
-    // Error forwarders
     #[error("File system error {0:?}: {1}")]
     FileSystemError(PathBuf, #[source] std::io::Error),
-    #[error("Internal error: {0}")]
-    InternalError(#[source] BoxedError),
-
-    // to remove
-    #[error("{0}")]
-    InternalStringError(String),
-
-    #[error("Failed to execute product processor: {0}")]
-    ProductProcessorError(#[source] BoxedError),
-
-    #[error("Failed to create Window processor: {0}")]
-    WindowProcessorFactoryError(#[source] BoxedError),
-
-    #[error("Failed to execute the Window processor: {0}")]
-    WindowProcessorError(#[source] BoxedError),
-
-    #[error("Failed to execute the Table processor: {0}")]
-    TableProcessorError(#[source] BoxedError),
-
-    #[error("JOIN processor received a Record from a wrong input: {0}")]
-    InvalidPort(u16),
-
-    #[error("Error variant for testing: {0}")]
-    TestError(String),
 }
 
 impl<T> From<crossbeam::channel::SendError<T>> for ExecutionError {

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -37,6 +37,8 @@ pub enum ExecutionError {
     Factory(#[source] BoxedError),
     #[error("Source error: {0}")]
     Source(#[source] BoxedError),
+    #[error("Processor or sink error: {0}")]
+    ProcessorOrSink(#[source] BoxedError),
 
     // Error forwarders
     #[error("File system error {0:?}: {1}")]

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -14,22 +14,14 @@ pub enum ExecutionError {
     WouldCycle,
     #[error("Invalid port handle: {0}")]
     InvalidPortHandle(PortHandle),
-    #[error("Invalid node handle: {0}")]
-    InvalidNodeHandle(NodeHandle),
     #[error("Missing input for node {node} on port {port}")]
     MissingInput { node: NodeHandle, port: PortHandle },
     #[error("Duplicate input for node {node} on port {port}")]
     DuplicateInput { node: NodeHandle, port: PortHandle },
-    #[error("Invalid operation: {0}")]
-    InvalidOperation(String),
     #[error("Invalid type: {0}")]
     InvalidType(String),
     #[error("Schema not initialized")]
     SchemaNotInitialized,
-    #[error("The database is invalid")]
-    InvalidDatabase,
-    #[error("Field not found at position {0}")]
-    FieldNotFound(String),
     #[error("Record not found")]
     RecordNotFound(),
     #[error("Cannot send to channel")]
@@ -37,25 +29,15 @@ pub enum ExecutionError {
     #[error("Cannot receive from channel")]
     CannotReceiveFromChannel,
     #[error("Cannot spawn worker thread: {0}")]
-    CannotSpawnWorkerThread(#[from] std::io::Error),
-    #[error("Internal thread panicked")]
-    InternalThreadPanic,
+    CannotSpawnWorkerThread(#[source] std::io::Error),
     #[error("Invalid source identifier {0}")]
     InvalidSourceIdentifier(AppSourceId),
     #[error("Ambiguous source identifier {0}")]
     AmbiguousSourceIdentifier(AppSourceId),
     #[error("Port not found for source: {0}")]
     PortNotFoundInSource(PortHandle),
-    #[error("Failed to get output schema: {0}")]
-    FailedToGetOutputSchema(String),
-    #[error("Update operation not supported: {0}")]
-    UnsupportedUpdateOperation(String),
-    #[error("Delete operation not supported: {0}")]
-    UnsupportedDeleteOperation(String),
     #[error("Invalid AppSource connection {0}. Already exists.")]
     AppSourceConnectionAlreadyExists(String),
-    #[error("Failed to get primary key for `{0}`")]
-    FailedToGetPrimaryKey(String),
 
     // Error forwarders
     #[error("File system error {0:?}: {1}")]
@@ -70,14 +52,6 @@ pub enum ExecutionError {
     // to remove
     #[error("{0}")]
     InternalStringError(String),
-
-    #[error("Channel returned empty message in sink. Might be an issue with the sender: {0}, {1}")]
-    SinkReceiverError(usize, #[source] BoxedError),
-
-    #[error(
-        "Channel returned empty message in processor. Might be an issue with the sender: {0}, {1}"
-    )]
-    ProcessorReceiverError(usize, #[source] BoxedError),
 
     #[error("Source error: {0}")]
     SourceError(SourceError),
@@ -96,6 +70,9 @@ pub enum ExecutionError {
 
     #[error("JOIN processor received a Record from a wrong input: {0}")]
     InvalidPort(u16),
+
+    #[error("Error variant for testing: {0}")]
+    TestError(String),
 }
 
 impl<T> From<crossbeam::channel::SendError<T>> for ExecutionError {

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -19,8 +19,6 @@ pub enum ExecutionError {
     DuplicateInput { node: NodeHandle, port: PortHandle },
     #[error("Invalid type: {0}")]
     InvalidType(String),
-    #[error("Schema not initialized")]
-    SchemaNotInitialized,
     #[error("Record not found")]
     RecordNotFound(),
     #[error("Cannot send to channel")]
@@ -37,6 +35,8 @@ pub enum ExecutionError {
     AppSourceConnectionAlreadyExists(String),
     #[error("Factory error: {0}")]
     Factory(#[source] BoxedError),
+    #[error("Source error: {0}")]
+    Source(#[source] BoxedError),
 
     // Error forwarders
     #[error("File system error {0:?}: {1}")]
@@ -47,9 +47,6 @@ pub enum ExecutionError {
     // to remove
     #[error("{0}")]
     InternalStringError(String),
-
-    #[error("Source error: {0}")]
-    SourceError(SourceError),
 
     #[error("Failed to execute product processor: {0}")]
     ProductProcessorError(#[source] BoxedError),
@@ -80,10 +77,4 @@ impl<T> From<daggy::WouldCycle<T>> for ExecutionError {
     fn from(_: daggy::WouldCycle<T>) -> Self {
         ExecutionError::WouldCycle
     }
-}
-
-#[derive(Error, Debug)]
-pub enum SourceError {
-    #[error("Failed to find table in Source: {0}")]
-    PortError(u32),
 }

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -64,8 +64,6 @@ pub enum ExecutionError {
     InternalTypeError(#[from] TypeError),
     #[error("Internal error: {0}")]
     InternalError(#[from] BoxedError),
-    #[error("Sink error: {0}")]
-    SinkError(#[from] SinkError),
 
     #[error("Failed to initialize source: {0}")]
     ConnectorError(#[source] BoxedError),
@@ -110,41 +108,6 @@ impl<T> From<daggy::WouldCycle<T>> for ExecutionError {
     fn from(_: daggy::WouldCycle<T>) -> Self {
         ExecutionError::WouldCycle
     }
-}
-
-#[derive(Error, Debug)]
-pub enum SinkError {
-    #[error("Failed to open Cache: {0:?}, Error: {1:?}.")]
-    CacheOpenFailed(String, #[source] BoxedError),
-
-    #[error("Failed to create Cache: {0:?}, Error: {1:?}.")]
-    CacheCreateFailed(String, #[source] BoxedError),
-
-    #[error("Failed to create alias {alias:?} for Cache: {real_name:?}, Error: {source:?}.")]
-    CacheCreateAliasFailed {
-        alias: String,
-        real_name: String,
-        #[source]
-        source: BoxedError,
-    },
-
-    #[error("Failed to insert record in Cache: {0:?}, Error: {1:?}. Usually this happens if primary key is wrongly specified.")]
-    CacheInsertFailed(String, #[source] BoxedError),
-
-    #[error("Failed to delete record in Cache: {0:?}, Error: {1:?}. Usually this happens if primary key is wrongly specified.")]
-    CacheDeleteFailed(String, #[source] BoxedError),
-
-    #[error("Failed to update record in Cache: {0:?}, Error: {1:?}. Usually this happens if primary key is wrongly specified.")]
-    CacheUpdateFailed(String, #[source] BoxedError),
-
-    #[error("Failed to commit cache transaction: {0:?}, Error: {1:?}")]
-    CacheCommitTransactionFailed(String, #[source] BoxedError),
-
-    #[error("Cache {0} has reached its maximum size. Try to increase `cache_max_map_size` in the config.")]
-    CacheFull(String),
-
-    #[error("Failed to count the records during init in Cache: {0:?}, Error: {1:?}")]
-    CacheCountFailed(String, #[source] BoxedError),
 }
 
 #[derive(Error, Debug)]

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use crate::appsource::AppSourceId;
 use crate::node::PortHandle;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::errors::types::TypeError;
 use dozer_types::node::NodeHandle;
 use dozer_types::thiserror;
 use dozer_types::thiserror::Error;
@@ -34,21 +33,17 @@ pub enum ExecutionError {
     InvalidSourceIdentifier(AppSourceId),
     #[error("Ambiguous source identifier {0}")]
     AmbiguousSourceIdentifier(AppSourceId),
-    #[error("Port not found for source: {0}")]
-    PortNotFoundInSource(PortHandle),
     #[error("Invalid AppSource connection {0}. Already exists.")]
     AppSourceConnectionAlreadyExists(String),
+    #[error("Factory error: {0}")]
+    Factory(#[source] BoxedError),
 
     // Error forwarders
     #[error("File system error {0:?}: {1}")]
     FileSystemError(PathBuf, #[source] std::io::Error),
-    #[error("Internal type error: {0}")]
-    InternalTypeError(#[from] TypeError),
     #[error("Internal error: {0}")]
-    InternalError(#[from] BoxedError),
+    InternalError(#[source] BoxedError),
 
-    #[error("Failed to initialize source: {0}")]
-    ConnectorError(#[source] BoxedError),
     // to remove
     #[error("{0}")]
     InternalStringError(String),

--- a/dozer-core/src/executor.rs
+++ b/dozer-core/src/executor.rs
@@ -164,7 +164,8 @@ fn start_source(
             Err(ExecutionError::CannotSendToChannel) => {}
             // Other errors result in panic.
             Err(e) => std::panic::panic_any(e),
-        })?;
+        })
+        .map_err(ExecutionError::CannotSpawnWorkerThread)?;
 
     Ok(Builder::new()
         .name(format!("{handle}-listener"))
@@ -172,7 +173,8 @@ fn start_source(
             if let Err(e) = source_listener.run() {
                 std::panic::panic_any(e);
             }
-        })?)
+        })
+        .map_err(ExecutionError::CannotSpawnWorkerThread)?)
 }
 
 fn start_processor(processor: ProcessorNode) -> Result<JoinHandle<()>, ExecutionError> {
@@ -182,13 +184,17 @@ fn start_processor(processor: ProcessorNode) -> Result<JoinHandle<()>, Execution
             if let Err(e) = processor.run() {
                 std::panic::panic_any(e);
             }
-        })?)
+        })
+        .map_err(ExecutionError::CannotSpawnWorkerThread)?)
 }
 
 fn start_sink(sink: SinkNode) -> Result<JoinHandle<()>, ExecutionError> {
-    Ok(Builder::new().name(sink.handle().to_string()).spawn(|| {
-        if let Err(e) = sink.run() {
-            std::panic::panic_any(e);
-        }
-    })?)
+    Ok(Builder::new()
+        .name(sink.handle().to_string())
+        .spawn(|| {
+            if let Err(e) = sink.run() {
+                std::panic::panic_any(e);
+            }
+        })
+        .map_err(ExecutionError::CannotSpawnWorkerThread)?)
 }

--- a/dozer-core/src/executor.rs
+++ b/dozer-core/src/executor.rs
@@ -167,34 +167,34 @@ fn start_source(
         })
         .map_err(ExecutionError::CannotSpawnWorkerThread)?;
 
-    Ok(Builder::new()
+    Builder::new()
         .name(format!("{handle}-listener"))
         .spawn(move || {
             if let Err(e) = source_listener.run() {
                 std::panic::panic_any(e);
             }
         })
-        .map_err(ExecutionError::CannotSpawnWorkerThread)?)
+        .map_err(ExecutionError::CannotSpawnWorkerThread)
 }
 
 fn start_processor(processor: ProcessorNode) -> Result<JoinHandle<()>, ExecutionError> {
-    Ok(Builder::new()
+    Builder::new()
         .name(processor.handle().to_string())
         .spawn(move || {
             if let Err(e) = processor.run() {
                 std::panic::panic_any(e);
             }
         })
-        .map_err(ExecutionError::CannotSpawnWorkerThread)?)
+        .map_err(ExecutionError::CannotSpawnWorkerThread)
 }
 
 fn start_sink(sink: SinkNode) -> Result<JoinHandle<()>, ExecutionError> {
-    Ok(Builder::new()
+    Builder::new()
         .name(sink.handle().to_string())
         .spawn(|| {
             if let Err(e) = sink.run() {
                 std::panic::panic_any(e);
             }
         })
-        .map_err(ExecutionError::CannotSpawnWorkerThread)?)
+        .map_err(ExecutionError::CannotSpawnWorkerThread)
 }

--- a/dozer-core/src/executor/processor_node.rs
+++ b/dozer-core/src/executor/processor_node.rs
@@ -96,7 +96,9 @@ impl ReceiverLoop for ProcessorNode {
     }
 
     fn on_commit(&mut self, epoch: &Epoch) -> Result<(), ExecutionError> {
-        self.processor.commit(epoch)?;
+        self.processor
+            .commit(epoch)
+            .map_err(ExecutionError::ProcessorOrSink)?;
         self.channel_manager.store_and_send_commit(epoch)
     }
 

--- a/dozer-core/src/executor/sink_node.rs
+++ b/dozer-core/src/executor/sink_node.rs
@@ -83,12 +83,16 @@ impl ReceiverLoop for SinkNode {
         index: usize,
         op: dozer_types::types::Operation,
     ) -> Result<(), ExecutionError> {
-        self.sink.process(self.port_handles[index], op)
+        self.sink
+            .process(self.port_handles[index], op)
+            .map_err(ExecutionError::ProcessorOrSink)
     }
 
     fn on_commit(&mut self, epoch: &Epoch) -> Result<(), ExecutionError> {
         debug!("[{}] Checkpointing - {}", self.node_handle, epoch);
-        self.sink.commit()?;
+        self.sink
+            .commit()
+            .map_err(ExecutionError::ProcessorOrSink)?;
         self.state_writer.store_commit_info(epoch)
     }
 
@@ -97,6 +101,8 @@ impl ReceiverLoop for SinkNode {
     }
 
     fn on_snapshotting_done(&mut self, connection_name: String) -> Result<(), ExecutionError> {
-        self.sink.on_source_snapshotting_done(connection_name)
+        self.sink
+            .on_source_snapshotting_done(connection_name)
+            .map_err(ExecutionError::ProcessorOrSink)
     }
 }

--- a/dozer-core/src/executor/source_node.rs
+++ b/dozer-core/src/executor/source_node.rs
@@ -56,7 +56,7 @@ impl Node for SourceSenderNode {
                 .map(|op_id| (op_id.txid, op_id.seq_in_tx)),
         );
         debug!("[{}-sender] Quit", self.node_handle);
-        result
+        result.map_err(ExecutionError::Source)
     }
 }
 

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -85,14 +85,11 @@ pub trait Processor: Send + Sync + Debug {
 
 pub trait SinkFactory<T>: Send + Sync + Debug {
     fn get_input_ports(&self) -> Vec<PortHandle>;
-    fn prepare(
-        &self,
-        input_schemas: HashMap<PortHandle, (Schema, T)>,
-    ) -> Result<(), ExecutionError>;
+    fn prepare(&self, input_schemas: HashMap<PortHandle, (Schema, T)>) -> Result<(), BoxedError>;
     fn build(
         &self,
         input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError>;
+    ) -> Result<Box<dyn Sink>, BoxedError>;
 }
 
 pub trait Sink: Send + Sync + Debug {

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -50,12 +50,12 @@ pub trait SourceFactory<T>: Send + Sync + Debug {
 pub trait Source: Send + Sync + Debug {
     /// Checks if the source can start from the given checkpoint.
     /// If this function returns false, the executor will start the source from the beginning.
-    fn can_start_from(&self, last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError>;
+    fn can_start_from(&self, last_checkpoint: (u64, u64)) -> Result<bool, BoxedError>;
     fn start(
         &self,
         fw: &mut dyn SourceChannelForwarder,
         last_checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError>;
+    ) -> Result<(), BoxedError>;
 }
 
 pub trait ProcessorFactory<T>: Send + Sync + Debug {

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -2,6 +2,7 @@ use crate::channels::{ProcessorChannelForwarder, SourceChannelForwarder};
 use crate::errors::ExecutionError;
 
 use dozer_types::epoch::Epoch;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::{Operation, Schema};
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
@@ -38,12 +39,12 @@ impl OutputPortDef {
 }
 
 pub trait SourceFactory<T>: Send + Sync + Debug {
-    fn get_output_schema(&self, port: &PortHandle) -> Result<(Schema, T), ExecutionError>;
+    fn get_output_schema(&self, port: &PortHandle) -> Result<(Schema, T), BoxedError>;
     fn get_output_ports(&self) -> Vec<OutputPortDef>;
     fn build(
         &self,
         output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError>;
+    ) -> Result<Box<dyn Source>, BoxedError>;
 }
 
 pub trait Source: Send + Sync + Debug {

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -63,14 +63,14 @@ pub trait ProcessorFactory<T>: Send + Sync + Debug {
         &self,
         output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, (Schema, T)>,
-    ) -> Result<(Schema, T), ExecutionError>;
+    ) -> Result<(Schema, T), BoxedError>;
     fn get_input_ports(&self) -> Vec<PortHandle>;
     fn get_output_ports(&self) -> Vec<OutputPortDef>;
     fn build(
         &self,
         input_schemas: HashMap<PortHandle, Schema>,
         output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError>;
+    ) -> Result<Box<dyn Processor>, BoxedError>;
 }
 
 pub trait Processor: Send + Sync + Debug {

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -93,11 +93,8 @@ pub trait SinkFactory<T>: Send + Sync + Debug {
 }
 
 pub trait Sink: Send + Sync + Debug {
-    fn commit(&mut self) -> Result<(), ExecutionError>;
-    fn process(&mut self, from_port: PortHandle, op: Operation) -> Result<(), ExecutionError>;
+    fn commit(&mut self) -> Result<(), BoxedError>;
+    fn process(&mut self, from_port: PortHandle, op: Operation) -> Result<(), BoxedError>;
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        connection_name: String,
-    ) -> Result<(), ExecutionError>;
+    fn on_source_snapshotting_done(&mut self, connection_name: String) -> Result<(), BoxedError>;
 }

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -1,5 +1,4 @@
 use crate::channels::{ProcessorChannelForwarder, SourceChannelForwarder};
-use crate::errors::ExecutionError;
 
 use dozer_types::epoch::Epoch;
 use dozer_types::errors::internal::BoxedError;
@@ -74,13 +73,13 @@ pub trait ProcessorFactory<T>: Send + Sync + Debug {
 }
 
 pub trait Processor: Send + Sync + Debug {
-    fn commit(&self, epoch_details: &Epoch) -> Result<(), ExecutionError>;
+    fn commit(&self, epoch_details: &Epoch) -> Result<(), BoxedError>;
     fn process(
         &mut self,
         from_port: PortHandle,
         op: Operation,
         fw: &mut dyn ProcessorChannelForwarder,
-    ) -> Result<(), ExecutionError>;
+    ) -> Result<(), BoxedError>;
 }
 
 pub trait SinkFactory<T>: Send + Sync + Debug {

--- a/dozer-core/src/tests/app.rs
+++ b/dozer-core/src/tests/app.rs
@@ -247,8 +247,7 @@ fn test_app_dag() {
         Arc::new(CountingSinkFactory::new(20_000, latch.clone())),
         "sink",
     );
-    p1.connect_nodes("join", None, "sink", Some(COUNTING_SINK_INPUT_PORT), true)
-        .unwrap();
+    p1.connect_nodes("join", None, "sink", Some(COUNTING_SINK_INPUT_PORT), true);
 
     app.add_pipeline(p1);
 
@@ -268,8 +267,7 @@ fn test_app_dag() {
         ],
     );
     p2.add_sink(Arc::new(CountingSinkFactory::new(20_000, latch)), "sink");
-    p2.connect_nodes("join", None, "sink", Some(COUNTING_SINK_INPUT_PORT), true)
-        .unwrap();
+    p2.connect_nodes("join", None, "sink", Some(COUNTING_SINK_INPUT_PORT), true);
 
     app.add_pipeline(p2);
 

--- a/dozer-core/src/tests/app.rs
+++ b/dozer-core/src/tests/app.rs
@@ -1,6 +1,5 @@
 use crate::app::{App, AppPipeline, PipelineEntryPoint};
 use crate::appsource::{AppSource, AppSourceId, AppSourceManager};
-use crate::errors::ExecutionError;
 use crate::executor::{DagExecutor, ExecutorOptions};
 use crate::node::{OutputPortDef, PortHandle, Source, SourceFactory};
 use crate::tests::dag_base_run::{
@@ -13,6 +12,7 @@ use crate::tests::sources::{
     GENERATOR_SOURCE_OUTPUT_PORT,
 };
 use crate::{Edge, Endpoint, DEFAULT_PORT_HANDLE};
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::Schema;
 
@@ -26,10 +26,7 @@ pub(crate) struct NoneContext {}
 #[derive(Debug)]
 struct NoneSourceFactory {}
 impl SourceFactory<NoneContext> for NoneSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         todo!()
     }
 
@@ -40,7 +37,7 @@ impl SourceFactory<NoneContext> for NoneSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         todo!()
     }
 }

--- a/dozer-core/src/tests/dag_base_create_errors.rs
+++ b/dozer-core/src/tests/dag_base_create_errors.rs
@@ -9,6 +9,7 @@ use crate::tests::dag_base_run::NoopProcessorFactory;
 use crate::tests::sinks::{CountingSinkFactory, COUNTING_SINK_INPUT_PORT};
 use crate::tests::sources::{GeneratorSourceFactory, GENERATOR_SOURCE_OUTPUT_PORT};
 
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 
@@ -30,10 +31,7 @@ impl CreateErrSourceFactory {
 }
 
 impl SourceFactory<NoneContext> for CreateErrSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
             Schema::empty()
                 .field(
@@ -60,11 +58,11 @@ impl SourceFactory<NoneContext> for CreateErrSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         if self.panic {
             panic!("Generated error");
         } else {
-            Err(ExecutionError::TestError("Generated Error".to_string()))
+            Err("Generated Error".to_string().into())
         }
     }
 }

--- a/dozer-core/src/tests/dag_base_create_errors.rs
+++ b/dozer-core/src/tests/dag_base_create_errors.rs
@@ -1,4 +1,3 @@
-use crate::errors::ExecutionError;
 use crate::executor::{DagExecutor, ExecutorOptions};
 use crate::node::{
     OutputPortDef, OutputPortType, PortHandle, Processor, ProcessorFactory, Source, SourceFactory,
@@ -167,7 +166,7 @@ impl ProcessorFactory<NoneContext> for CreateErrProcessorFactory {
         &self,
         _port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
             Schema::empty()
                 .field(
@@ -199,11 +198,11 @@ impl ProcessorFactory<NoneContext> for CreateErrProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         if self.panic {
             panic!("Generated error");
         } else {
-            Err(ExecutionError::TestError("Generated Error".to_string()))
+            Err("Generated Error".to_string().into())
         }
     }
 }

--- a/dozer-core/src/tests/dag_base_create_errors.rs
+++ b/dozer-core/src/tests/dag_base_create_errors.rs
@@ -64,9 +64,7 @@ impl SourceFactory<NoneContext> for CreateErrSourceFactory {
         if self.panic {
             panic!("Generated error");
         } else {
-            Err(ExecutionError::InvalidOperation(
-                "Generated Error".to_string(),
-            ))
+            Err(ExecutionError::TestError("Generated Error".to_string()))
         }
     }
 }
@@ -207,9 +205,7 @@ impl ProcessorFactory<NoneContext> for CreateErrProcessorFactory {
         if self.panic {
             panic!("Generated error");
         } else {
-            Err(ExecutionError::InvalidOperation(
-                "Generated Error".to_string(),
-            ))
+            Err(ExecutionError::TestError("Generated Error".to_string()))
         }
     }
 }

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -38,7 +38,7 @@ impl ProcessorFactory<NoneContext> for ErrorProcessorFactory {
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         Ok(input_schemas.get(&DEFAULT_PORT_HANDLE).unwrap().clone())
     }
 
@@ -57,7 +57,7 @@ impl ProcessorFactory<NoneContext> for ErrorProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         Ok(Box::new(ErrorProcessor {
             err_on: self.err_on,
             count: 0,

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -425,14 +425,14 @@ impl SinkFactory<NoneContext> for ErrSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         Ok(Box::new(ErrSink {
             err_at: self.err_at,
             current: 0,

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -448,26 +448,23 @@ pub(crate) struct ErrSink {
     panic: bool,
 }
 impl Sink for ErrSink {
-    fn commit(&mut self) -> Result<(), ExecutionError> {
+    fn commit(&mut self) -> Result<(), BoxedError> {
         Ok(())
     }
 
-    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), ExecutionError> {
+    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), BoxedError> {
         self.current += 1;
         if self.current == self.err_at {
             if self.panic {
                 panic!("Generated error");
             } else {
-                return Err(ExecutionError::TestError("Generated error".to_string()));
+                return Err("Generated error".to_string().into());
             }
         }
         Ok(())
     }
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        _connection_name: String,
-    ) -> Result<(), ExecutionError> {
+    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }
 }

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -10,6 +10,7 @@ use crate::tests::sinks::{CountingSinkFactory, COUNTING_SINK_INPUT_PORT};
 use crate::tests::sources::{GeneratorSourceFactory, GENERATOR_SOURCE_OUTPUT_PORT};
 use crate::{Dag, Endpoint, DEFAULT_PORT_HANDLE};
 use dozer_types::epoch::Epoch;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::{
@@ -278,10 +279,7 @@ impl ErrGeneratorSourceFactory {
 }
 
 impl SourceFactory<NoneContext> for ErrGeneratorSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
             Schema::empty()
                 .field(
@@ -317,7 +315,7 @@ impl SourceFactory<NoneContext> for ErrGeneratorSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         Ok(Box::new(ErrGeneratorSource {
             count: self.count,
             err_at: self.err_at,

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -330,7 +330,7 @@ pub(crate) struct ErrGeneratorSource {
 }
 
 impl Source for ErrGeneratorSource {
-    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError> {
+    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, BoxedError> {
         Ok(false)
     }
 
@@ -338,10 +338,10 @@ impl Source for ErrGeneratorSource {
         &self,
         fw: &mut dyn SourceChannelForwarder,
         _checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         for n in 1..(self.count + 1) {
             if n == self.err_at {
-                return Err(ExecutionError::TestError("Generated Error".to_string()));
+                return Err("Generated Error".to_string().into());
             }
 
             fw.send(

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -88,7 +88,7 @@ impl Processor for ErrorProcessor {
             if self.panic {
                 panic!("Generated error");
             } else {
-                return Err(ExecutionError::InvalidOperation("Uknown".to_string()));
+                return Err(ExecutionError::TestError("Uknown".to_string()));
             }
         }
 
@@ -343,9 +343,7 @@ impl Source for ErrGeneratorSource {
     ) -> Result<(), ExecutionError> {
         for n in 1..(self.count + 1) {
             if n == self.err_at {
-                return Err(ExecutionError::InvalidOperation(
-                    "Generated Error".to_string(),
-                ));
+                return Err(ExecutionError::TestError("Generated Error".to_string()));
             }
 
             fw.send(
@@ -462,9 +460,7 @@ impl Sink for ErrSink {
             if self.panic {
                 panic!("Generated error");
             } else {
-                return Err(ExecutionError::InvalidOperation(
-                    "Generated error".to_string(),
-                ));
+                return Err(ExecutionError::TestError("Generated error".to_string()));
             }
         }
         Ok(())

--- a/dozer-core/src/tests/dag_base_run.rs
+++ b/dozer-core/src/tests/dag_base_run.rs
@@ -1,6 +1,5 @@
 use crate::channels::ProcessorChannelForwarder;
 use crate::dag_schemas::DagSchemas;
-use crate::errors::ExecutionError;
 use crate::executor::{DagExecutor, ExecutorOptions};
 use crate::node::{OutputPortDef, OutputPortType, PortHandle, Processor, ProcessorFactory};
 use crate::tests::sinks::{CountingSinkFactory, COUNTING_SINK_INPUT_PORT};
@@ -59,7 +58,7 @@ impl ProcessorFactory<NoneContext> for NoopProcessorFactory {
 pub(crate) struct NoopProcessor {}
 
 impl Processor for NoopProcessor {
-    fn commit(&self, _epoch_details: &Epoch) -> Result<(), ExecutionError> {
+    fn commit(&self, _epoch_details: &Epoch) -> Result<(), BoxedError> {
         Ok(())
     }
 
@@ -68,8 +67,8 @@ impl Processor for NoopProcessor {
         _from_port: PortHandle,
         op: Operation,
         fw: &mut dyn ProcessorChannelForwarder,
-    ) -> Result<(), ExecutionError> {
-        fw.send(op, DEFAULT_PORT_HANDLE)
+    ) -> Result<(), BoxedError> {
+        fw.send(op, DEFAULT_PORT_HANDLE).map_err(Into::into)
     }
 }
 
@@ -199,7 +198,7 @@ impl ProcessorFactory<NoneContext> for NoopJoinProcessorFactory {
 pub(crate) struct NoopJoinProcessor {}
 
 impl Processor for NoopJoinProcessor {
-    fn commit(&self, _epoch_details: &Epoch) -> Result<(), ExecutionError> {
+    fn commit(&self, _epoch_details: &Epoch) -> Result<(), BoxedError> {
         Ok(())
     }
 
@@ -208,8 +207,8 @@ impl Processor for NoopJoinProcessor {
         _from_port: PortHandle,
         op: Operation,
         fw: &mut dyn ProcessorChannelForwarder,
-    ) -> Result<(), ExecutionError> {
-        fw.send(op, DEFAULT_PORT_HANDLE)
+    ) -> Result<(), BoxedError> {
+        fw.send(op, DEFAULT_PORT_HANDLE).map_err(Into::into)
     }
 }
 

--- a/dozer-core/src/tests/dag_base_run.rs
+++ b/dozer-core/src/tests/dag_base_run.rs
@@ -11,6 +11,7 @@ use crate::tests::sources::{
 };
 use crate::{Dag, Endpoint, DEFAULT_PORT_HANDLE};
 use dozer_types::epoch::Epoch;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::{Operation, Schema};
 
@@ -30,7 +31,7 @@ impl ProcessorFactory<NoneContext> for NoopProcessorFactory {
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         Ok(input_schemas.get(&DEFAULT_PORT_HANDLE).unwrap().clone())
     }
 
@@ -49,7 +50,7 @@ impl ProcessorFactory<NoneContext> for NoopProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         Ok(Box::new(NoopProcessor {}))
     }
 }
@@ -170,7 +171,7 @@ impl ProcessorFactory<NoneContext> for NoopJoinProcessorFactory {
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         Ok(input_schemas.get(&1).unwrap().clone())
     }
 
@@ -189,7 +190,7 @@ impl ProcessorFactory<NoneContext> for NoopJoinProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         Ok(Box::new(NoopJoinProcessor {}))
     }
 }

--- a/dozer-core/src/tests/dag_ports.rs
+++ b/dozer-core/src/tests/dag_ports.rs
@@ -1,4 +1,3 @@
-use crate::errors::ExecutionError;
 use crate::node::{
     OutputPortDef, OutputPortType, PortHandle, Processor, ProcessorFactory, Source, SourceFactory,
 };
@@ -60,7 +59,7 @@ impl ProcessorFactory<NoneContext> for DynPortsProcessorFactory {
         &self,
         _output_port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         todo!()
     }
 
@@ -79,7 +78,7 @@ impl ProcessorFactory<NoneContext> for DynPortsProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         todo!()
     }
 }

--- a/dozer-core/src/tests/dag_ports.rs
+++ b/dozer-core/src/tests/dag_ports.rs
@@ -4,6 +4,7 @@ use crate::node::{
 };
 use crate::tests::app::NoneContext;
 use crate::{Dag, Endpoint, DEFAULT_PORT_HANDLE};
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::{node::NodeHandle, types::Schema};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -20,10 +21,7 @@ impl DynPortsSourceFactory {
 }
 
 impl SourceFactory<NoneContext> for DynPortsSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         todo!()
     }
 
@@ -37,7 +35,7 @@ impl SourceFactory<NoneContext> for DynPortsSourceFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         todo!()
     }
 }

--- a/dozer-core/src/tests/dag_schemas.rs
+++ b/dozer-core/src/tests/dag_schemas.rs
@@ -6,6 +6,7 @@ use crate::node::{
 };
 use crate::{Dag, Endpoint, DEFAULT_PORT_HANDLE};
 
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
 use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 use std::collections::HashMap;
@@ -23,10 +24,7 @@ macro_rules! chk {
 struct TestUsersSourceFactory {}
 
 impl SourceFactory<NoneContext> for TestUsersSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
             Schema::empty()
                 .field(
@@ -71,7 +69,7 @@ impl SourceFactory<NoneContext> for TestUsersSourceFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         todo!()
     }
 }
@@ -80,10 +78,7 @@ impl SourceFactory<NoneContext> for TestUsersSourceFactory {
 struct TestCountriesSourceFactory {}
 
 impl SourceFactory<NoneContext> for TestCountriesSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
             Schema::empty()
                 .field(
@@ -119,7 +114,7 @@ impl SourceFactory<NoneContext> for TestCountriesSourceFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         todo!()
     }
 }

--- a/dozer-core/src/tests/dag_schemas.rs
+++ b/dozer-core/src/tests/dag_schemas.rs
@@ -172,14 +172,14 @@ impl SinkFactory<NoneContext> for TestSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn crate::node::Sink>, ExecutionError> {
+    ) -> Result<Box<dyn crate::node::Sink>, BoxedError> {
         todo!()
     }
 }

--- a/dozer-core/src/tests/dag_schemas.rs
+++ b/dozer-core/src/tests/dag_schemas.rs
@@ -1,5 +1,4 @@
 use crate::dag_schemas::{DagHaveSchemas, DagSchemas};
-use crate::errors::ExecutionError;
 use crate::node::{
     OutputPortDef, OutputPortType, PortHandle, Processor, ProcessorFactory, SinkFactory, Source,
     SourceFactory,
@@ -127,7 +126,7 @@ impl ProcessorFactory<NoneContext> for TestJoinProcessorFactory {
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         let mut joined: Vec<FieldDefinition> = Vec::new();
         joined.extend(input_schemas.get(&1).unwrap().0.fields.clone());
         joined.extend(input_schemas.get(&2).unwrap().0.fields.clone());
@@ -156,7 +155,7 @@ impl ProcessorFactory<NoneContext> for TestJoinProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         todo!()
     }
 }

--- a/dozer-core/src/tests/processors.rs
+++ b/dozer-core/src/tests/processors.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use dozer_types::types::Schema;
+use dozer_types::{errors::internal::BoxedError, types::Schema};
 
 use crate::{
     node::{OutputPortDef, OutputPortType, PortHandle, Processor, ProcessorFactory},
@@ -28,7 +28,7 @@ impl ProcessorFactory<NoneContext> for ConnectivityTestProcessorFactory {
         &self,
         _output_port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), crate::errors::ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         unimplemented!(
             "This struct is for connectivity test, only input and output ports are defined"
         )
@@ -38,7 +38,7 @@ impl ProcessorFactory<NoneContext> for ConnectivityTestProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, crate::errors::ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         unimplemented!(
             "This struct is for connectivity test, only input and output ports are defined"
         )
@@ -64,7 +64,7 @@ impl ProcessorFactory<NoneContext> for NoInputPortProcessorFactory {
         &self,
         _output_port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(Schema, NoneContext), crate::errors::ExecutionError> {
+    ) -> Result<(Schema, NoneContext), BoxedError> {
         unimplemented!(
             "This struct is for connectivity test, only input and output ports are defined"
         )
@@ -74,7 +74,7 @@ impl ProcessorFactory<NoneContext> for NoInputPortProcessorFactory {
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, crate::errors::ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         unimplemented!(
             "This struct is for connectivity test, only input and output ports are defined"
         )

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -1,6 +1,7 @@
 use crate::errors::ExecutionError;
 use crate::node::{PortHandle, Sink, SinkFactory};
 use crate::DEFAULT_PORT_HANDLE;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::{Operation, Schema};
 
 use dozer_types::log::debug;
@@ -35,14 +36,14 @@ impl SinkFactory<NoneContext> for CountingSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         Ok(Box::new(CountingSink {
             expected: self.expected,
             current: 0,
@@ -100,14 +101,14 @@ impl SinkFactory<NoneContext> for ConnectivityTestSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         unimplemented!("This struct is for connectivity test, only input ports are defined")
     }
 
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         unimplemented!("This struct is for connectivity test, only input ports are defined")
     }
 }
@@ -123,14 +124,14 @@ impl SinkFactory<NoneContext> for NoInputPortSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, NoneContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         unimplemented!("This struct is for connectivity test, only input ports are defined")
     }
 
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         unimplemented!("This struct is for connectivity test, only input ports are defined")
     }
 }

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -1,4 +1,3 @@
-use crate::errors::ExecutionError;
 use crate::node::{PortHandle, Sink, SinkFactory};
 use crate::DEFAULT_PORT_HANDLE;
 use dozer_types::errors::internal::BoxedError;
@@ -59,7 +58,7 @@ pub(crate) struct CountingSink {
     running: Arc<AtomicBool>,
 }
 impl Sink for CountingSink {
-    fn commit(&mut self) -> Result<(), ExecutionError> {
+    fn commit(&mut self) -> Result<(), BoxedError> {
         // if self.current == self.expected {
         //     info!(
         //         "Received {} messages. Notifying sender to exit!",
@@ -70,7 +69,7 @@ impl Sink for CountingSink {
         Ok(())
     }
 
-    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), ExecutionError> {
+    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), BoxedError> {
         self.current += 1;
         if self.current == self.expected {
             debug!(
@@ -82,10 +81,7 @@ impl Sink for CountingSink {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        _connection_name: String,
-    ) -> Result<(), ExecutionError> {
+    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }
 }

--- a/dozer-core/src/tests/sources.rs
+++ b/dozer-core/src/tests/sources.rs
@@ -1,5 +1,4 @@
 use crate::channels::SourceChannelForwarder;
-use crate::errors::ExecutionError;
 use crate::node::{OutputPortDef, OutputPortType, PortHandle, Source, SourceFactory};
 use crate::DEFAULT_PORT_HANDLE;
 use dozer_types::errors::internal::BoxedError;
@@ -91,7 +90,7 @@ pub(crate) struct GeneratorSource {
 }
 
 impl Source for GeneratorSource {
-    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError> {
+    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, BoxedError> {
         Ok(true)
     }
 
@@ -99,7 +98,7 @@ impl Source for GeneratorSource {
         &self,
         fw: &mut dyn SourceChannelForwarder,
         last_checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         let start = last_checkpoint.unwrap_or((0, 0)).0;
 
         for n in start + 1..(start + self.count + 1) {
@@ -218,7 +217,7 @@ pub(crate) struct DualPortGeneratorSource {
 }
 
 impl Source for DualPortGeneratorSource {
-    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError> {
+    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, BoxedError> {
         Ok(false)
     }
 
@@ -226,7 +225,7 @@ impl Source for DualPortGeneratorSource {
         &self,
         fw: &mut dyn SourceChannelForwarder,
         _last_checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         for n in 1..(self.count + 1) {
             fw.send(
                 IngestionMessage::new_op(

--- a/dozer-core/src/tests/sources.rs
+++ b/dozer-core/src/tests/sources.rs
@@ -2,6 +2,7 @@ use crate::channels::SourceChannelForwarder;
 use crate::errors::ExecutionError;
 use crate::node::{OutputPortDef, OutputPortType, PortHandle, Source, SourceFactory};
 use crate::DEFAULT_PORT_HANDLE;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
@@ -35,10 +36,7 @@ impl GeneratorSourceFactory {
 }
 
 impl SourceFactory<NoneContext> for GeneratorSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
             Schema::empty()
                 .field(
@@ -78,7 +76,7 @@ impl SourceFactory<NoneContext> for GeneratorSourceFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         Ok(Box::new(GeneratorSource {
             count: self.count,
             running: self.running.clone(),
@@ -155,10 +153,7 @@ impl DualPortGeneratorSourceFactory {
 }
 
 impl SourceFactory<NoneContext> for DualPortGeneratorSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
             Schema::empty()
                 .field(
@@ -208,7 +203,7 @@ impl SourceFactory<NoneContext> for DualPortGeneratorSourceFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         Ok(Box::new(DualPortGeneratorSource {
             count: self.count,
             running: self.running.clone(),
@@ -280,10 +275,7 @@ impl Source for DualPortGeneratorSource {
 pub struct ConnectivityTestSourceFactory;
 
 impl SourceFactory<NoneContext> for ConnectivityTestSourceFactory {
-    fn get_output_schema(
-        &self,
-        _port: &PortHandle,
-    ) -> Result<(Schema, NoneContext), ExecutionError> {
+    fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         unimplemented!("This struct is for connectivity test, only output ports are defined")
     }
 
@@ -297,7 +289,7 @@ impl SourceFactory<NoneContext> for ConnectivityTestSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         unimplemented!("This struct is for connectivity test, only output ports are defined")
     }
 }

--- a/dozer-log/src/errors.rs
+++ b/dozer-log/src/errors.rs
@@ -19,8 +19,16 @@ pub enum ReaderError {
 
 #[derive(Debug, Error)]
 pub enum SchemaError {
-    #[error("Filesystem error: {0:?} - {1:?}")]
+    #[error("Filesystem error: {0:?} - {1}")]
     Filesystem(PathBuf, #[source] std::io::Error),
-    #[error("Error deserializing schema: {0:?}")]
+    #[error("Error deserializing schema: {0}")]
     Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum WriterError {
+    #[error("Filesystem error: {0:?} - {1}")]
+    FileSystem(PathBuf, #[source] std::io::Error),
+    #[error("Bincode error: {0}")]
+    Bincode(#[from] bincode::Error),
 }

--- a/dozer-log/src/lib.rs
+++ b/dozer-log/src/lib.rs
@@ -2,5 +2,28 @@ pub mod errors;
 pub mod home_dir;
 pub mod reader;
 pub mod schemas;
+pub mod writer;
 
+use dozer_types::indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 pub use tokio;
+
+fn attach_progress(multi_pb: Option<MultiProgress>) -> ProgressBar {
+    let pb = ProgressBar::new_spinner();
+    multi_pb.as_ref().map(|m| m.add(pb.clone()));
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.blue} {msg}: {pos}: {per_sec}")
+            .unwrap()
+            // For more spinners check out the cli-spinners project:
+            // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
+            .tick_strings(&[
+                "▹▹▹▹▹",
+                "▸▹▹▹▹",
+                "▹▸▹▹▹",
+                "▹▹▸▹▹",
+                "▹▹▹▸▹",
+                "▹▹▹▹▸",
+                "▪▪▪▪▪",
+            ]),
+    );
+    pb
+}

--- a/dozer-log/src/reader.rs
+++ b/dozer-log/src/reader.rs
@@ -1,8 +1,10 @@
 use std::{io::SeekFrom, path::Path, time::Duration};
 
+use crate::attach_progress;
+
 use super::errors::ReaderError;
 use dozer_types::epoch::ExecutorOperation;
-use dozer_types::indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use dozer_types::indicatif::{MultiProgress, ProgressBar};
 use dozer_types::{bincode, log::trace};
 use tokio::{
     fs::{File, OpenOptions},
@@ -90,25 +92,4 @@ async fn read_msg(reader: &mut BufReader<File>) -> Result<(ExecutorOperation, u6
         .map_err(ReaderError::ReadError)?;
     let msg = bincode::deserialize(&buf).map_err(ReaderError::DeserializationError)?;
     Ok((msg, len + 8))
-}
-
-fn attach_progress(multi_pb: Option<MultiProgress>) -> ProgressBar {
-    let pb = ProgressBar::new_spinner();
-    multi_pb.as_ref().map(|m| m.add(pb.clone()));
-    pb.set_style(
-        ProgressStyle::with_template("{spinner:.blue} {msg}: {pos}: {per_sec}")
-            .unwrap()
-            // For more spinners check out the cli-spinners project:
-            // https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json
-            .tick_strings(&[
-                "▹▹▹▹▹",
-                "▸▹▹▹▹",
-                "▹▸▹▹▹",
-                "▹▹▸▹▹",
-                "▹▹▹▸▹",
-                "▹▹▹▹▸",
-                "▪▪▪▪▪",
-            ]),
-    );
-    pb
 }

--- a/dozer-log/src/writer.rs
+++ b/dozer-log/src/writer.rs
@@ -1,0 +1,71 @@
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufWriter, Write},
+    path::PathBuf,
+};
+
+use dozer_types::{
+    bytes::{BufMut, BytesMut},
+    epoch::ExecutorOperation,
+    indicatif::{MultiProgress, ProgressBar},
+};
+
+use crate::{attach_progress, errors::WriterError};
+
+#[derive(Debug)]
+pub struct LogWriter {
+    writer: BufWriter<File>,
+    path: PathBuf,
+    pb: ProgressBar,
+    counter: u64,
+}
+
+impl LogWriter {
+    pub fn new(
+        path: PathBuf,
+        file_buffer_capacity: usize,
+        name: String,
+        multi_pb: Option<MultiProgress>,
+    ) -> Result<Self, WriterError> {
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .map_err(|e| WriterError::FileSystem(path.clone(), e))?;
+
+        let writer = BufWriter::with_capacity(file_buffer_capacity, file);
+
+        let pb = attach_progress(multi_pb);
+        pb.set_message(name);
+
+        Ok(Self {
+            writer,
+            path,
+            pb,
+            counter: 0,
+        })
+    }
+
+    pub fn write_op(&mut self, op: &ExecutorOperation) -> Result<(), WriterError> {
+        let msg = dozer_types::bincode::serialize(op)?;
+
+        let mut buf = BytesMut::with_capacity(msg.len() + 4);
+        buf.put_u64_le(msg.len() as u64);
+        buf.put_slice(&msg);
+
+        self.writer
+            .write_all(&buf)
+            .map_err(|e| WriterError::FileSystem(self.path.clone(), e))?;
+
+        self.counter += 1;
+        self.pb.set_position(self.counter);
+
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<(), WriterError> {
+        self.writer
+            .flush()
+            .map_err(|e| WriterError::FileSystem(self.path.clone(), e))
+    }
+}

--- a/dozer-sql/src/pipeline/aggregation/aggregator.rs
+++ b/dozer-sql/src/pipeline/aggregation/aggregator.rs
@@ -215,29 +215,29 @@ macro_rules! try_unwrap {
 #[macro_export]
 macro_rules! calculate_err {
     ($stmt:expr, $aggr:expr) => {
-        $stmt.ok_or(PipelineError::InternalExecutionError(InvalidType(format!(
+        $stmt.ok_or(PipelineError::InvalidReturnType(format!(
             "Failed to calculate {}",
             $aggr
-        ))))?
+        )))?
     };
 }
 
 #[macro_export]
 macro_rules! calculate_err_field {
     ($stmt:expr, $aggr:expr, $field:expr) => {
-        $stmt.ok_or(PipelineError::InternalExecutionError(InvalidType(format!(
+        $stmt.ok_or(PipelineError::InvalidReturnType(format!(
             "Failed to calculate {} while parsing {}",
             $aggr, $field
-        ))))?
+        )))?
     };
 }
 
 #[macro_export]
 macro_rules! calculate_err_type {
     ($stmt:expr, $aggr:expr, $return_type:expr) => {
-        $stmt.ok_or(PipelineError::InternalExecutionError(InvalidType(format!(
+        $stmt.ok_or(PipelineError::InvalidReturnType(format!(
             "Failed to calculate {} while casting {}",
             $aggr, $return_type
-        ))))?
+        )))?
     };
 }

--- a/dozer-sql/src/pipeline/aggregation/avg.rs
+++ b/dozer-sql/src/pipeline/aggregation/avg.rs
@@ -6,7 +6,6 @@ use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Avg;
 use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
-use dozer_core::errors::ExecutionError::InvalidType;
 use dozer_types::arrow::datatypes::ArrowNativeTypeOp;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
@@ -216,12 +215,12 @@ fn get_average(
             | FieldType::Timestamp
             | FieldType::Binary
             | FieldType::Json
-            | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+            | FieldType::Point => Err(PipelineError::InvalidReturnType(format!(
                 "Not supported return type {typ} for {Avg}"
-            )))),
+            ))),
         },
-        None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+        None => Err(PipelineError::InvalidReturnType(format!(
             "Not supported None return type for {Avg}"
-        )))),
+        ))),
     }
 }

--- a/dozer-sql/src/pipeline/aggregation/count.rs
+++ b/dozer-sql/src/pipeline/aggregation/count.rs
@@ -3,7 +3,6 @@ use crate::pipeline::aggregation::aggregator::Aggregator;
 use crate::pipeline::errors::PipelineError;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Count;
 use crate::pipeline::expression::execution::{Expression, ExpressionType};
-use dozer_core::errors::ExecutionError::InvalidType;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
 use dozer_types::types::{Field, FieldType, Schema, SourceDefinition};
@@ -78,12 +77,12 @@ fn get_count(count: u64, return_type: Option<FieldType>) -> Result<Field, Pipeli
             | FieldType::Timestamp
             | FieldType::Binary
             | FieldType::Json
-            | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+            | FieldType::Point => Err(PipelineError::InvalidReturnType(format!(
                 "Not supported return type {typ} for {Count}"
-            )))),
+            ))),
         },
-        None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+        None => Err(PipelineError::InvalidReturnType(format!(
             "Not supported None return type for {Count}"
-        )))),
+        ))),
     }
 }

--- a/dozer-sql/src/pipeline/aggregation/max.rs
+++ b/dozer-sql/src/pipeline/aggregation/max.rs
@@ -4,7 +4,6 @@ use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Max;
 use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
 use crate::{argv, calculate_err, calculate_err_field};
-use dozer_core::errors::ExecutionError::InvalidType;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::types::{Field, FieldType, Schema, SourceDefinition};
 use std::collections::BTreeMap;
@@ -130,13 +129,13 @@ fn get_max(
                 | FieldType::Text
                 | FieldType::Binary
                 | FieldType::Json
-                | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(
-                    format!("Not supported return type {typ} for {Max}"),
+                | FieldType::Point => Err(PipelineError::InvalidReturnType(format!(
+                    "Not supported return type {typ} for {Max}"
                 ))),
             },
-            None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+            None => Err(PipelineError::InvalidReturnType(format!(
                 "Not supported None return type for {Max}"
-            )))),
+            ))),
         }
     }
 }

--- a/dozer-sql/src/pipeline/aggregation/min.rs
+++ b/dozer-sql/src/pipeline/aggregation/min.rs
@@ -4,7 +4,6 @@ use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Min;
 use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
 use crate::{argv, calculate_err, calculate_err_field};
-use dozer_core::errors::ExecutionError::InvalidType;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::types::{Field, FieldType, Schema, SourceDefinition};
 use std::collections::BTreeMap;
@@ -130,13 +129,13 @@ fn get_min(
                 | FieldType::Text
                 | FieldType::Binary
                 | FieldType::Json
-                | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(
-                    format!("Not supported return type {typ} for {Min}"),
+                | FieldType::Point => Err(PipelineError::InvalidReturnType(format!(
+                    "Not supported return type {typ} for {Min}"
                 ))),
             },
-            None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+            None => Err(PipelineError::InvalidReturnType(format!(
                 "Not supported None return type for {Min}"
-            )))),
+            ))),
         }
     }
 }

--- a/dozer-sql/src/pipeline/aggregation/processor.rs
+++ b/dozer-sql/src/pipeline/aggregation/processor.rs
@@ -4,10 +4,9 @@ use crate::pipeline::errors::PipelineError;
 use crate::pipeline::expression::execution::ExpressionExecutor;
 use crate::pipeline::{aggregation::aggregator::Aggregator, expression::execution::Expression};
 use dozer_core::channels::ProcessorChannelForwarder;
-use dozer_core::errors::ExecutionError;
-use dozer_core::errors::ExecutionError::InternalError;
 use dozer_core::node::{PortHandle, Processor};
 use dozer_core::DEFAULT_PORT_HANDLE;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::{Field, FieldType, Operation, Record, Schema};
 use std::hash::{Hash, Hasher};
 
@@ -558,7 +557,7 @@ fn get_key(
 }
 
 impl Processor for AggregationProcessor {
-    fn commit(&self, _epoch: &Epoch) -> Result<(), ExecutionError> {
+    fn commit(&self, _epoch: &Epoch) -> Result<(), BoxedError> {
         Ok(())
     }
 
@@ -567,8 +566,8 @@ impl Processor for AggregationProcessor {
         _from_port: PortHandle,
         op: Operation,
         fw: &mut dyn ProcessorChannelForwarder,
-    ) -> Result<(), ExecutionError> {
-        let ops = self.aggregate(op).map_err(|e| InternalError(Box::new(e)))?;
+    ) -> Result<(), BoxedError> {
+        let ops = self.aggregate(op)?;
         for fop in ops {
             fw.send(fop, DEFAULT_PORT_HANDLE)?;
         }

--- a/dozer-sql/src/pipeline/aggregation/sum.rs
+++ b/dozer-sql/src/pipeline/aggregation/sum.rs
@@ -4,7 +4,6 @@ use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Sum;
 use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
 use crate::{argv, calculate_err_field};
-use dozer_core::errors::ExecutionError::InvalidType;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
 use dozer_types::types::{DozerDuration, Field, FieldType, Schema, SourceDefinition, TimeUnit};
@@ -222,12 +221,12 @@ pub fn get_sum(
             | FieldType::Timestamp
             | FieldType::Binary
             | FieldType::Json
-            | FieldType::Point => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+            | FieldType::Point => Err(PipelineError::InvalidReturnType(format!(
                 "Not supported return type {typ} for {Sum}"
-            )))),
+            ))),
         },
-        None => Err(PipelineError::InternalExecutionError(InvalidType(format!(
+        None => Err(PipelineError::InvalidReturnType(format!(
             "Not supported None return type for {Sum}"
-        )))),
+        ))),
     }
 }

--- a/dozer-sql/src/pipeline/builder.rs
+++ b/dozer-sql/src/pipeline/builder.rs
@@ -259,7 +259,7 @@ fn select_to_pipeline(
                 processor_name,
                 Some(*processor_port as PortHandle),
                 true,
-            )?;
+            );
             // If not present in pipeline_map, insert into used_sources as this is coming from source
         } else {
             query_ctx.used_sources.push(source_name.clone());
@@ -282,7 +282,7 @@ fn select_to_pipeline(
             &gen_selection_name,
             Some(DEFAULT_PORT_HANDLE),
             true,
-        )?;
+        );
 
         pipeline.connect_nodes(
             &gen_selection_name,
@@ -290,7 +290,7 @@ fn select_to_pipeline(
             &gen_agg_name,
             Some(DEFAULT_PORT_HANDLE),
             true,
-        )?;
+        );
     } else {
         pipeline.connect_nodes(
             &gen_product_name,
@@ -298,7 +298,7 @@ fn select_to_pipeline(
             &gen_agg_name,
             Some(DEFAULT_PORT_HANDLE),
             true,
-        )?;
+        );
     }
 
     query_ctx.pipeline_map.insert(
@@ -455,7 +455,7 @@ fn set_to_pipeline(
         &gen_set_name,
         Some(0 as PortHandle),
         true,
-    )?;
+    );
 
     pipeline.connect_nodes(
         &right_pipeline_output_node.node,
@@ -463,7 +463,7 @@ fn set_to_pipeline(
         &gen_set_name,
         Some(1 as PortHandle),
         true,
-    )?;
+    );
 
     for (_, table_name) in query_ctx.pipeline_map.keys() {
         query_ctx.output_tables_map.remove_entry(table_name);

--- a/dozer-sql/src/pipeline/errors.rs
+++ b/dozer-sql/src/pipeline/errors.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::enum_variant_names)]
 
 use dozer_core::errors::ExecutionError;
+use dozer_core::node::PortHandle;
 use dozer_types::chrono::RoundingError;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::errors::types::TypeError;
@@ -152,6 +153,9 @@ pub enum PipelineError {
 
     #[error("Window: {0}")]
     TableOperatorError(#[from] TableOperatorError),
+
+    #[error("Invalid port handle: {0}")]
+    InvalidPortHandle(PortHandle),
 }
 
 #[cfg(feature = "python")]

--- a/dozer-sql/src/pipeline/errors.rs
+++ b/dozer-sql/src/pipeline/errors.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::enum_variant_names)]
 
-use dozer_core::errors::ExecutionError;
 use dozer_core::node::PortHandle;
 use dozer_types::chrono::RoundingError;
 use dozer_types::errors::internal::BoxedError;
@@ -34,6 +33,8 @@ pub enum PipelineError {
     InvalidOperandType(String),
     #[error("Invalid input type. Reason: {0}")]
     InvalidInputType(String),
+    #[error("Invalid return type: {0}")]
+    InvalidReturnType(String),
     #[error("Invalid function: {0}")]
     InvalidFunction(String),
     #[error("Invalid operator: {0}")]
@@ -88,8 +89,6 @@ pub enum PipelineError {
     // Error forwarding
     #[error("Internal type error: {0}")]
     InternalTypeError(#[from] TypeError),
-    #[error("Internal execution error: {0}")]
-    InternalExecutionError(#[from] ExecutionError),
     #[error("Internal error: {0}")]
     InternalError(#[from] BoxedError),
 
@@ -98,6 +97,9 @@ pub enum PipelineError {
 
     #[error("Join: {0}")]
     JoinError(#[from] JoinError),
+
+    #[error("Product: {0}")]
+    ProductError(#[from] ProductError),
 
     #[error("Set: {0}")]
     SetError(#[from] SetError),
@@ -156,6 +158,8 @@ pub enum PipelineError {
 
     #[error("Invalid port handle: {0}")]
     InvalidPortHandle(PortHandle),
+    #[error("JOIN processor received a Record from a wrong input: {0}")]
+    InvalidPort(u16),
 }
 
 #[cfg(feature = "python")]
@@ -221,10 +225,6 @@ pub enum SetError {
     DatabaseUnavailable,
     #[error("History unavailable for SET source [{0}]")]
     HistoryUnavailable(u16),
-    #[error(
-        "Record with key: {0:x?} version: {1} not available in History for SET source[{2}]\n{3}"
-    )]
-    HistoryRecordNotFound(Vec<u8>, u32, u16, dozer_core::errors::ExecutionError),
 }
 
 #[derive(Error, Debug)]

--- a/dozer-sql/src/pipeline/pipeline_builder/from_builder.rs
+++ b/dozer-sql/src/pipeline/pipeline_builder/from_builder.rs
@@ -162,7 +162,7 @@ fn insert_table_operator_processor_to_pipeline(
             &product_processor_name,
             Some(DEFAULT_PORT_HANDLE),
             true,
-        )?;
+        );
 
         Ok(ConnectionInfo {
             input_nodes,
@@ -206,7 +206,7 @@ fn insert_table_operator_processor_to_pipeline(
             &product_processor_name,
             Some(DEFAULT_PORT_HANDLE),
             true,
-        )?;
+        );
 
         Ok(ConnectionInfo {
             input_nodes,

--- a/dozer-sql/src/pipeline/pipeline_builder/join_builder.rs
+++ b/dozer-sql/src/pipeline/pipeline_builder/join_builder.rs
@@ -104,46 +104,38 @@ pub(crate) fn insert_join_to_pipeline(
 
         match left_join_source {
             JoinSource::Table(_) => {}
-            JoinSource::Operator(ref connection_info) => pipeline
-                .connect_nodes(
-                    &connection_info.output_node.0,
-                    Some(connection_info.output_node.1),
-                    &join_processor_name,
-                    Some(LEFT_JOIN_PORT),
-                    true,
-                )
-                .map_err(PipelineError::InternalExecutionError)?,
-            JoinSource::Join(ref connection_info) => pipeline
-                .connect_nodes(
-                    &connection_info.output_node.0,
-                    Some(connection_info.output_node.1),
-                    &join_processor_name,
-                    Some(LEFT_JOIN_PORT),
-                    true,
-                )
-                .map_err(PipelineError::InternalExecutionError)?,
+            JoinSource::Operator(ref connection_info) => pipeline.connect_nodes(
+                &connection_info.output_node.0,
+                Some(connection_info.output_node.1),
+                &join_processor_name,
+                Some(LEFT_JOIN_PORT),
+                true,
+            ),
+            JoinSource::Join(ref connection_info) => pipeline.connect_nodes(
+                &connection_info.output_node.0,
+                Some(connection_info.output_node.1),
+                &join_processor_name,
+                Some(LEFT_JOIN_PORT),
+                true,
+            ),
         }
 
         match right_join_source {
             JoinSource::Table(_) => {}
-            JoinSource::Operator(connection_info) => pipeline
-                .connect_nodes(
-                    &connection_info.output_node.0,
-                    Some(connection_info.output_node.1),
-                    &join_processor_name,
-                    Some(RIGHT_JOIN_PORT),
-                    true,
-                )
-                .map_err(PipelineError::InternalExecutionError)?,
-            JoinSource::Join(connection_info) => pipeline
-                .connect_nodes(
-                    &connection_info.output_node.0,
-                    Some(connection_info.output_node.1),
-                    &join_processor_name,
-                    Some(RIGHT_JOIN_PORT),
-                    true,
-                )
-                .map_err(PipelineError::InternalExecutionError)?,
+            JoinSource::Operator(connection_info) => pipeline.connect_nodes(
+                &connection_info.output_node.0,
+                Some(connection_info.output_node.1),
+                &join_processor_name,
+                Some(RIGHT_JOIN_PORT),
+                true,
+            ),
+            JoinSource::Join(connection_info) => pipeline.connect_nodes(
+                &connection_info.output_node.0,
+                Some(connection_info.output_node.1),
+                &join_processor_name,
+                Some(RIGHT_JOIN_PORT),
+                true,
+            ),
         }
 
         // TODO: refactor join source name and aliasing logic

--- a/dozer-sql/src/pipeline/product/join/processor.rs
+++ b/dozer-sql/src/pipeline/product/join/processor.rs
@@ -1,9 +1,11 @@
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::epoch::Epoch;
-use dozer_core::errors::ExecutionError;
 use dozer_core::node::{PortHandle, Processor};
 use dozer_core::DEFAULT_PORT_HANDLE;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::Operation;
+
+use crate::pipeline::errors::PipelineError;
 
 use super::operator::{JoinAction, JoinBranch, JoinOperator};
 
@@ -30,7 +32,7 @@ impl ProductProcessor {
 }
 
 impl Processor for ProductProcessor {
-    fn commit(&self, _epoch: &Epoch) -> Result<(), ExecutionError> {
+    fn commit(&self, _epoch: &Epoch) -> Result<(), BoxedError> {
         Ok(())
     }
 
@@ -39,11 +41,11 @@ impl Processor for ProductProcessor {
         from_port: PortHandle,
         op: Operation,
         fw: &mut dyn ProcessorChannelForwarder,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         let from_branch = match from_port {
             0 => &JoinBranch::Left,
             1 => &JoinBranch::Right,
-            _ => return Err(ExecutionError::InvalidPort(from_port)),
+            _ => return Err(PipelineError::InvalidPort(from_port).into()),
         };
 
         let records = match op {
@@ -54,7 +56,7 @@ impl Processor for ProductProcessor {
 
                 self.join_operator
                     .delete(from_branch, old)
-                    .map_err(|err| ExecutionError::InternalError(Box::new(err)))?
+                    .map_err(PipelineError::JoinError)?
             }
             Operation::Insert { ref new } => {
                 if let Some(lifetime) = &new.lifetime {
@@ -63,7 +65,7 @@ impl Processor for ProductProcessor {
 
                 self.join_operator
                     .insert(from_branch, new)
-                    .map_err(|err| ExecutionError::InternalError(Box::new(err)))?
+                    .map_err(PipelineError::JoinError)?
             }
             Operation::Update { ref old, ref new } => {
                 if let Some(lifetime) = &old.lifetime {
@@ -73,12 +75,12 @@ impl Processor for ProductProcessor {
                 let old_records = self
                     .join_operator
                     .delete(from_branch, old)
-                    .map_err(|err| ExecutionError::InternalError(Box::new(err)))?;
+                    .map_err(PipelineError::JoinError)?;
 
                 let new_records = self
                     .join_operator
                     .insert(from_branch, new)
-                    .map_err(|err| ExecutionError::InternalError(Box::new(err)))?;
+                    .map_err(PipelineError::JoinError)?;
 
                 old_records
                     .into_iter()

--- a/dozer-sql/src/pipeline/product/table/factory.rs
+++ b/dozer-sql/src/pipeline/product/table/factory.rs
@@ -81,12 +81,12 @@ pub fn get_name_or_alias(relation: &TableFactor) -> Result<NameOrAlias, Pipeline
             }
             Ok(NameOrAlias("dozer_derived".to_string(), None))
         }
-        TableFactor::TableFunction { .. } => Err(PipelineError::InternalError(Box::new(
+        TableFactor::TableFunction { .. } => Err(PipelineError::ProductError(
             ProductError::UnsupportedTableFunction,
-        ))),
-        TableFactor::UNNEST { .. } => Err(PipelineError::InternalError(Box::new(
-            ProductError::UnsupportedUnnest,
-        ))),
+        )),
+        TableFactor::UNNEST { .. } => {
+            Err(PipelineError::ProductError(ProductError::UnsupportedUnnest))
+        }
         TableFactor::NestedJoin { alias, .. } => {
             if let Some(table_alias) = alias {
                 let alias = table_alias.name.value.clone();

--- a/dozer-sql/src/pipeline/product/table/processor.rs
+++ b/dozer-sql/src/pipeline/product/table/processor.rs
@@ -1,8 +1,8 @@
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::epoch::Epoch;
-use dozer_core::errors::ExecutionError;
 use dozer_core::node::{PortHandle, Processor};
 use dozer_core::DEFAULT_PORT_HANDLE;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::Operation;
 
 #[derive(Debug)]
@@ -15,7 +15,7 @@ impl TableProcessor {
 }
 
 impl Processor for TableProcessor {
-    fn commit(&self, _epoch: &Epoch) -> Result<(), ExecutionError> {
+    fn commit(&self, _epoch: &Epoch) -> Result<(), BoxedError> {
         Ok(())
     }
 
@@ -24,7 +24,7 @@ impl Processor for TableProcessor {
         _from_port: PortHandle,
         op: Operation,
         fw: &mut dyn ProcessorChannelForwarder,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         fw.send(op, DEFAULT_PORT_HANDLE)?;
         Ok(())
     }

--- a/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
@@ -1,12 +1,12 @@
 use dozer_core::app::{App, AppPipeline};
 use dozer_core::appsource::{AppSource, AppSourceManager};
 use dozer_core::channels::SourceChannelForwarder;
-use dozer_core::errors::ExecutionError;
 use dozer_core::executor::{DagExecutor, ExecutorOptions};
 use dozer_core::node::{
     OutputPortDef, OutputPortType, PortHandle, Sink, SinkFactory, Source, SourceFactory,
 };
 use dozer_core::DEFAULT_PORT_HANDLE;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::tracing::{debug, info};
@@ -47,7 +47,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn get_output_schema(
         &self,
         port: &PortHandle,
-    ) -> Result<(Schema, SchemaSQLContext), ExecutionError> {
+    ) -> Result<(Schema, SchemaSQLContext), BoxedError> {
         if port == &USER_PORT {
             let source_id = SourceDefinition::Table {
                 connection: "connection".to_string(),
@@ -167,7 +167,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         Ok(Box::new(TestSource {
             running: self.running.clone(),
         }))
@@ -180,7 +180,7 @@ pub struct TestSource {
 }
 
 impl Source for TestSource {
-    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError> {
+    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, BoxedError> {
         Ok(false)
     }
 
@@ -188,7 +188,7 @@ impl Source for TestSource {
         &self,
         fw: &mut dyn SourceChannelForwarder,
         _last_checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         let operations = vec![
             (
                 Operation::Insert {
@@ -415,7 +415,7 @@ impl SinkFactory<SchemaSQLContext> for TestSinkFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         Ok(Box::new(TestSink {
             expected: self.expected,
             current: 0,
@@ -426,7 +426,7 @@ impl SinkFactory<SchemaSQLContext> for TestSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, SchemaSQLContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 }
@@ -439,7 +439,7 @@ pub struct TestSink {
 }
 
 impl Sink for TestSink {
-    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), ExecutionError> {
+    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), BoxedError> {
         match _op {
             Operation::Delete { old } => info!("o0:-> - {:?}", old.values),
             Operation::Insert { new } => info!("o0:-> + {:?}", new.values),
@@ -459,14 +459,11 @@ impl Sink for TestSink {
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<(), ExecutionError> {
+    fn commit(&mut self) -> Result<(), BoxedError> {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        _connection_name: String,
-    ) -> Result<(), ExecutionError> {
+    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }
 }
@@ -505,15 +502,13 @@ fn test_pipeline_builder() {
     .unwrap();
 
     pipeline.add_sink(Arc::new(TestSinkFactory::new(8, latch)), "sink");
-    pipeline
-        .connect_nodes(
-            &table_info.node,
-            Some(table_info.port),
-            "sink",
-            Some(DEFAULT_PORT_HANDLE),
-            true,
-        )
-        .unwrap();
+    pipeline.connect_nodes(
+        &table_info.node,
+        Some(table_info.port),
+        "sink",
+        Some(DEFAULT_PORT_HANDLE),
+        true,
+    );
 
     let mut app = App::new(asm);
     app.add_pipeline(pipeline);

--- a/dozer-sql/src/pipeline/selection/factory.rs
+++ b/dozer-sql/src/pipeline/selection/factory.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 
-use crate::pipeline::builder::SchemaSQLContext;
 use crate::pipeline::expression::builder::ExpressionBuilder;
+use crate::pipeline::{builder::SchemaSQLContext, errors::PipelineError};
 use dozer_core::{
-    errors::ExecutionError,
     node::{OutputPortDef, OutputPortType, PortHandle, Processor, ProcessorFactory},
     DEFAULT_PORT_HANDLE,
 };
-use dozer_types::types::Schema;
+use dozer_types::{errors::internal::BoxedError, types::Schema};
 use sqlparser::ast::Expr as SqlExpr;
 
 use super::processor::SelectionProcessor;
@@ -40,10 +39,10 @@ impl ProcessorFactory<SchemaSQLContext> for SelectionProcessorFactory {
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, (Schema, SchemaSQLContext)>,
-    ) -> Result<(Schema, SchemaSQLContext), ExecutionError> {
+    ) -> Result<(Schema, SchemaSQLContext), BoxedError> {
         let schema = input_schemas
             .get(&DEFAULT_PORT_HANDLE)
-            .ok_or(ExecutionError::InvalidPortHandle(DEFAULT_PORT_HANDLE))?;
+            .ok_or(PipelineError::InvalidPortHandle(DEFAULT_PORT_HANDLE))?;
         Ok(schema.clone())
     }
 
@@ -51,17 +50,17 @@ impl ProcessorFactory<SchemaSQLContext> for SelectionProcessorFactory {
         &self,
         input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Processor>, ExecutionError> {
+    ) -> Result<Box<dyn Processor>, BoxedError> {
         let schema = input_schemas
             .get(&DEFAULT_PORT_HANDLE)
-            .ok_or(ExecutionError::InvalidPortHandle(DEFAULT_PORT_HANDLE))?;
+            .ok_or(PipelineError::InvalidPortHandle(DEFAULT_PORT_HANDLE))?;
 
         match ExpressionBuilder::new(schema.fields.len()).build(false, &self.statement, schema) {
             Ok(expression) => Ok(Box::new(SelectionProcessor::new(
                 schema.clone(),
                 expression,
             ))),
-            Err(e) => Err(ExecutionError::InternalStringError(e.to_string())),
+            Err(e) => Err(e.into()),
         }
     }
 }

--- a/dozer-sql/src/pipeline/selection/processor.rs
+++ b/dozer-sql/src/pipeline/selection/processor.rs
@@ -1,10 +1,9 @@
 use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::epoch::Epoch;
-use dozer_core::errors::ExecutionError;
-use dozer_core::errors::ExecutionError::InternalError;
 use dozer_core::node::{PortHandle, Processor};
 use dozer_core::DEFAULT_PORT_HANDLE;
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::{Field, Operation, Schema};
 
 #[derive(Debug)]
@@ -35,7 +34,7 @@ impl SelectionProcessor {
 }
 
 impl Processor for SelectionProcessor {
-    fn commit(&self, _epoch: &Epoch) -> Result<(), ExecutionError> {
+    fn commit(&self, _epoch: &Epoch) -> Result<(), BoxedError> {
         Ok(())
     }
 
@@ -44,39 +43,23 @@ impl Processor for SelectionProcessor {
         _from_port: PortHandle,
         op: Operation,
         fw: &mut dyn ProcessorChannelForwarder,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         match op {
             Operation::Delete { ref old } => {
-                if self
-                    .expression
-                    .evaluate(old, &self.input_schema)
-                    .map_err(|e| InternalError(Box::new(e)))?
-                    == Field::Boolean(true)
-                {
+                if self.expression.evaluate(old, &self.input_schema)? == Field::Boolean(true) {
                     let _ = fw.send(op, DEFAULT_PORT_HANDLE);
                 }
             }
             Operation::Insert { ref new } => {
-                if self
-                    .expression
-                    .evaluate(new, &self.input_schema)
-                    .map_err(|e| InternalError(Box::new(e)))?
-                    == Field::Boolean(true)
-                {
+                if self.expression.evaluate(new, &self.input_schema)? == Field::Boolean(true) {
                     let _ = fw.send(op, DEFAULT_PORT_HANDLE);
                 }
             }
             Operation::Update { ref old, ref new } => {
-                let old_fulfilled = self
-                    .expression
-                    .evaluate(old, &self.input_schema)
-                    .map_err(|e| InternalError(Box::new(e)))?
-                    == Field::Boolean(true);
-                let new_fulfilled = self
-                    .expression
-                    .evaluate(new, &self.input_schema)
-                    .map_err(|e| InternalError(Box::new(e)))?
-                    == Field::Boolean(true);
+                let old_fulfilled =
+                    self.expression.evaluate(old, &self.input_schema)? == Field::Boolean(true);
+                let new_fulfilled =
+                    self.expression.evaluate(new, &self.input_schema)? == Field::Boolean(true);
                 match (old_fulfilled, new_fulfilled) {
                     (true, true) => {
                         // both records fulfills the WHERE condition, forward the operation

--- a/dozer-sql/src/pipeline/table_operator/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/table_operator/tests/pipeline_test.rs
@@ -1,7 +1,6 @@
 use dozer_core::app::{App, AppPipeline};
 use dozer_core::appsource::{AppSource, AppSourceManager};
 use dozer_core::channels::SourceChannelForwarder;
-use dozer_core::errors::ExecutionError;
 use dozer_core::executor::{DagExecutor, ExecutorOptions};
 use dozer_core::node::{
     OutputPortDef, OutputPortType, PortHandle, Sink, SinkFactory, Source, SourceFactory,
@@ -9,6 +8,7 @@ use dozer_core::node::{
 
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_types::chrono::{TimeZone, Utc};
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::tracing::{debug, info};
 use dozer_types::types::{
@@ -65,15 +65,13 @@ fn test_lifetime_pipeline() {
         Arc::new(TestSinkFactory::new(EXPECTED_SINK_OP_COUNT, latch)),
         "sink",
     );
-    pipeline
-        .connect_nodes(
-            &table_info.node,
-            Some(table_info.port),
-            "sink",
-            Some(DEFAULT_PORT_HANDLE),
-            true,
-        )
-        .unwrap();
+    pipeline.connect_nodes(
+        &table_info.node,
+        Some(table_info.port),
+        "sink",
+        Some(DEFAULT_PORT_HANDLE),
+        true,
+    );
 
     let mut app = App::new(asm);
     app.add_pipeline(pipeline);
@@ -117,7 +115,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn get_output_schema(
         &self,
         port: &PortHandle,
-    ) -> Result<(Schema, SchemaSQLContext), ExecutionError> {
+    ) -> Result<(Schema, SchemaSQLContext), BoxedError> {
         if port == &TRIPS_PORT {
             let taxi_trips_source = SourceDefinition::Table {
                 connection: "connection".to_string(),
@@ -191,7 +189,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         Ok(Box::new(TestSource {
             _running: self.running.clone(),
         }))
@@ -204,7 +202,7 @@ pub struct TestSource {
 }
 
 impl Source for TestSource {
-    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError> {
+    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, BoxedError> {
         Ok(false)
     }
 
@@ -212,7 +210,7 @@ impl Source for TestSource {
         &self,
         fw: &mut dyn SourceChannelForwarder,
         _last_checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         let operations = vec![
             (
                 Operation::Insert {
@@ -383,7 +381,7 @@ impl SinkFactory<SchemaSQLContext> for TestSinkFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         Ok(Box::new(TestSink {
             _expected: self.expected,
             _current: 0,
@@ -394,7 +392,7 @@ impl SinkFactory<SchemaSQLContext> for TestSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, SchemaSQLContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 }
@@ -407,7 +405,7 @@ pub struct TestSink {
 }
 
 impl Sink for TestSink {
-    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), ExecutionError> {
+    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), BoxedError> {
         match _op {
             Operation::Delete { old } => info!("o0:-> - {:?}", old.values),
             Operation::Insert { new } => info!("o0:-> + {:?}", new.values),
@@ -419,14 +417,11 @@ impl Sink for TestSink {
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<(), ExecutionError> {
+    fn commit(&mut self) -> Result<(), BoxedError> {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        _connection_name: String,
-    ) -> Result<(), ExecutionError> {
+    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }
 }

--- a/dozer-sql/src/pipeline/window/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/window/tests/pipeline_test.rs
@@ -1,7 +1,6 @@
 use dozer_core::app::{App, AppPipeline};
 use dozer_core::appsource::{AppSource, AppSourceManager};
 use dozer_core::channels::SourceChannelForwarder;
-use dozer_core::errors::ExecutionError;
 use dozer_core::executor::{DagExecutor, ExecutorOptions};
 use dozer_core::node::{
     OutputPortDef, OutputPortType, PortHandle, Sink, SinkFactory, Source, SourceFactory,
@@ -9,6 +8,7 @@ use dozer_core::node::{
 
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_types::chrono::{TimeZone, Utc};
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::tracing::{debug, info};
 use dozer_types::types::{
@@ -67,15 +67,13 @@ fn test_pipeline_builder() {
         Arc::new(TestSinkFactory::new(EXPECTED_SINK_OP_COUNT, latch)),
         "sink",
     );
-    pipeline
-        .connect_nodes(
-            &table_info.node,
-            Some(table_info.port),
-            "sink",
-            Some(DEFAULT_PORT_HANDLE),
-            true,
-        )
-        .unwrap();
+    pipeline.connect_nodes(
+        &table_info.node,
+        Some(table_info.port),
+        "sink",
+        Some(DEFAULT_PORT_HANDLE),
+        true,
+    );
 
     let mut app = App::new(asm);
     app.add_pipeline(pipeline);
@@ -117,7 +115,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn get_output_schema(
         &self,
         port: &PortHandle,
-    ) -> Result<(Schema, SchemaSQLContext), ExecutionError> {
+    ) -> Result<(Schema, SchemaSQLContext), BoxedError> {
         if port == &TRIPS_PORT {
             let taxi_trips_source = SourceDefinition::Table {
                 connection: "connection".to_string(),
@@ -191,7 +189,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         Ok(Box::new(TestSource {
             running: self.running.clone(),
         }))
@@ -204,7 +202,7 @@ pub struct TestSource {
 }
 
 impl Source for TestSource {
-    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError> {
+    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, BoxedError> {
         Ok(false)
     }
 
@@ -212,7 +210,7 @@ impl Source for TestSource {
         &self,
         fw: &mut dyn SourceChannelForwarder,
         _last_checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         let operations = vec![
             (
                 Operation::Insert {
@@ -386,7 +384,7 @@ impl SinkFactory<SchemaSQLContext> for TestSinkFactory {
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         Ok(Box::new(TestSink {
             expected: self.expected,
             current: 0,
@@ -397,7 +395,7 @@ impl SinkFactory<SchemaSQLContext> for TestSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, SchemaSQLContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 }
@@ -410,7 +408,7 @@ pub struct TestSink {
 }
 
 impl Sink for TestSink {
-    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), ExecutionError> {
+    fn process(&mut self, _from_port: PortHandle, _op: Operation) -> Result<(), BoxedError> {
         match _op {
             Operation::Delete { old } => info!("o0:-> - {:?}", old.values),
             Operation::Insert { new } => info!("o0:-> + {:?}", new.values),
@@ -430,14 +428,11 @@ impl Sink for TestSink {
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<(), ExecutionError> {
+    fn commit(&mut self) -> Result<(), BoxedError> {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        _connection_name: String,
-    ) -> Result<(), ExecutionError> {
+    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }
 }

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -108,7 +108,7 @@ pub struct TestSource {
 }
 
 impl Source for TestSource {
-    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, ExecutionError> {
+    fn can_start_from(&self, _last_checkpoint: (u64, u64)) -> Result<bool, BoxedError> {
         Ok(false)
     }
 
@@ -116,7 +116,7 @@ impl Source for TestSource {
         &self,
         fw: &mut dyn SourceChannelForwarder,
         _last_checkpoint: Option<(u64, u64)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         let mut idx = 0;
 
         while let Ok(Some((schema_name, op))) = self.receiver.recv() {

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -222,19 +222,16 @@ impl TestSink {
 }
 
 impl Sink for TestSink {
-    fn process(&mut self, _from_port: PortHandle, op: Operation) -> Result<(), ExecutionError> {
+    fn process(&mut self, _from_port: PortHandle, op: Operation) -> Result<(), BoxedError> {
         self.update_result(op);
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<(), ExecutionError> {
+    fn commit(&mut self) -> Result<(), BoxedError> {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(
-        &mut self,
-        _connection_name: String,
-    ) -> Result<(), ExecutionError> {
+    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }
 }

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -294,15 +294,13 @@ impl TestPipeline {
         let output = Arc::new(Mutex::new(HashMap::new()));
         pipeline.add_sink(Arc::new(TestSinkFactory::new(output.clone())), "sink");
 
-        pipeline
-            .connect_nodes(
-                &output_table.node,
-                Some(output_table.port),
-                "sink",
-                Some(DEFAULT_PORT_HANDLE),
-                true,
-            )
-            .unwrap();
+        pipeline.connect_nodes(
+            &output_table.node,
+            Some(output_table.port),
+            "sink",
+            Some(DEFAULT_PORT_HANDLE),
+            true,
+        );
         let used_schemas = pipeline.get_entry_points_sources_names();
         let mut app = App::new(asm);
         app.add_pipeline(pipeline);

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -161,14 +161,14 @@ impl SinkFactory<SchemaSQLContext> for TestSinkFactory {
     fn prepare(
         &self,
         _input_schemas: HashMap<PortHandle, (Schema, SchemaSQLContext)>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 
     fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Sink>, ExecutionError> {
+    ) -> Result<Box<dyn Sink>, BoxedError> {
         Ok(Box::new(TestSink::new(self.output.to_owned())))
     }
 }

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -14,6 +14,7 @@ use dozer_core::executor::{DagExecutor, ExecutorOptions};
 use dozer_sql::pipeline::builder::{statement_to_pipeline, SchemaSQLContext};
 use dozer_types::crossbeam::channel::{Receiver, Sender};
 
+use dozer_types::errors::internal::BoxedError;
 use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::types::{Operation, Record, Schema, SourceDefinition};
 use std::collections::HashMap;
@@ -50,7 +51,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn get_output_schema(
         &self,
         port: &PortHandle,
-    ) -> Result<(Schema, SchemaSQLContext), ExecutionError> {
+    ) -> Result<(Schema, SchemaSQLContext), BoxedError> {
         let mut schema = self
             .schemas
             .get(port)
@@ -92,7 +93,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
     fn build(
         &self,
         _output_schemas: HashMap<PortHandle, Schema>,
-    ) -> Result<Box<dyn Source>, ExecutionError> {
+    ) -> Result<Box<dyn Source>, BoxedError> {
         Ok(Box::new(TestSource {
             name_to_port: self.name_to_port.to_owned(),
             receiver: self.receiver.clone(),


### PR DESCRIPTION
The purpose of this PR is to cleanup the error variants of `ExecutionError` so we have a clearer view of what's recoverable and what's not.

When we need to return an error from, for example, `trait Processor`, we have 3 choices:

1. Associated error type.
2. Concrete error type.
3. `Box<dyn Error>`.

Option 1 is not possible because we need to use dynamic dispatch `dyn Processor`.

Option 2 is what we used before this PR, an `ExecutionError`. The problem is that it's not clear how the implementors of `trait Processor` should return their errors. Some of them chose to add an error variant to `ExecutionError`, resulting many `ExecutionError` variants; some of them utilize the `ExecutionError::Internal(Box<dyn Error>)` variant, which are being used at too many places that the variant does not contain any useful information.

In this PR we adopt option 3. Implementors can return any boxed error, `dozer-core` classifies the error as `Factory`, which results from the factories; `Source`, which results from the sources; and `ProcessorOrSink`, which results from the processors and sinks. `Factory` and `Source` are not recoverable, `ProcessorOrSink` is recoverable.