### PR TITLE
feat: Add `cloud api set-num-replicas`

### DIFF
--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -30,6 +30,9 @@ pub enum CloudCommands {
     /// Application version management
     #[command(subcommand)]
     Version(VersionCommand),
+    /// Dozer API server management
+    #[command(subcommand)]
+    Api(ApiCommand),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -95,6 +98,18 @@ pub enum VersionCommand {
     SetCurrent {
         /// The version to set as current
         version: u32,
+        /// The application id.
+        #[clap(short, long)]
+        app_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ApiCommand {
+    /// Sets the number of replicas to serve Dozer APIs
+    SetNumReplicas {
+        /// The number of replicas to set
+        num_replicas: i32,
         /// The application id.
         #[clap(short, long)]
         app_id: String,

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -166,6 +166,7 @@ fn run() -> Result<(), OrchestrationError> {
                 CloudCommands::Delete(app) => dozer.delete(cloud, app.app_id),
                 CloudCommands::Logs(app) => dozer.trace_logs(cloud, app.app_id),
                 CloudCommands::Version(version) => dozer.version(cloud, version),
+                CloudCommands::Api(api) => dozer.api(cloud, api),
             },
             Commands::Init => {
                 panic!("This should not happen as it is handled in parse_and_generate");

--- a/dozer-types/protos/cloud.proto
+++ b/dozer-types/protos/cloud.proto
@@ -35,6 +35,7 @@ service DozerCloud {
   rpc get_status(GetStatusRequest) returns (GetStatusResponse);
   rpc upsert_version(UpsertVersionRequest) returns (UpsertVersionResponse);
   rpc set_current_version(SetCurrentVersionRequest) returns (SetCurrentVersionResponse);
+  rpc set_num_api_instances(SetNumApiInstancesRequest) returns (SetNumApiInstancesResponse);
 
   rpc list_files(ListFilesRequest) returns (ListFilesResponse);
   rpc update_files(UpdateFileRequest) returns (UpdateFileResponse);
@@ -131,7 +132,8 @@ message GetStatusResponse {
 
 message DeploymentStatus {
   bool app_running = 1;
-  bool api_running = 2;
+  int32 api_desired = 2;
+  int32 api_available = 3;
 }
 
 message UpsertVersionRequest {
@@ -148,6 +150,14 @@ message SetCurrentVersionRequest {
 }
 
 message SetCurrentVersionResponse {}
+
+message SetNumApiInstancesRequest {
+  string app_id = 1;
+  uint32 deployment = 2;
+  int32 num_api_instances = 3;
+}
+
+message SetNumApiInstancesResponse {}
 
 message CreateAppRequest {
   repeated File files = 3;


### PR DESCRIPTION
`cloud status` looks like this:

```text
+--------------+---------------------------------------------------------------------+
| Api endpoint | http://company.dev.getdozer.io/8cbece58-7d9c-480a-9b09-aea343554795 |
+--------------+---------------------------------------------------------------------+
| Deployments  | +------------+-----+-----+--------------+                           |
|              | | Deployment | App | Api | Version      |                           |
|              | +============+=====+=====+==============+                           |
|              | | 0          | 🟢  | 2/2 |              |                           |
|              | +------------+-----+-----+--------------+                           |
|              | | 1          | 🟢  | 3/3 | v1 (current) |                           |
|              | +------------+-----+-----+--------------+                           |
+--------------+---------------------------------------------------------------------+
```