### PR TITLE
feat: emit Product processor metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,7 @@ dependencies = [
  "jsonpath-rust",
  "like",
  "linked-hash-map",
+ "metrics",
  "multimap",
  "num-traits",
  "pest",

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -11,21 +11,22 @@ dozer-types = {path = "../dozer-types"}
 dozer-core = {path = "../dozer-core"}
 dozer-tracing = {path = "../dozer-tracing"}
 
-num-traits = "0.2.15"
-sqlparser = "0.32.0"
-dyn-clone = "1.0.10"
-like = "0.3.1"
-multimap = "0.8.3"
-uuid = {version = "1.3.0", features = ["v1", "v4", "fast-rng"]}
-hashbrown = "0.13"
 ahash = "0.8.3"
 bloom = "0.3.2"
+dyn-clone = "1.0.10"
 enum_dispatch = "0.3.11"
-linked-hash-map = "0.5.6"
-pest_derive = "2.5.6"
-pest = "2.5.6"
+hashbrown = "0.13"
 jsonpath-rust = "0.3.0"
+like = "0.3.1"
+linked-hash-map = "0.5.6"
+metrics = "0.21.0"
+multimap = "0.8.3"
+num-traits = "0.2.15"
+pest = "2.5.6"
+pest_derive = "2.5.6"
 regex = "1.8.1"
+sqlparser = "0.32.0"
+uuid = {version = "1.3.0", features = ["v1", "v4", "fast-rng"]}
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-sql/src/pipeline/product/join/operator.rs
+++ b/dozer-sql/src/pipeline/product/join/operator.rs
@@ -85,6 +85,14 @@ impl JoinOperator {
         }
     }
 
+    pub fn left_lookup_size(&self) -> usize {
+        self.left_map.len()
+    }
+
+    pub fn right_lookup_size(&self) -> usize {
+        self.right_map.len()
+    }
+
     fn inner_join_from_left(
         &self,
         action: &JoinAction,

--- a/dozer-sql/src/pipeline/product/join/processor.rs
+++ b/dozer-sql/src/pipeline/product/join/processor.rs
@@ -41,7 +41,7 @@ impl ProductProcessor {
             "Number of records forwarded by the product processor"
         );
 
-        describe_histogram!("product.latency", "Processing latency (ns)");
+        describe_histogram!("product.latency", "Processing latency");
         Self { join_operator }
     }
 
@@ -117,7 +117,7 @@ impl Processor for ProductProcessor {
         };
 
         let elapsed = now.elapsed();
-        histogram!("product.latency", elapsed.as_nanos() as f64);
+        histogram!("product.latency", elapsed);
 
         increment_counter!("product.input_operations");
 

--- a/dozer-sql/src/pipeline/product/join/processor.rs
+++ b/dozer-sql/src/pipeline/product/join/processor.rs
@@ -4,7 +4,7 @@ use dozer_core::node::{PortHandle, Processor};
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::Operation;
-use metrics::{describe_counter, describe_gauge, gauge, increment_counter, increment_gauge};
+use metrics::{describe_gauge, gauge, increment_gauge};
 
 use crate::pipeline::errors::PipelineError;
 
@@ -116,7 +116,7 @@ impl Processor for ProductProcessor {
         let elapsed = now.elapsed();
         gauge!("product.latency", elapsed.as_nanos() as f64);
 
-        increment_gauge!("product.input_operations", 1 as f64);
+        increment_gauge!("product.input_operations", 1_f64);
 
         increment_gauge!("product.output_operations", records.len() as f64);
 

--- a/dozer-sql/src/pipeline/product/join/processor.rs
+++ b/dozer-sql/src/pipeline/product/join/processor.rs
@@ -5,8 +5,8 @@ use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::types::Operation;
 use metrics::{
-    describe_counter, describe_gauge, describe_histogram, gauge, histogram, increment_counter,
-    increment_gauge,
+    counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
+    increment_counter,
 };
 
 use crate::pipeline::errors::PipelineError;
@@ -36,7 +36,7 @@ impl ProductProcessor {
             "product.in_ops",
             "Number of records received by the product processor"
         );
-        describe_gauge!(
+        describe_counter!(
             "product.out_ops",
             "Number of records forwarded by the product processor"
         );
@@ -121,7 +121,7 @@ impl Processor for ProductProcessor {
 
         increment_counter!("product.input_operations");
 
-        increment_gauge!("product.output_operations", records.len() as f64);
+        counter!("product.output_operations", records.len() as u64);
 
         gauge!(
             "product.left_lookup_size",


### PR DESCRIPTION
Emit Join metrics on Prometheus endpoint

```

# HELP product_unsatisfied_joins Operations not matching the Join condition
# TYPE product_unsatisfied_joins counter
product_unsatisfied_joins 265

# TYPE product_output_operations counter
product_output_operations 1887841

# TYPE product_input_operations counter
product_input_operations 1888106

# HELP product_right_lookup_size Total number of items in the right lookup table
# TYPE product_right_lookup_size gauge
product_right_lookup_size 265

# HELP product_left_lookup_size Total number of items in the left lookup table
# TYPE product_left_lookup_size gauge
product_left_lookup_size 254

# HELP product_latency Processing latency
# TYPE product_latency summary
product_latency{quantile="0"} 0.0000025
product_latency{quantile="0.5"} 0.000040480100968151095
product_latency{quantile="0.9"} 0.000040480100968151095
product_latency{quantile="0.95"} 0.000040480100968151095
product_latency{quantile="0.99"} 0.000040480100968151095
product_latency{quantile="0.999"} 0.00014963672503375144
product_latency{quantile="1"} 0.028400292
product_latency_sum 17.38265707894686
product_latency_count 1888365

```