### PR TITLE
feat: Emit metrics of source operations and pipeline latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,6 +2234,7 @@ dependencies = [
  "glob",
  "handlebars",
  "include_dir",
+ "metrics",
  "page_size",
  "reqwest",
  "rustyline",

--- a/dozer-cli/Cargo.toml
+++ b/dozer-cli/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = { version = "0.11.16", features = ["rustls-tls", "cookies"], default-f
 glob = "0.3.1"
 atty = "0.2.14"
 tower = "0.4.13"
+metrics = "0.21.0"
 
 [[bin]]
 edition = "2021"


### PR DESCRIPTION
The`metrics` endpoint looks like this

```text
# HELP source_insert Number of inserts from source
# TYPE source_insert counter
source_insert{connection="ny_taxi",table="trips"} 208234

# HELP pipeline_latency The pipeline processing latency in seconds
# TYPE pipeline_latency summary
pipeline_latency{endpoint="trips_cache",quantile="0"} 0.000089
pipeline_latency{endpoint="trips_cache",quantile="0.5"} 0.00014900956873666247
pipeline_latency{endpoint="trips_cache",quantile="0.9"} 0.00018999742594343942
pipeline_latency{endpoint="trips_cache",quantile="0.95"} 0.00020801506910651807
pipeline_latency{endpoint="trips_cache",quantile="0.99"} 0.0002740225838011025
pipeline_latency{endpoint="trips_cache",quantile="0.999"} 0.0002750108429051483
pipeline_latency{endpoint="trips_cache",quantile="1"} 0.001199
pipeline_latency_sum{endpoint="trips_cache"} 0.02932199999999997
pipeline_latency_count{endpoint="trips_cache"} 184

```