### PR TITLE
feat: Emit metrics of source operations and pipeline latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
  "dozer-tracing",
  "dozer-types",
  "dyn-clone",
+ "metrics",
  "tempdir",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,6 +2234,7 @@ dependencies = [
  "glob",
  "handlebars",
  "include_dir",
+ "metrics",
  "page_size",
  "reqwest",
  "rustyline",

--- a/dozer-cli/Cargo.toml
+++ b/dozer-cli/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = { version = "0.11.16", features = ["rustls-tls", "cookies"], default-f
 glob = "0.3.1"
 atty = "0.2.14"
 tower = "0.4.13"
+metrics = "0.21.0"
 
 [[bin]]
 edition = "2021"

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, time::SystemTime};
 
 use dozer_cache::dozer_log::{errors::WriterError, writer::LogWriter};
 use dozer_core::{
@@ -94,7 +94,7 @@ impl Sink for LogSink {
 
     fn commit(&mut self) -> Result<(), BoxedError> {
         self.0.write_op(&ExecutorOperation::Commit {
-            epoch: Epoch::new(0, Default::default()),
+            epoch: Epoch::new(0, Default::default(), SystemTime::now()),
         })?;
         self.0.flush()?;
         Ok(())

--- a/dozer-core/Cargo.toml
+++ b/dozer-core/Cargo.toml
@@ -14,6 +14,7 @@ uuid = {version = "1.3.0", features = ["v1", "v4", "fast-rng"]}
 crossbeam = "0.8.2"
 dyn-clone = "1.0.10"
 daggy = { git = "https://github.com/getdozer/daggy", branch = "feat/map_owned" }
+metrics = "0.21.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-core/src/epoch.rs
+++ b/dozer-core/src/epoch.rs
@@ -1,7 +1,7 @@
 use dozer_types::parking_lot::Mutex;
 use std::sync::{Arc, Barrier};
 use std::thread::sleep;
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
 pub use dozer_types::epoch::Epoch;
 
@@ -25,7 +25,7 @@ enum EpochManagerState {
         /// Closed epoch id.
         epoch_id: u64,
         /// Instant when the epoch was closed.
-        instant: Instant,
+        instant: SystemTime,
         /// Number of sources that have confirmed the epoch close.
         num_source_confirmations: usize,
     },
@@ -63,7 +63,7 @@ impl EpochManager {
         &self,
         request_termination: bool,
         request_commit: bool,
-    ) -> (bool, Option<u64>, Instant) {
+    ) -> (bool, Option<u64>, SystemTime) {
         let barrier = loop {
             let mut state = self.state.lock();
             match &mut *state {
@@ -102,7 +102,7 @@ impl EpochManager {
                 terminating: *should_terminate,
                 committing: *should_commit,
                 epoch_id: *epoch_id,
-                instant: Instant::now(),
+                instant: SystemTime::now(),
                 num_source_confirmations: 0,
             };
         }
@@ -156,7 +156,7 @@ mod tests {
     fn run_epoch_manager(
         termination_gen: &(impl Fn(u16) -> bool + Sync),
         commit_gen: &(impl Fn(u16) -> bool + Sync),
-    ) -> (bool, Option<u64>, Instant) {
+    ) -> (bool, Option<u64>, SystemTime) {
         let epoch_manager = EpochManager::new(NUM_THREADS as usize);
         let epoch_manager = &epoch_manager;
         scope(|scope| {

--- a/dozer-types/src/epoch.rs
+++ b/dozer-types/src/epoch.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    time::SystemTime,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -11,19 +14,31 @@ use crate::{
 pub struct Epoch {
     pub id: u64,
     pub details: SourceStates,
+    pub decision_instant: SystemTime,
 }
 
 impl Epoch {
-    pub fn new(id: u64, details: SourceStates) -> Self {
-        Self { id, details }
+    pub fn new(id: u64, details: SourceStates, decision_instant: SystemTime) -> Self {
+        Self {
+            id,
+            details,
+            decision_instant,
+        }
     }
 
-    pub fn from(id: u64, node_handle: NodeHandle, txid: u64, seq_in_tx: u64) -> Self {
+    pub fn from(
+        id: u64,
+        node_handle: NodeHandle,
+        txid: u64,
+        seq_in_tx: u64,
+        decision_instant: SystemTime,
+    ) -> Self {
         Self {
             id,
             details: [(node_handle, OpIdentifier::new(txid, seq_in_tx))]
                 .into_iter()
                 .collect(),
+            decision_instant,
         }
     }
 }


### PR DESCRIPTION
The`metrics` endpoint looks like this

```text
# HELP source_insert Number of inserts from source
# TYPE source_insert counter
source_insert{connection="ny_taxi",table="trips"} 208234

# HELP pipeline_latency The pipeline processing latency in seconds
# TYPE pipeline_latency summary
pipeline_latency{endpoint="trips_cache",quantile="0"} 0.000089
pipeline_latency{endpoint="trips_cache",quantile="0.5"} 0.00014900956873666247
pipeline_latency{endpoint="trips_cache",quantile="0.9"} 0.00018999742594343942
pipeline_latency{endpoint="trips_cache",quantile="0.95"} 0.00020801506910651807
pipeline_latency{endpoint="trips_cache",quantile="0.99"} 0.0002740225838011025
pipeline_latency{endpoint="trips_cache",quantile="0.999"} 0.0002750108429051483
pipeline_latency{endpoint="trips_cache",quantile="1"} 0.001199
pipeline_latency_sum{endpoint="trips_cache"} 0.02932199999999997
pipeline_latency_count{endpoint="trips_cache"} 184
```