### PR TITLE
chore: Remove maturin sccache because it keeps failing

### DIFF
--- a/.github/workflows/dozer-log-python.yml
+++ b/.github/workflows/dozer-log-python.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --features python-extension-module
-          sccache: 'true'
           manylinux: auto
           container: off
           working-directory: dozer-log-python
@@ -90,7 +89,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --features python-extension-module
-          sccache: 'true'
           working-directory: dozer-log-python
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -119,7 +117,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --features python-extension-module
-          sccache: 'true'
           working-directory: dozer-log-python
       - name: Upload wheels
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I removed sccache and it runs fine. We'll lose `pydozer_log` `0.1.24` release but I think that's fine. Nothing has changed from `0.1.23`.