### PR TITLE
feat: Add more cache metrics

### DIFF
--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -114,10 +114,22 @@ fn build_cache_task(
 ) -> Result<(), CacheError> {
     let schema = cache.get_schema().0.clone();
 
-    const BUILD_CACHE_COUNTER_NAME: &str = "build_cache";
+    const CACHE_INSERT_COUNTER_NAME: &str = "cache_insert";
     describe_counter!(
-        BUILD_CACHE_COUNTER_NAME,
-        "Number of operations processed by cache builder"
+        CACHE_INSERT_COUNTER_NAME,
+        "Number of inserts processed by cache builder"
+    );
+
+    const CACHE_DELETE_COUNTER_NAME: &str = "cache_delete";
+    describe_counter!(
+        CACHE_DELETE_COUNTER_NAME,
+        "Number of deletes processed by cache builder"
+    );
+
+    const CACHE_UPDATE_COUNTER_NAME: &str = "cache_update";
+    describe_counter!(
+        CACHE_UPDATE_COUNTER_NAME,
+        "Number of updates processed by cache builder"
     );
 
     while let Some((op, offset)) = receiver.blocking_recv() {
@@ -135,10 +147,12 @@ fn build_cache_task(
                             send_and_log_error(operations_sender, operation);
                         }
                     }
+                    increment_counter!(CACHE_DELETE_COUNTER_NAME, cache.labels().clone());
                 }
                 Operation::Insert { mut new } => {
                     new.schema_id = schema.identifier;
                     let result = cache.insert(&new)?;
+                    increment_counter!(CACHE_INSERT_COUNTER_NAME, cache.labels().clone());
 
                     if let Some((endpoint_name, operations_sender)) = operations_sender.as_ref() {
                         send_upsert_result(
@@ -155,6 +169,7 @@ fn build_cache_task(
                     old.schema_id = schema.identifier;
                     new.schema_id = schema.identifier;
                     let upsert_result = cache.update(&old, &new)?;
+                    increment_counter!(CACHE_UPDATE_COUNTER_NAME, cache.labels().clone());
 
                     if let Some((endpoint_name, operations_sender)) = operations_sender.as_ref() {
                         send_upsert_result(
@@ -181,8 +196,6 @@ fn build_cache_task(
                 break;
             }
         }
-
-        increment_counter!(BUILD_CACHE_COUNTER_NAME, cache.labels().clone());
     }
 
     Ok(())

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
@@ -14,7 +14,7 @@ use crate::cache::{
 #[test]
 fn test_operation_log_append_only() {
     let mut env = create_env(&Default::default()).unwrap().0;
-    let log = OperationLog::create(&mut env).unwrap();
+    let log = OperationLog::create(&mut env, Default::default()).unwrap();
     let txn = env.txn_mut().unwrap();
     let append_only = true;
 
@@ -57,7 +57,7 @@ fn test_operation_log_append_only() {
 #[test]
 fn test_operation_log_with_primary_key() {
     let mut env = create_env(&Default::default()).unwrap().0;
-    let log = OperationLog::create(&mut env).unwrap();
+    let log = OperationLog::create(&mut env, Default::default()).unwrap();
     let txn = env.txn_mut().unwrap();
     let append_only = false;
 
@@ -180,7 +180,7 @@ fn test_operation_log_with_primary_key() {
 #[test]
 fn test_operation_log_without_primary_key() {
     let mut env = create_env(&Default::default()).unwrap().0;
-    let log = OperationLog::create(&mut env).unwrap();
+    let log = OperationLog::create(&mut env, Default::default()).unwrap();
     let txn = env.txn_mut().unwrap();
     let append_only = false;
 


### PR DESCRIPTION
Example metrics:

```
# HELP cache_update Number of updates processed by cache builder
# TYPE cache_update counter
cache_update{endpoint="trips_cache",migration="v0053"} 18477

# HELP build_index Number of operations built into indexes
# TYPE build_index counter
build_index{endpoint="trips_cache",migration="v0053",secondary_index="0",secondary_index_type="SortedInverted"} 36979
build_index{endpoint="trips_cache",migration="v0053",secondary_index="1",secondary_index_type="SortedInverted"} 36979
build_index{endpoint="trips_cache",migration="v0053",secondary_index="4",secondary_index_type="SortedInverted"} 36889
build_index{endpoint="trips_cache",migration="v0053",secondary_index="3",secondary_index_type="SortedInverted"} 36979
build_index{endpoint="trips_cache",migration="v0053",secondary_index="2",secondary_index_type="SortedInverted"} 36979

# HELP cache_operation Number of operations stored in the cache
# TYPE cache_operation counter
cache_operation{endpoint="trips_cache",migration="v0053"} 36979

# HELP cache_insert Number of inserts processed by cache builder
# TYPE cache_insert counter
cache_insert{endpoint="trips_cache",migration="v0053"} 25
```

`cache_delete` is not shown because it's not produced in above run.