### PR TITLE
feat: Implement cache dump and restore

### DIFF
--- a/.github/workflows/dozer.yaml
+++ b/.github/workflows/dozer.yaml
@@ -20,9 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Check for println!()
-        run: (! grep -R -a -n --include "*.rs" --exclude-dir target "println\!" *)
-
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -57,7 +57,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.3",
  "base64 0.21.0",
- "bitflags 1.3.2",
+ "bitflags",
  "brotli",
  "bytes",
  "bytestring",
@@ -323,6 +323,55 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -971,7 +1020,7 @@ checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -1072,12 +1121,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "bitvec"
@@ -1395,7 +1438,7 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
@@ -1403,30 +1446,38 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.11"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [
- "bitflags 2.0.2",
+ "clap_builder",
  "clap_derive",
- "clap_lex 0.3.2",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.5.0",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.9"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1440,12 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clipboard-win"
@@ -1467,6 +1515,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "comfy-table"
@@ -2205,10 +2259,12 @@ name = "dozer-cache"
 version = "0.1.24"
 dependencies = [
  "ahash 0.8.3",
+ "clap 4.3.2",
  "criterion",
  "dozer-log",
  "dozer-storage",
  "dozer-types",
+ "env_logger",
  "futures",
  "itertools",
  "metrics",
@@ -2226,7 +2282,7 @@ name = "dozer-cli"
 version = "0.1.24"
 dependencies = [
  "atty",
- "clap 4.1.11",
+ "clap 4.3.2",
  "ctrlc",
  "dozer-api",
  "dozer-cache",
@@ -2383,7 +2439,7 @@ dependencies = [
  "ahash 0.8.3",
  "async-trait",
  "bson",
- "clap 4.1.11",
+ "clap 4.3.2",
  "csv",
  "dozer-api",
  "dozer-cache",
@@ -2718,7 +2774,7 @@ version = "23.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f5399c2c9c50ae9418e522842ad362f61ee48b346ac106807bd355a8a7c619"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "rustc_version 0.4.0",
 ]
 
@@ -3056,7 +3112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "headers-core",
  "http",
@@ -3724,7 +3780,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b603516767d1ab23d0de09d023e62966c3322f7148297c35cf3d97aa8b37fa"
 dependencies = [
- "clap 4.1.11",
+ "clap 4.3.2",
  "termcolor",
  "threadpool",
 ]
@@ -3762,7 +3818,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447a296f7aca299cfbb50f4e4f3d49451549af655fb7215d7f8c0c3d64bad42b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "byteorder",
  "libc",
  "lmdb-rkv-sys",
@@ -4062,7 +4118,7 @@ checksum = "a37fe10c1485a0cd603468e284a1a8535b4ecf46808f5f7de3639a1e1252dbf8"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
- "bitflags 1.3.2",
+ "bitflags",
  "bson",
  "chrono",
  "derivative",
@@ -4184,7 +4240,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -4396,7 +4452,7 @@ version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4963,30 +5019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5008,7 +5040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -5342,7 +5374,7 @@ version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -5382,7 +5414,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -5702,7 +5734,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -5769,7 +5801,7 @@ version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno 0.2.8",
  "io-lifetimes",
  "libc",
@@ -5859,7 +5891,7 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "clipboard-win",
  "dirs-next",
@@ -5988,7 +6020,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6993,7 +7025,7 @@ checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
  "async-compression",
  "base64 0.13.1",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,7 +2371,9 @@ dependencies = [
  "lmdb-rkv",
  "lmdb-rkv-sys",
  "page_size",
+ "pin-project",
  "tempdir",
+ "tokio",
 ]
 
 [[package]]
@@ -4777,22 +4779,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -6722,14 +6724,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -6737,7 +6738,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6752,13 +6753,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/dozer-cache/Cargo.toml
+++ b/dozer-cache/Cargo.toml
@@ -21,6 +21,8 @@ uuid = { version = "1.3.0", features = ["v4"] }
 rayon = "1.7.0"
 ahash = "0.8.3"
 metrics = "0.21.0"
+clap = { version = "4.3.2", features = ["derive"] }
+env_logger = "0.10.0"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
@@ -1,0 +1,158 @@
+use std::sync::Arc;
+
+use dozer_storage::{
+    errors::StorageError,
+    generator::FutureGeneratorContext,
+    lmdb::{RoTransaction, Transaction},
+    DumpItem, LmdbEnvironment,
+};
+use dozer_types::{log::info, parking_lot::Mutex};
+use tokio::io::AsyncRead;
+
+use crate::{
+    cache::{lmdb::indexing::IndexingThreadPool, CacheWriteOptions, RoCache},
+    errors::CacheError,
+};
+
+use super::{
+    main_environment, secondary_environment, secondary_environment_name, CacheOptions, LmdbCache,
+    LmdbRwCache, MainEnvironment,
+};
+
+pub struct DumpTransaction<T: Transaction> {
+    main_txn: T,
+    secondary_txns: Vec<T>,
+}
+
+pub fn begin_dump_txn<C: LmdbCache>(
+    cache: &C,
+) -> Result<DumpTransaction<RoTransaction>, CacheError> {
+    let main_env = cache.main_env();
+    let main_txn = main_env.begin_txn()?;
+    let secondary_txns = (0..main_env.schema().1.len())
+        .map(|index| {
+            let secondary_env = cache.secondary_env(index);
+            secondary_env.begin_txn()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(DumpTransaction {
+        main_txn,
+        secondary_txns,
+    })
+}
+
+pub async fn dump<'txn, T: Transaction, C: LmdbCache>(
+    cache: &C,
+    txn: &'txn DumpTransaction<T>,
+    context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+) -> Result<(), ()> {
+    main_environment::dump_restore::dump(cache.main_env(), &txn.main_txn, context).await?;
+
+    for index in 0..cache.get_schema().1.len() {
+        let secondary_env = cache.secondary_env(index);
+        let txn = &txn.secondary_txns[index];
+        secondary_environment::dump_restore::dump(secondary_env, txn, context).await?;
+    }
+
+    Ok(())
+}
+
+pub async fn restore(
+    options: &CacheOptions,
+    write_options: CacheWriteOptions,
+    indexing_thread_pool: Arc<Mutex<IndexingThreadPool>>,
+    reader: &mut (impl AsyncRead + Unpin),
+) -> Result<LmdbRwCache, CacheError> {
+    info!("Restoring cache with options {options:?}");
+    let rw_main_env =
+        main_environment::dump_restore::restore(options, write_options, reader).await?;
+
+    let options = CacheOptions {
+        path: Some((
+            rw_main_env.base_path().to_path_buf(),
+            rw_main_env.labels().clone(),
+        )),
+        ..*options
+    };
+    let ro_main_env = rw_main_env.share();
+
+    let mut rw_secondary_envs = vec![];
+    let mut ro_secondary_envs = vec![];
+    for index in 0..ro_main_env.schema().1.len() {
+        let name = secondary_environment_name(index);
+        let rw_secondary_env =
+            secondary_environment::dump_restore::restore(name, &options, reader).await?;
+        let ro_secondary_env = rw_secondary_env.share();
+
+        rw_secondary_envs.push(rw_secondary_env);
+        ro_secondary_envs.push(ro_secondary_env);
+    }
+
+    indexing_thread_pool
+        .lock()
+        .add_cache(ro_main_env, rw_secondary_envs);
+
+    Ok(LmdbRwCache {
+        main_env: rw_main_env,
+        secondary_envs: ro_secondary_envs,
+        indexing_thread_pool,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::pin;
+
+    use dozer_storage::generator::{Generator, IntoGenerator};
+
+    use crate::cache::{
+        lmdb::tests::utils::{create_cache, insert_rec_1},
+        test_utils, RwCache,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_dump_restore() {
+        let (mut cache, indexing_thread_pool, schema, _) = create_cache(test_utils::schema_1);
+
+        insert_rec_1(&mut cache, &schema, (0, Some("a".to_string()), None));
+        insert_rec_1(&mut cache, &schema, (1, None, Some(2)));
+        insert_rec_1(&mut cache, &schema, (2, Some("b".to_string()), Some(3)));
+        cache.commit().unwrap();
+        indexing_thread_pool.lock().wait_until_catchup();
+
+        let mut data = vec![];
+        {
+            let cache = &cache;
+            let txn = &begin_dump_txn(cache).unwrap();
+            let generator = |context| async move { dump(cache, txn, &context).await.unwrap() };
+            let generator = generator.into_generator();
+            for item in pin!(generator).into_iter() {
+                data.extend_from_slice(&item.unwrap());
+            }
+        }
+
+        let restored_cache = restore(
+            &Default::default(),
+            Default::default(),
+            indexing_thread_pool.clone(),
+            &mut data.as_slice(),
+        )
+        .await
+        .unwrap();
+
+        super::super::main_environment::dump_restore::tests::assert_main_env_equal(
+            cache.main_env(),
+            restored_cache.main_env(),
+        );
+
+        for index in 0..cache.main_env().schema().1.len() {
+            super::super::secondary_environment::dump_restore::tests::assert_secondary_env_equal(
+                cache.secondary_env(index),
+                restored_cache.secondary_env(index),
+            );
+        }
+    }
+}

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/dump_restore.rs
@@ -1,0 +1,177 @@
+use dozer_storage::{
+    errors::StorageError, generator::FutureGeneratorContext, lmdb::Transaction, DumpItem,
+    LmdbEnvironment, LmdbMap, LmdbOption,
+};
+use dozer_types::{borrow::IntoOwned, log::info};
+use tokio::io::AsyncRead;
+
+use crate::{
+    cache::{
+        lmdb::{cache::CacheOptions, utils::create_env},
+        CacheWriteOptions,
+    },
+    errors::CacheError,
+};
+
+use super::{
+    MainEnvironment, MainEnvironmentCommon, OperationLog, RwMainEnvironment,
+    CONNECTION_SNAPSHOTTING_DONE_DB_NAME, METADATA_DB_NAME, SCHEMA_DB_NAME,
+};
+
+pub async fn dump<'txn, E: MainEnvironment, T: Transaction>(
+    env: &E,
+    txn: &'txn T,
+    context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+) -> Result<(), ()> {
+    dozer_storage::dump(
+        txn,
+        SCHEMA_DB_NAME,
+        env.common().schema_option.database(),
+        context,
+    )
+    .await?;
+    dozer_storage::dump(
+        txn,
+        METADATA_DB_NAME,
+        env.common().metadata.database(),
+        context,
+    )
+    .await?;
+    dozer_storage::dump(
+        txn,
+        CONNECTION_SNAPSHOTTING_DONE_DB_NAME,
+        env.common().connection_snapshotting_done.database(),
+        context,
+    )
+    .await?;
+    env.common().operation_log.dump(txn, context).await
+}
+
+pub async fn restore(
+    options: &CacheOptions,
+    write_options: CacheWriteOptions,
+    reader: &mut (impl AsyncRead + Unpin),
+) -> Result<RwMainEnvironment, CacheError> {
+    info!("Restoring main environment with options {options:?}");
+    let (mut env, (base_path, labels), temp_dir) = create_env(options)?;
+
+    info!("Restoring schema");
+    dozer_storage::restore(&mut env, reader).await?;
+    info!("Restoring metadata");
+    dozer_storage::restore(&mut env, reader).await?;
+    info!("Restoring connection snapshotting done");
+    dozer_storage::restore(&mut env, reader).await?;
+    info!("Restoring operation log");
+    let operation_log = OperationLog::restore(&mut env, reader, labels).await?;
+
+    let schema_option = LmdbOption::open(&env, Some(SCHEMA_DB_NAME))?;
+    let metadata = LmdbOption::open(&env, Some(METADATA_DB_NAME))?;
+    let connection_snapshotting_done =
+        LmdbMap::open(&env, Some(CONNECTION_SNAPSHOTTING_DONE_DB_NAME))?;
+
+    let schema = schema_option
+        .load(&env.begin_txn()?)?
+        .map(IntoOwned::into_owned)
+        .ok_or(CacheError::SchemaNotFound)?;
+
+    Ok(RwMainEnvironment {
+        env,
+        common: MainEnvironmentCommon {
+            base_path,
+            schema,
+            schema_option,
+            metadata,
+            connection_snapshotting_done,
+            operation_log,
+            intersection_chunk_size: options.intersection_chunk_size,
+        },
+        _temp_dir: temp_dir,
+        write_options,
+    })
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::pin::pin;
+
+    use super::*;
+
+    use dozer_storage::{
+        assert_database_equal,
+        generator::{Generator, IntoGenerator},
+    };
+    use dozer_types::types::{Record, Schema};
+
+    use crate::cache::lmdb::cache::{
+        main_environment::operation_log::tests::assert_operation_log_equal, RwMainEnvironment,
+    };
+
+    pub fn assert_main_env_equal<E1: MainEnvironment, E2: MainEnvironment>(env1: &E1, env2: &E2) {
+        assert_eq!(env1.common().schema, env2.common().schema);
+        let txn1 = env1.begin_txn().unwrap();
+        let txn2 = env2.begin_txn().unwrap();
+        assert_database_equal(
+            &txn1,
+            env1.common().schema_option.database(),
+            &txn2,
+            env2.common().schema_option.database(),
+        );
+        assert_database_equal(
+            &txn1,
+            env1.common().metadata.database(),
+            &txn2,
+            env2.common().metadata.database(),
+        );
+        assert_database_equal(
+            &txn1,
+            env1.common().connection_snapshotting_done.database(),
+            &txn2,
+            env2.common().connection_snapshotting_done.database(),
+        );
+        assert_operation_log_equal(
+            &env1.common().operation_log,
+            &txn1,
+            &env2.common().operation_log,
+            &txn2,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dump_restore() {
+        let schema = Schema::empty();
+        let mut env = RwMainEnvironment::new(
+            Some(&(schema, vec![])),
+            None,
+            &Default::default(),
+            Default::default(),
+        )
+        .unwrap();
+
+        let record = Record::new(None, vec![]);
+        env.insert(&record).unwrap();
+        env.insert(&record).unwrap();
+        env.delete(&record).unwrap();
+        env.commit().unwrap();
+
+        let mut data = vec![];
+        {
+            let env = &env;
+            let txn = &env.begin_txn().unwrap();
+            let generator = |context| async move { dump(env, txn, &context).await.unwrap() };
+            let generator = generator.into_generator();
+            for item in pin!(generator).into_iter() {
+                data.extend_from_slice(&item.unwrap());
+            }
+        }
+
+        let restored_env = restore(
+            &Default::default(),
+            Default::default(),
+            &mut data.as_slice(),
+        )
+        .await
+        .unwrap();
+
+        assert_main_env_equal(&env, &restored_env);
+    }
+}

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
@@ -98,12 +98,18 @@ pub trait MainEnvironment: LmdbEnvironment {
     }
 }
 
+const SCHEMA_DB_NAME: &str = "schema";
+const METADATA_DB_NAME: &str = "metadata";
+const CONNECTION_SNAPSHOTTING_DONE_DB_NAME: &str = "connection_snapshotting_done";
+
 #[derive(Debug, Clone)]
 pub struct MainEnvironmentCommon {
     /// The environment base path.
     base_path: PathBuf,
     /// The schema.
     schema: SchemaWithIndex,
+    /// The schema database, used for dumping.
+    schema_option: LmdbOption<SchemaWithIndex>,
     /// The metadata.
     metadata: LmdbOption<u64>,
     /// The source status.
@@ -143,10 +149,10 @@ impl RwMainEnvironment {
         let (mut env, (base_path, labels), temp_dir) = create_env(options)?;
 
         let operation_log = OperationLog::create(&mut env, labels.clone())?;
-        let schema_option = LmdbOption::create(&mut env, Some("schema"))?;
-        let metadata = LmdbOption::create(&mut env, Some("metadata"))?;
+        let schema_option = LmdbOption::create(&mut env, Some(SCHEMA_DB_NAME))?;
+        let metadata = LmdbOption::create(&mut env, Some(METADATA_DB_NAME))?;
         let connection_snapshotting_done =
-            LmdbMap::create(&mut env, Some("connection_snapshotting_done"))?;
+            LmdbMap::create(&mut env, Some(CONNECTION_SNAPSHOTTING_DONE_DB_NAME))?;
 
         let old_schema = schema_option
             .load(&env.begin_txn()?)?
@@ -203,6 +209,7 @@ impl RwMainEnvironment {
             common: MainEnvironmentCommon {
                 base_path,
                 schema,
+                schema_option,
                 metadata,
                 connection_snapshotting_done,
                 operation_log,
@@ -540,10 +547,10 @@ impl RoMainEnvironment {
         let (env, (base_path, labels), _temp_dir) = open_env(options)?;
 
         let operation_log = OperationLog::open(&env, labels.clone())?;
-        let schema_option = LmdbOption::open(&env, Some("schema"))?;
-        let metadata = LmdbOption::open(&env, Some("metadata"))?;
+        let schema_option = LmdbOption::open(&env, Some(SCHEMA_DB_NAME))?;
+        let metadata = LmdbOption::open(&env, Some(METADATA_DB_NAME))?;
         let connection_snapshotting_done =
-            LmdbMap::open(&env, Some("connection_snapshotting_done"))?;
+            LmdbMap::open(&env, Some(CONNECTION_SNAPSHOTTING_DONE_DB_NAME))?;
 
         let schema = schema_option
             .load(&env.begin_txn()?)?
@@ -555,6 +562,7 @@ impl RoMainEnvironment {
             common: MainEnvironmentCommon {
                 base_path: base_path.to_path_buf(),
                 schema,
+                schema_option,
                 metadata,
                 connection_snapshotting_done,
                 operation_log,
@@ -563,6 +571,8 @@ impl RoMainEnvironment {
         })
     }
 }
+
+pub mod dump_restore;
 
 fn debug_check_schema_record_consistency(schema: &Schema, record: &Record) {
     debug_assert_eq!(schema.identifier, record.schema_id);

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/hash_metadata.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/hash_metadata.rs
@@ -1,6 +1,6 @@
 use dozer_storage::{
     errors::StorageError,
-    lmdb::{RwTransaction, Transaction},
+    lmdb::{Database, RwTransaction, Transaction},
     LmdbEnvironment, LmdbMultimap, RwLmdbEnvironment,
 };
 use dozer_types::{borrow::IntoOwned, types::Record};
@@ -12,11 +12,17 @@ pub struct HashMetadata(LmdbMultimap<u64, RecordMetadata>);
 
 impl HashMetadata {
     pub fn create(env: &mut RwLmdbEnvironment) -> Result<Self, StorageError> {
-        LmdbMultimap::create(env, Some("hash_metadata")).map(Self)
+        LmdbMultimap::create(env, Some(Self::DATABASE_NAME)).map(Self)
     }
 
     pub fn open<E: LmdbEnvironment>(env: &E) -> Result<Self, StorageError> {
-        LmdbMultimap::open(env, Some("hash_metadata")).map(Self)
+        LmdbMultimap::open(env, Some(Self::DATABASE_NAME)).map(Self)
+    }
+
+    pub const DATABASE_NAME: &str = "hash_metadata";
+
+    pub fn database(&self) -> Database {
+        self.0.database()
     }
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/primary_key_metadata.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/primary_key_metadata.rs
@@ -1,5 +1,7 @@
 use dozer_storage::{
-    errors::StorageError, lmdb::Transaction, LmdbEnvironment, LmdbMap, RwLmdbEnvironment,
+    errors::StorageError,
+    lmdb::{Database, Transaction},
+    LmdbEnvironment, LmdbMap, RwLmdbEnvironment,
 };
 use dozer_types::borrow::IntoOwned;
 
@@ -10,11 +12,11 @@ pub struct PrimaryKeyMetadata(LmdbMap<Vec<u8>, RecordMetadata>);
 
 impl PrimaryKeyMetadata {
     pub fn create(env: &mut RwLmdbEnvironment) -> Result<Self, StorageError> {
-        LmdbMap::create(env, Some("primary_key_metadata")).map(Self)
+        LmdbMap::create(env, Some(Self::DATABASE_NAME)).map(Self)
     }
 
     pub fn open<E: LmdbEnvironment>(env: &E) -> Result<Self, StorageError> {
-        LmdbMap::open(env, Some("primary_key_metadata")).map(Self)
+        LmdbMap::open(env, Some(Self::DATABASE_NAME)).map(Self)
     }
 
     fn get<T: Transaction>(
@@ -25,6 +27,12 @@ impl PrimaryKeyMetadata {
         self.0
             .get(txn, key)
             .map(|metadata| metadata.map(|metadata| metadata.into_owned()))
+    }
+
+    pub const DATABASE_NAME: &str = "primary_key_metadata";
+
+    pub fn database(&self) -> Database {
+        self.0.database()
     }
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
@@ -1,3 +1,4 @@
+use dozer_storage::{assert_database_equal, lmdb::Transaction};
 use dozer_types::{borrow::IntoOwned, types::Record};
 
 use crate::cache::{
@@ -10,6 +11,44 @@ use crate::cache::{
     },
     CacheRecord,
 };
+
+pub fn assert_operation_log_equal<T1: Transaction, T2: Transaction>(
+    log1: &OperationLog,
+    txn1: &T1,
+    log2: &OperationLog,
+    txn2: &T2,
+) {
+    assert_database_equal(
+        txn1,
+        log1.primary_key_metadata.database(),
+        txn2,
+        log2.primary_key_metadata.database(),
+    );
+    assert_database_equal(
+        txn1,
+        log1.hash_metadata.database(),
+        txn2,
+        log2.hash_metadata.database(),
+    );
+    assert_database_equal(
+        txn1,
+        log1.present_operation_ids.database(),
+        txn2,
+        log2.present_operation_ids.database(),
+    );
+    assert_database_equal(
+        txn1,
+        log1.next_operation_id.database(),
+        txn2,
+        log2.next_operation_id.database(),
+    );
+    assert_database_equal(
+        txn1,
+        log1.operation_id_to_operation.database(),
+        txn2,
+        log2.operation_id_to_operation.database(),
+    );
+}
 
 #[test]
 fn test_operation_log_append_only() {

--- a/dozer-cache/src/cache/lmdb/cache/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/mod.rs
@@ -14,6 +14,7 @@ use crate::cache::expression::QueryExpression;
 use crate::cache::{CacheRecord, CacheWriteOptions, RecordMeta, UpsertResult};
 use crate::errors::CacheError;
 
+pub mod dump_restore;
 mod main_environment;
 mod query;
 mod secondary_environment;
@@ -56,8 +57,8 @@ impl Default for CacheOptions {
 
 #[derive(Debug, Clone)]
 pub struct LmdbRoCache {
-    pub(crate) main_env: RoMainEnvironment,
-    pub(crate) secondary_envs: Vec<RoSecondaryEnvironment>,
+    pub main_env: RoMainEnvironment,
+    pub secondary_envs: Vec<RoSecondaryEnvironment>,
 }
 
 impl LmdbRoCache {

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
@@ -1,0 +1,197 @@
+use dozer_storage::{
+    errors::StorageError, generator::FutureGeneratorContext, lmdb::Transaction, DumpItem,
+    LmdbCounter, LmdbEnvironment, LmdbMultimap, LmdbOption,
+};
+use dozer_types::{borrow::IntoOwned, log::info};
+use tokio::io::AsyncRead;
+
+use crate::{cache::lmdb::utils::create_env, errors::CacheError};
+
+use super::{
+    get_cache_options, set_comparator, CacheOptions, RwSecondaryEnvironment, SecondaryEnvironment,
+    SecondaryEnvironmentCommon, DATABASE_DB_NAME, INDEX_DEFINITION_DB_NAME,
+    NEXT_OPERATION_ID_DB_NAME,
+};
+
+pub async fn dump<'txn, E: SecondaryEnvironment, T: Transaction>(
+    env: &E,
+    txn: &'txn T,
+    context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+) -> Result<(), ()> {
+    dozer_storage::dump(
+        txn,
+        INDEX_DEFINITION_DB_NAME,
+        env.common().index_definition_option.database(),
+        context,
+    )
+    .await?;
+    dozer_storage::dump(
+        txn,
+        DATABASE_DB_NAME,
+        env.common().database.database(),
+        context,
+    )
+    .await?;
+    dozer_storage::dump(
+        txn,
+        NEXT_OPERATION_ID_DB_NAME,
+        env.common().next_operation_id.database(),
+        context,
+    )
+    .await
+}
+
+pub async fn restore(
+    name: String,
+    options: &CacheOptions,
+    reader: &mut (impl AsyncRead + Unpin),
+) -> Result<RwSecondaryEnvironment, CacheError> {
+    info!("Restoring secondary environment {name} with options {options:?}");
+    let mut env = create_env(&get_cache_options(name.clone(), options))?.0;
+
+    info!("Restoring index definition");
+    dozer_storage::restore(&mut env, reader).await?;
+    info!("Restoring database");
+    dozer_storage::restore(&mut env, reader).await?;
+    info!("Restoring next operation id");
+    dozer_storage::restore(&mut env, reader).await?;
+
+    let index_definition_option = LmdbOption::open(&env, Some(INDEX_DEFINITION_DB_NAME))?;
+    let database = LmdbMultimap::open(&env, Some(DATABASE_DB_NAME))?;
+    let next_operation_id = LmdbCounter::open(&env, Some(NEXT_OPERATION_ID_DB_NAME))?;
+
+    let index_definition = index_definition_option
+        .load(&env.begin_txn()?)?
+        .map(IntoOwned::into_owned)
+        .ok_or(CacheError::IndexDefinitionNotFound(name))?;
+
+    set_comparator(&env, &index_definition, database)?;
+
+    Ok(RwSecondaryEnvironment {
+        env,
+        common: SecondaryEnvironmentCommon {
+            index_definition,
+            index_definition_option,
+            database,
+            next_operation_id,
+        },
+    })
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::pin::pin;
+
+    use super::*;
+
+    use dozer_storage::{
+        assert_database_equal,
+        generator::{Generator, IntoGenerator},
+        LmdbEnvironment,
+    };
+    use dozer_types::types::{
+        Field, FieldDefinition, FieldType, IndexDefinition, Record, Schema, SourceDefinition,
+    };
+
+    use crate::cache::lmdb::cache::{MainEnvironment, RwMainEnvironment, RwSecondaryEnvironment};
+
+    pub fn assert_secondary_env_equal<E1: SecondaryEnvironment, E2: SecondaryEnvironment>(
+        env1: &E1,
+        env2: &E2,
+    ) {
+        assert_eq!(
+            env1.common().index_definition,
+            env2.common().index_definition
+        );
+        let txn1 = env1.begin_txn().unwrap();
+        let txn2 = env2.begin_txn().unwrap();
+        assert_database_equal(
+            &txn1,
+            env1.common().index_definition_option.database(),
+            &txn2,
+            env2.common().index_definition_option.database(),
+        );
+        assert_database_equal(
+            &txn1,
+            env1.common().database.database(),
+            &txn2,
+            env2.common().database.database(),
+        );
+        assert_database_equal(
+            &txn1,
+            env1.common().next_operation_id.database(),
+            &txn2,
+            env2.common().next_operation_id.database(),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dump_restore() {
+        let schema = Schema {
+            identifier: None,
+            fields: vec![FieldDefinition {
+                name: "test".to_string(),
+                typ: FieldType::String,
+                nullable: true,
+                source: SourceDefinition::Dynamic,
+            }],
+            primary_index: vec![0],
+        };
+        let mut main_env = RwMainEnvironment::new(
+            Some(&(schema, vec![])),
+            None,
+            &Default::default(),
+            Default::default(),
+        )
+        .unwrap();
+
+        let record_a = Record {
+            schema_id: None,
+            values: vec![Field::String("a".to_string())],
+            lifetime: None,
+        };
+        let record_b = Record {
+            schema_id: None,
+            values: vec![Field::String("b".to_string())],
+            lifetime: None,
+        };
+        main_env.insert(&record_a).unwrap();
+        main_env.insert(&record_b).unwrap();
+        main_env.delete(&record_a).unwrap();
+        main_env.commit().unwrap();
+
+        let mut env = RwSecondaryEnvironment::new(
+            &IndexDefinition::SortedInverted(vec![0]),
+            "0".to_string(),
+            &Default::default(),
+        )
+        .unwrap();
+        {
+            let log_txn = main_env.begin_txn().unwrap();
+            env.index(
+                &log_txn,
+                main_env.operation_log().clone(),
+                "TEMP",
+                &Default::default(),
+            )
+            .unwrap();
+            env.commit().unwrap();
+        }
+
+        let mut data = vec![];
+        {
+            let env = &env;
+            let txn = &env.begin_txn().unwrap();
+            let generator = |context| async move { dump(env, txn, &context).await.unwrap() };
+            let generator = generator.into_generator();
+            for item in pin!(generator).into_iter() {
+                data.extend_from_slice(&item.unwrap());
+            }
+        }
+
+        let restored_env = restore("0".to_string(), &Default::default(), &mut data.as_slice())
+            .await
+            .unwrap();
+        assert_secondary_env_equal(&env, &restored_env);
+    }
+}

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
@@ -21,9 +21,28 @@ mod indexer;
 
 pub type SecondaryIndexDatabase = LmdbMultimap<Vec<u8>, u64>;
 
+#[derive(Debug, Clone)]
+pub struct SecondaryEnvironmentCommon {
+    pub index_definition: IndexDefinition,
+    pub index_definition_option: LmdbOption<IndexDefinition>,
+    pub database: SecondaryIndexDatabase,
+    pub next_operation_id: LmdbCounter,
+}
+
+const INDEX_DEFINITION_DB_NAME: &str = "index_definition";
+const DATABASE_DB_NAME: &str = "database";
+const NEXT_OPERATION_ID_DB_NAME: &str = "next_operation_id";
+
 pub trait SecondaryEnvironment: LmdbEnvironment {
-    fn index_definition(&self) -> &IndexDefinition;
-    fn database(&self) -> SecondaryIndexDatabase;
+    fn common(&self) -> &SecondaryEnvironmentCommon;
+
+    fn index_definition(&self) -> &IndexDefinition {
+        &self.common().index_definition
+    }
+
+    fn database(&self) -> SecondaryIndexDatabase {
+        self.common().database
+    }
 
     fn count_data(&self) -> Result<usize, CacheError> {
         let txn = self.begin_txn()?;
@@ -33,10 +52,8 @@ pub trait SecondaryEnvironment: LmdbEnvironment {
 
 #[derive(Debug)]
 pub struct RwSecondaryEnvironment {
-    index_definition: IndexDefinition,
     env: RwLmdbEnvironment,
-    database: SecondaryIndexDatabase,
-    next_operation_id: LmdbCounter,
+    common: SecondaryEnvironmentCommon,
 }
 
 impl LmdbEnvironment for RwSecondaryEnvironment {
@@ -46,12 +63,8 @@ impl LmdbEnvironment for RwSecondaryEnvironment {
 }
 
 impl SecondaryEnvironment for RwSecondaryEnvironment {
-    fn index_definition(&self) -> &IndexDefinition {
-        &self.index_definition
-    }
-
-    fn database(&self) -> SecondaryIndexDatabase {
-        self.database
+    fn common(&self) -> &SecondaryEnvironmentCommon {
+        &self.common
     }
 }
 
@@ -63,9 +76,9 @@ impl RwSecondaryEnvironment {
     ) -> Result<Self, CacheError> {
         let mut env = create_env(&get_cache_options(name.clone(), options))?.0;
 
-        let database = LmdbMultimap::create(&mut env, Some("database"))?;
-        let next_operation_id = LmdbCounter::create(&mut env, Some("next_operation_id"))?;
-        let index_definition_option = LmdbOption::create(&mut env, Some("index_definition"))?;
+        let database = LmdbMultimap::create(&mut env, Some(DATABASE_DB_NAME))?;
+        let next_operation_id = LmdbCounter::create(&mut env, Some(NEXT_OPERATION_ID_DB_NAME))?;
+        let index_definition_option = LmdbOption::create(&mut env, Some(INDEX_DEFINITION_DB_NAME))?;
 
         let old_index_definition = index_definition_option
             .load(&env.begin_txn()?)?
@@ -89,18 +102,20 @@ impl RwSecondaryEnvironment {
         set_comparator(&env, &index_definition, database)?;
 
         Ok(Self {
-            index_definition,
             env,
-            database,
-            next_operation_id,
+            common: SecondaryEnvironmentCommon {
+                index_definition,
+                index_definition_option,
+                database,
+                next_operation_id,
+            },
         })
     }
 
     pub fn share(&self) -> RoSecondaryEnvironment {
         RoSecondaryEnvironment {
-            index_definition: self.index_definition.clone(),
             env: self.env.share(),
-            database: self.database,
+            common: self.common.clone(),
         }
     }
 
@@ -117,7 +132,7 @@ impl RwSecondaryEnvironment {
         let txn = self.env.txn_mut()?;
         loop {
             // Start from `next_operation_id`.
-            let operation_id = self.next_operation_id.load(txn)?;
+            let operation_id = self.common.next_operation_id.load(txn)?;
             if operation_id >= main_env_next_operation_id {
                 return Ok(true);
             }
@@ -132,9 +147,9 @@ impl RwSecondaryEnvironment {
                     // Build secondary index.
                     indexer::build_index(
                         txn,
-                        self.database,
+                        self.common.database,
                         &record,
-                        &self.index_definition,
+                        &self.common.index_definition,
                         operation_id,
                     )?;
                 }
@@ -151,14 +166,14 @@ impl RwSecondaryEnvironment {
                     // Delete secondary index.
                     indexer::delete_index(
                         txn,
-                        self.database,
+                        self.common.database,
                         &record,
-                        &self.index_definition,
+                        &self.common.index_definition,
                         operation_id,
                     )?;
                 }
             }
-            self.next_operation_id.store(txn, operation_id + 1)?;
+            self.common.next_operation_id.store(txn, operation_id + 1)?;
 
             increment_counter!(counter_name, labels.clone());
         }
@@ -171,9 +186,8 @@ impl RwSecondaryEnvironment {
 
 #[derive(Debug, Clone)]
 pub struct RoSecondaryEnvironment {
-    index_definition: IndexDefinition,
     env: RoLmdbEnvironment,
-    database: SecondaryIndexDatabase,
+    common: SecondaryEnvironmentCommon,
 }
 
 impl LmdbEnvironment for RoSecondaryEnvironment {
@@ -183,12 +197,8 @@ impl LmdbEnvironment for RoSecondaryEnvironment {
 }
 
 impl SecondaryEnvironment for RoSecondaryEnvironment {
-    fn index_definition(&self) -> &IndexDefinition {
-        &self.index_definition
-    }
-
-    fn database(&self) -> SecondaryIndexDatabase {
-        self.database
+    fn common(&self) -> &SecondaryEnvironmentCommon {
+        &self.common
     }
 }
 
@@ -196,8 +206,9 @@ impl RoSecondaryEnvironment {
     pub fn new(name: String, options: &CacheOptions) -> Result<Self, CacheError> {
         let env = open_env(&get_cache_options(name.clone(), options))?.0;
 
-        let database = LmdbMultimap::open(&env, Some("database"))?;
-        let index_definition_option = LmdbOption::open(&env, Some("index_definition"))?;
+        let database = LmdbMultimap::open(&env, Some(DATABASE_DB_NAME))?;
+        let index_definition_option = LmdbOption::open(&env, Some(INDEX_DEFINITION_DB_NAME))?;
+        let next_operation_id = LmdbCounter::open(&env, Some(NEXT_OPERATION_ID_DB_NAME))?;
 
         let index_definition = index_definition_option
             .load(&env.begin_txn()?)?
@@ -207,11 +218,17 @@ impl RoSecondaryEnvironment {
         set_comparator(&env, &index_definition, database)?;
         Ok(Self {
             env,
-            database,
-            index_definition,
+            common: SecondaryEnvironmentCommon {
+                index_definition,
+                index_definition_option,
+                database,
+                next_operation_id,
+            },
         })
     }
 }
+
+pub mod dump_restore;
 
 fn get_cache_options(name: String, options: &CacheOptions) -> CacheOptions {
     let path = options.path.as_ref().map(|(main_base_path, main_labels)| {

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -12,7 +12,9 @@ use dozer_types::{
     serde::{Deserialize, Serialize},
     types::{IndexDefinition, Record, Schema, SchemaWithIndex},
 };
-pub use lmdb::cache_manager::{CacheManagerOptions, LmdbRoCacheManager, LmdbRwCacheManager};
+pub use lmdb::cache_manager::{
+    begin_dump_txn, dump, CacheManagerOptions, LmdbRoCacheManager, LmdbRwCacheManager,
+};
 pub mod expression;
 mod index;
 mod plan;

--- a/dozer-cache/src/errors.rs
+++ b/dozer-cache/src/errors.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use dozer_storage::errors::StorageError;
+use dozer_storage::RestoreError;
 use dozer_types::thiserror;
 use dozer_types::thiserror::Error;
 
@@ -28,6 +29,10 @@ pub enum CacheError {
     Plan(#[from] PlanError),
     #[error("Type error: {0}")]
     Type(#[from] TypeError),
+    #[error("Restore error: {0}")]
+    Restore(#[from] RestoreError),
+    #[error("Failed to dump to writer: {0}")]
+    FailedToDumpToWriter(#[source] std::io::Error),
 
     #[error("Log error: {0}")]
     ReaderError(#[from] ReaderError),

--- a/dozer-cache/src/errors.rs
+++ b/dozer-cache/src/errors.rs
@@ -31,8 +31,6 @@ pub enum CacheError {
     Type(#[from] TypeError),
     #[error("Restore error: {0}")]
     Restore(#[from] RestoreError),
-    #[error("Failed to dump to writer: {0}")]
-    FailedToDumpToWriter(#[source] std::io::Error),
 
     #[error("Log error: {0}")]
     ReaderError(#[from] ReaderError),

--- a/dozer-cache/src/main.rs
+++ b/dozer-cache/src/main.rs
@@ -1,0 +1,99 @@
+use std::pin::pin;
+
+use clap::{Parser, Subcommand};
+use dozer_cache::cache::{
+    begin_dump_txn, dump, expression::QueryExpression, CacheManagerOptions, LmdbRoCacheManager,
+    LmdbRwCacheManager, RoCache,
+};
+use dozer_storage::generator::{Generator, IntoGenerator};
+use dozer_types::labels::Labels;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, Parser)]
+struct Cli {
+    /// Dozer cache directory.
+    cache_dir: String,
+    /// The endpoint name.
+    endpoint: String,
+    /// The migration name.
+    migration: String,
+    #[clap(subcommand)]
+    command: CacheCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum CacheCommand {
+    /// Counts the number of records in the cache.
+    Count,
+    /// Dumps the cache to a file.
+    Dump {
+        /// The path to the file to dump to.
+        path: String,
+    },
+    /// Restores the cache from a file.
+    Restore {
+        /// The path to the file to restore from.
+        path: String,
+    },
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let cli = Cli::parse();
+    let labels = labels(cli.endpoint.clone(), cli.migration.clone());
+
+    match cli.command {
+        CacheCommand::Count => {
+            let cache_manager = LmdbRoCacheManager::new(CacheManagerOptions {
+                path: Some(cli.cache_dir.into()),
+                ..Default::default()
+            })
+            .unwrap();
+            let cache = cache_manager.open_lmdb_cache(labels).unwrap().unwrap();
+            let count = cache.count(&QueryExpression::with_no_limit()).unwrap();
+            println!("Count: {}", count);
+        }
+        CacheCommand::Dump { path } => {
+            let cache_manager = LmdbRoCacheManager::new(CacheManagerOptions {
+                path: Some(cli.cache_dir.into()),
+                ..Default::default()
+            })
+            .unwrap();
+            let cache = &cache_manager.open_lmdb_cache(labels).unwrap().unwrap();
+            let file = tokio::fs::File::create(path).await.unwrap();
+            let mut writer = tokio::io::BufWriter::new(file);
+
+            let txn = &begin_dump_txn(cache).unwrap();
+            let generator = |context| async move { dump(cache, txn, &context).await.unwrap() };
+            let generator = generator.into_generator();
+            for item in pin!(generator).into_iter() {
+                let item = item.unwrap();
+                writer.write_all(&item).await.unwrap();
+            }
+
+            writer.flush().await.unwrap();
+        }
+        CacheCommand::Restore { path } => {
+            let cache_manager = LmdbRwCacheManager::new(CacheManagerOptions {
+                path: Some(cli.cache_dir.into()),
+                ..Default::default()
+            })
+            .unwrap();
+            let file = tokio::fs::File::open(path).await.unwrap();
+            let mut reader = tokio::io::BufReader::new(file);
+            cache_manager
+                .restore_cache(labels, Default::default(), &mut reader)
+                .await
+                .unwrap();
+        }
+    }
+}
+
+fn labels(endpoint: String, migration: String) -> Labels {
+    let mut labels = Labels::default();
+    labels.push("endpoint", endpoint);
+    labels.push("migration", migration);
+    labels
+}

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -28,11 +28,10 @@ fn main() {
 }
 
 fn render_logo() {
-    use std::println as info;
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-    info!("{LOGO}");
-    info!("\nDozer Version: {VERSION}\n");
+    println!("{LOGO}");
+    println!("\nDozer Version: {VERSION}\n");
 }
 
 #[derive(Deserialize, Debug)]

--- a/dozer-cli/src/simple/cloud/login.rs
+++ b/dozer-cli/src/simple/cloud/login.rs
@@ -1,6 +1,6 @@
 use crate::errors::{CloudCredentialError, CloudLoginError};
 use std::collections::HashMap;
-use std::{env, fs, io, println as info};
+use std::{env, fs, io};
 
 use dozer_types::grpc_types::cloud::company_request::Criteria;
 use dozer_types::grpc_types::cloud::dozer_public_client::DozerPublicClient;
@@ -138,17 +138,17 @@ impl LoginSvc {
 
     async fn login_by_credential(&self) -> Result<(), CloudLoginError> {
         let mut profile_name = String::new();
-        info!("Please enter profile name:");
+        println!("Please enter profile name:");
         io::stdin().read_line(&mut profile_name)?;
         profile_name = profile_name.trim().to_owned();
 
         let mut client_id = String::new();
-        info!("Please enter your client_id:");
+        println!("Please enter your client_id:");
         io::stdin().read_line(&mut client_id)?;
         client_id = client_id.trim().to_owned();
 
         let mut client_secret = String::new();
-        info!("Please enter your client_secret:");
+        println!("Please enter your client_secret:");
         io::stdin().read_line(&mut client_secret)?;
         client_secret = client_secret.trim().to_owned();
 
@@ -161,7 +161,7 @@ impl LoginSvc {
         };
         credential_info.get_access_token().await?;
         credential_info.save()?;
-        info!("Login success !");
+        println!("Login success !");
         Ok(())
     }
 }

--- a/dozer-core/src/dag_impl.rs
+++ b/dozer-core/src/dag_impl.rs
@@ -120,8 +120,7 @@ impl<T> Dag<T> {
 
     /// Print the DAG in DOT format.
     pub fn print_dot(&self) {
-        use std::println as info;
-        info!("{}", dot::Dot::new(&self.graph));
+        println!("{}", dot::Dot::new(&self.graph));
     }
 
     /// Adds a source. Panics if the `handle` exists in the `Dag`.

--- a/dozer-ingestion/src/connectors/grpc/tests.rs
+++ b/dozer-ingestion/src/connectors/grpc/tests.rs
@@ -135,7 +135,6 @@ async fn ingest_grpc_default() {
 #[tokio::test]
 #[ignore]
 async fn test_serialize_arrow_schema() {
-    use std::println as info;
     let schema = arrow_types::Schema::new(vec![
         arrow_types::Field::new("id", arrow_types::DataType::Int32, false),
         arrow_types::Field::new(
@@ -149,7 +148,7 @@ async fn test_serialize_arrow_schema() {
     ]);
 
     let str = dozer_types::serde_json::to_string(&schema).unwrap();
-    info!("{str}");
+    println!("{str}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/dozer-sql/src/jsonpath/path/mod.rs
+++ b/dozer-sql/src/jsonpath/path/mod.rs
@@ -14,7 +14,7 @@ mod json;
 mod top;
 
 /// The trait defining the behaviour of processing every separated element.
-/// type Data usually stands for json [[Value]]
+/// type Data usually stands for json [[JsonValue]]
 /// The trait also requires to have a root json to process.
 /// It needs in case if in the filter there will be a pointer to the absolute path
 pub trait Path<'a> {

--- a/dozer-storage/Cargo.toml
+++ b/dozer-storage/Cargo.toml
@@ -12,6 +12,9 @@ dozer-types = { path = "../dozer-types" }
 lmdb-rkv = "0.14.0"
 lmdb-rkv-sys = "0.11.2"
 page_size = "0.5.0"
+pin-project = "1.1.0"
+tokio = "1.28.2"
 
 [dev-dependencies]
 tempdir = "0.3.7"
+tokio = { version = "1.28.2", features = ["fs"] }

--- a/dozer-storage/Cargo.toml
+++ b/dozer-storage/Cargo.toml
@@ -17,4 +17,3 @@ tokio = "1.28.2"
 
 [dev-dependencies]
 tempdir = "0.3.7"
-tokio = { version = "1.28.2", features = ["fs"] }

--- a/dozer-storage/src/generator.rs
+++ b/dozer-storage/src/generator.rs
@@ -1,0 +1,262 @@
+use std::{
+    cell::RefCell,
+    future::Future,
+    pin::Pin,
+    ptr::null,
+    rc::Rc,
+    task::{self, RawWaker, RawWakerVTable, Waker},
+};
+
+use pin_project::pin_project;
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+pub enum GeneratorState<Y, R> {
+    Yielded(Y),
+    Complete(R),
+}
+
+/// Exactly `std::ops::Generator`, with an additional `into_iter`.
+pub trait Generator {
+    type Yield;
+
+    type Return;
+
+    fn resume(self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return>;
+
+    fn into_iter(self) -> GeneratorIterator<Self>
+    where
+        Self: Sized + Unpin,
+    {
+        GeneratorIterator::new(self)
+    }
+}
+
+impl<G: Generator> Generator for Pin<Box<G>> {
+    type Yield = G::Yield;
+
+    type Return = G::Return;
+
+    fn resume(self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return> {
+        unsafe { self.get_unchecked_mut() }.as_mut().resume()
+    }
+}
+
+impl<G: Generator> Generator for Pin<&mut G> {
+    type Yield = G::Yield;
+
+    type Return = G::Return;
+
+    fn resume(self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return> {
+        unsafe { self.get_unchecked_mut() }.as_mut().resume()
+    }
+}
+
+/// This `Iterator` yields the values yielded by a `Generator` until it's completed.
+pub struct GeneratorIterator<G: Generator + Unpin> {
+    generator: G,
+    state: GeneratorIteratorState<G::Return>,
+}
+
+enum GeneratorIteratorState<T> {
+    Yielding,
+    Completed(T),
+    CompletedAndTaken,
+}
+
+impl<T> GeneratorIteratorState<T> {
+    fn take_return(&mut self) -> Option<T> {
+        if matches!(self, Self::Yielding) || matches!(self, Self::CompletedAndTaken) {
+            None
+        } else {
+            match std::mem::replace(self, Self::CompletedAndTaken) {
+                Self::Completed(value) => Some(value),
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+impl<G: Generator + Unpin> Iterator for GeneratorIterator<G> {
+    type Item = G::Yield;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let GeneratorIteratorState::Yielding = self.state {
+            match Pin::new(&mut self.generator).resume() {
+                GeneratorState::Yielded(value) => Some(value),
+                GeneratorState::Complete(value) => {
+                    self.state = GeneratorIteratorState::Completed(value);
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<G: Generator + Unpin> GeneratorIterator<G> {
+    pub fn new(generator: G) -> Self {
+        Self {
+            generator,
+            state: GeneratorIteratorState::Yielding,
+        }
+    }
+
+    pub fn into_generator(self) -> G {
+        self.generator
+    }
+
+    pub fn take_return(&mut self) -> Option<G::Return> {
+        self.state.take_return()
+    }
+}
+
+/// The generic parameter `Arg` is a workaround from <https://github.com/rust-lang/rust/issues/60074#issuecomment-779452213>.
+pub trait IntoGenerator<Arg = ()> {
+    type Generator: Generator;
+
+    fn into_generator(self) -> Self::Generator;
+
+    fn into_iter(self) -> GeneratorIterator<Self::Generator>
+    where
+        Self: Sized,
+        Self::Generator: Unpin,
+    {
+        GeneratorIterator::new(self.into_generator())
+    }
+}
+
+/// This future is polled once and then returns `Poll::Ready(())` forever.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[pin_project]
+pub struct Once {
+    done: bool,
+}
+
+impl Future for Once {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        let done = self.project().done;
+        if *done {
+            task::Poll::Ready(())
+        } else {
+            *done = true;
+            task::Poll::Pending
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Use this to yield from an async function to make the function a generator.
+///
+/// ```rust
+/// use dozer_storage::generator::{FutureGeneratorContext, Generator, GeneratorState, IntoGenerator};
+///
+/// async fn fib(context: FutureGeneratorContext<i32>) {
+///    let mut x = 0;
+///     let mut y = 1;
+///     loop {
+///         context.yield_(x).await;
+///         let tmp = x + y;
+///         x = y;
+///         y = tmp;
+///     }
+/// }
+///
+/// let generator = std::pin::pin!(fib.into_generator());
+/// assert_eq!(
+///     generator
+///         .into_iter()
+///         .take(10)
+///         .collect::<Vec<_>>(),
+///     vec![0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
+/// );
+/// ```
+pub struct FutureGeneratorContext<T> {
+    value: Rc<RefCell<Option<T>>>,
+}
+
+impl<T> Clone for FutureGeneratorContext<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+        }
+    }
+}
+
+impl<T> FutureGeneratorContext<T> {
+    pub fn yield_(&self, value: T) -> Once {
+        let mut cell = self.value.borrow_mut();
+        assert!(
+            cell.is_none(),
+            "Make sure to await the future returned by `yield_`"
+        );
+        *cell = Some(value);
+        Once { done: false }
+    }
+}
+
+#[pin_project]
+pub struct FutureGenerator<Y, R, F: Future<Output = R>> {
+    #[pin]
+    future: F,
+    waker: Waker,
+    context: FutureGeneratorContext<Y>,
+}
+
+impl<Y, R, F: Future<Output = R>> Generator for FutureGenerator<Y, R, F> {
+    type Yield = Y;
+
+    type Return = R;
+
+    fn resume(self: Pin<&mut Self>) -> GeneratorState<Self::Yield, Self::Return> {
+        let this = self.project();
+        let result = match this.future.poll(&mut task::Context::from_waker(this.waker)) {
+            std::task::Poll::Ready(value) => GeneratorState::Complete(value),
+            std::task::Poll::Pending => GeneratorState::Yielded(
+                this.context
+                    .value
+                    .take()
+                    .expect("Generator should only await using Context::yield"),
+            ),
+        };
+        result
+    }
+}
+
+impl<Y, R, Fut: Future<Output = R>, Fn: FnOnce(FutureGeneratorContext<Y>) -> Fut> IntoGenerator<Y>
+    for Fn
+{
+    type Generator = FutureGenerator<Y, R, Fut>;
+
+    fn into_generator(self) -> Self::Generator {
+        let context = FutureGeneratorContext {
+            value: Rc::new(RefCell::new(None)),
+        };
+        let future = self(context.clone());
+        let waker = unsafe { Waker::from_raw(RawWaker::new(null(), &VTABLE)) };
+        FutureGenerator {
+            future,
+            waker,
+            context,
+        }
+    }
+}
+
+const VTABLE: RawWakerVTable = RawWakerVTable::new(
+    raw_waker_clone,
+    raw_waker_wake,
+    raw_waker_wake_by_ref,
+    raw_waker_drop,
+);
+
+unsafe fn raw_waker_clone(_: *const ()) -> RawWaker {
+    RawWaker::new(null(), &VTABLE)
+}
+
+unsafe fn raw_waker_wake(_: *const ()) {}
+
+unsafe fn raw_waker_wake_by_ref(_: *const ()) {}
+
+unsafe fn raw_waker_drop(_: *const ()) {}

--- a/dozer-storage/src/lib.rs
+++ b/dozer-storage/src/lib.rs
@@ -4,8 +4,8 @@ pub use lmdb_storage::{LmdbEnvironment, RoLmdbEnvironment, RwLmdbEnvironment};
 
 mod lmdb_database;
 pub use lmdb_database::{
-    dump, restore, BorrowEncode, Decode, DumpItem, Encode, Encoded, Iterator, KeyIterator, LmdbKey,
-    LmdbKeyType, LmdbVal, RestoreError, ValueIterator,
+    assert_database_equal, dump, restore, BorrowEncode, Decode, DumpItem, Encode, Encoded,
+    Iterator, KeyIterator, LmdbKey, LmdbKeyType, LmdbVal, RestoreError, ValueIterator,
 };
 mod lmdb_map;
 pub use lmdb_map::LmdbMap;
@@ -19,7 +19,7 @@ mod lmdb_option;
 pub use lmdb_option::LmdbOption;
 
 #[cfg(test)]
-mod tests;
+pub mod tests;
 
 pub use lmdb;
 pub use lmdb_sys;

--- a/dozer-storage/src/lib.rs
+++ b/dozer-storage/src/lib.rs
@@ -19,7 +19,7 @@ mod lmdb_option;
 pub use lmdb_option::LmdbOption;
 
 #[cfg(test)]
-pub mod tests;
+mod tests;
 
 pub use lmdb;
 pub use lmdb_sys;

--- a/dozer-storage/src/lib.rs
+++ b/dozer-storage/src/lib.rs
@@ -4,8 +4,8 @@ pub use lmdb_storage::{LmdbEnvironment, RoLmdbEnvironment, RwLmdbEnvironment};
 
 mod lmdb_database;
 pub use lmdb_database::{
-    BorrowEncode, Decode, Encode, Encoded, Iterator, KeyIterator, LmdbKey, LmdbKeyType, LmdbVal,
-    ValueIterator,
+    dump, restore, BorrowEncode, Decode, DumpItem, Encode, Encoded, Iterator, KeyIterator, LmdbKey,
+    LmdbKeyType, LmdbVal, RestoreError, ValueIterator,
 };
 mod lmdb_map;
 pub use lmdb_map::LmdbMap;
@@ -23,3 +23,5 @@ mod tests;
 
 pub use lmdb;
 pub use lmdb_sys;
+
+pub mod generator;

--- a/dozer-storage/src/lmdb_counter.rs
+++ b/dozer-storage/src/lmdb_counter.rs
@@ -1,5 +1,5 @@
 use dozer_types::borrow::IntoOwned;
-use lmdb::{RwTransaction, Transaction};
+use lmdb::{Database, RwTransaction, Transaction};
 
 use crate::{
     errors::StorageError,
@@ -33,6 +33,10 @@ impl LmdbCounter {
         let current = self.load(txn)?;
         self.store(txn, current + value)?;
         Ok(current)
+    }
+
+    pub fn database(&self) -> Database {
+        self.0.database()
     }
 }
 

--- a/dozer-storage/src/lmdb_database/dump/dup/generator.rs
+++ b/dozer-storage/src/lmdb_database/dump/dup/generator.rs
@@ -1,0 +1,240 @@
+use std::pin::pin;
+
+use lmdb::Cursor;
+use lmdb_sys::{MDB_FIRST, MDB_NEXT, MDB_NEXT_DUP};
+
+use crate::{
+    generator::{FutureGeneratorContext, Generator, IntoGenerator},
+    yield_return_if_err,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DupData<'txn> {
+    First { key: &'txn [u8], value: &'txn [u8] },
+    Following { value: &'txn [u8] },
+}
+
+/// A `Generator` that yields all `DupData` in given `cursor`.
+///
+/// The cursor must be opened with a database that has `DUP_SORT` enabled.
+pub async fn dup_data<'txn, C: Cursor<'txn>>(
+    cursor: C,
+    context: &FutureGeneratorContext<Result<DupData<'txn>, lmdb::Error>>,
+) -> C {
+    match get_one_dup_data(&cursor, MDB_FIRST, context, true).await {
+        Ok(Some(())) => (),
+        _ => return cursor,
+    }
+    if let Err(()) = get_following_dup_data(&cursor, context).await {
+        return cursor;
+    }
+
+    loop {
+        match get_one_dup_data(&cursor, MDB_NEXT, context, true).await {
+            Ok(Some(())) => (),
+            _ => return cursor,
+        }
+        if let Err(()) = get_following_dup_data(&cursor, context).await {
+            return cursor;
+        }
+    }
+}
+
+/// A `Generator` that yields number of value items in each key.
+///
+/// The cursor must be opened with a database that has `DUP_SORT` enabled.
+pub async fn dup_value_counts<'txn, C: Cursor<'txn>>(
+    cursor: C,
+    context: &FutureGeneratorContext<Result<u64, lmdb::Error>>,
+) {
+    let generator =
+        pin!((|context| async move { dup_data(cursor, &context).await }).into_generator());
+    let mut iter = generator.into_iter();
+    let mut current_count = None;
+    loop {
+        match iter.next() {
+            Some(result) => match yield_return_if_err!(context, result) {
+                DupData::First { .. } => {
+                    if let Some(count) = current_count {
+                        context.yield_(Ok(count)).await;
+                    }
+                    current_count = Some(1);
+                }
+                DupData::Following { .. } => {
+                    current_count = Some(current_count.expect("Must be `Some`") + 1);
+                }
+            },
+            None => {
+                if let Some(count) = current_count {
+                    context.yield_(Ok(count)).await;
+                }
+                return;
+            }
+        }
+    }
+}
+
+/// Gets one `DupData` using given `op`.
+///
+/// # Arguments
+///
+/// - `cursor`: The cursor to use.
+/// - `op`: The operation to use, `MDB_FIRST`, `MDB_NEXT`, `MDB_NEXT_DUP`, etc.
+/// - `context`: The context to yield the result.
+/// - `first`: Whether the yielded `DupData` is the first one. If `true`, will yield `DupData::First`, otherwise `DupData::Following`.
+///
+/// # Return
+///
+/// - `Ok(Some(()))`: Successfully yielded one `DupData`.
+/// - `Ok(None)`: Using given `op`, the cursor get result is `MDB_NOTFOUND`.
+/// - `Err(())`: Yielded an error.
+///
+/// `cursor` must not be used by other functions between the await points.
+async fn get_one_dup_data<'txn, C: Cursor<'txn>>(
+    cursor: &C,
+    op: u32,
+    context: &FutureGeneratorContext<Result<DupData<'txn>, lmdb::Error>>,
+    first: bool,
+) -> Result<Option<()>, ()> {
+    match cursor.get(None, None, op) {
+        Ok((key, value)) => {
+            let key = key.expect("get_first_dup_data should always return a key");
+            if first {
+                context.yield_(Ok(DupData::First { key, value })).await;
+            } else {
+                context.yield_(Ok(DupData::Following { value })).await;
+            }
+            Ok(Some(()))
+        }
+        Err(lmdb::Error::NotFound) => Ok(None),
+        Err(e) => {
+            context.yield_(Err(e.into())).await;
+            Err(())
+        }
+    }
+}
+
+/// Gets all following `DupData` using `MDB_NEXT_DUP` until `MDB_NOTFOUND`.
+/// Yields `Err(())` and returns if any error occurs.
+///
+/// # Return
+///
+/// - `Ok(())`: Successfully yielded all following `DupData`.
+/// - `Err(())`: Yielded an error.
+///
+/// `cursor` must not be used by other functions between the await points.
+async fn get_following_dup_data<'txn, C: Cursor<'txn>>(
+    cursor: &C,
+    context: &FutureGeneratorContext<Result<DupData<'txn>, lmdb::Error>>,
+) -> Result<(), ()> {
+    loop {
+        match get_one_dup_data(cursor, MDB_NEXT_DUP, context, false).await {
+            Ok(Some(())) => (),
+            Ok(None) => return Ok(()),
+            Err(()) => return Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::pin;
+
+    use lmdb::{Database, DatabaseFlags, Transaction};
+    use tempdir::TempDir;
+
+    use crate::{
+        generator::{Generator, IntoGenerator},
+        lmdb_storage::{LmdbEnvironmentManager, LmdbEnvironmentOptions},
+        LmdbEnvironment, RwLmdbEnvironment,
+    };
+
+    use super::*;
+
+    fn setup_test_env() -> (TempDir, RwLmdbEnvironment, Database) {
+        let temp_dir = TempDir::new("test").unwrap();
+        let mut env = LmdbEnvironmentManager::create_rw(
+            temp_dir.path(),
+            "dump_tests_env",
+            LmdbEnvironmentOptions::default(),
+        )
+        .unwrap();
+        let db = env
+            .create_database(Some("test_dup_data_generator"), DatabaseFlags::DUP_SORT)
+            .unwrap();
+
+        let data: Vec<(&'static [u8], &'static [u8])> = vec![
+            (b"key1", b"value1"),
+            (b"key1", b"value2"),
+            (b"key2", b"value3"),
+            (b"key2", b"value4"),
+            (b"key2", b"value5"),
+        ];
+        let txn = env.txn_mut().unwrap();
+        for (key, value) in data.iter() {
+            txn.put(db, key, value, lmdb::WriteFlags::empty()).unwrap();
+        }
+        env.commit().unwrap();
+
+        (temp_dir, env, db)
+    }
+
+    #[test]
+    fn test_dup_data_generator() {
+        let (_temp_dir, env, db) = setup_test_env();
+
+        let txn = env.begin_txn().unwrap();
+        let cursor = txn.open_ro_cursor(db).unwrap();
+        let generator =
+            pin!((|context| async move { dup_data(cursor, &context).await }).into_generator());
+        let mut iter = generator.into_iter();
+
+        let DupData::First { key, value } = iter.next().unwrap().unwrap() else {
+            panic!("Must be first");
+        };
+        assert_eq!(key, b"key1");
+        assert_eq!(value, b"value1");
+
+        let DupData::Following { value } = iter.next().unwrap().unwrap() else {
+            panic!("Must be following");
+        };
+        assert_eq!(value, b"value2");
+
+        let DupData::First { key, value } = iter.next().unwrap().unwrap() else {
+            panic!("Must be first");
+        };
+        assert_eq!(key, b"key2");
+        assert_eq!(value, b"value3");
+
+        let DupData::Following { value } = iter.next().unwrap().unwrap() else {
+            panic!("Must be following");
+        };
+        assert_eq!(value, b"value4");
+
+        let DupData::Following { value } = iter.next().unwrap().unwrap() else {
+            panic!("Must be following");
+        };
+        assert_eq!(value, b"value5");
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_dup_value_counts() {
+        let (_temp_dir, env, db) = setup_test_env();
+
+        let txn = env.begin_txn().unwrap();
+        let cursor = txn.open_ro_cursor(db).unwrap();
+        let generator = pin!(
+            (|context| async move { dup_value_counts(cursor, &context).await }).into_generator()
+        );
+        assert_eq!(
+            generator
+                .into_iter()
+                .take(2)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![2, 3]
+        );
+    }
+}

--- a/dozer-storage/src/lmdb_database/dump/dup/mod.rs
+++ b/dozer-storage/src/lmdb_database/dump/dup/mod.rs
@@ -1,0 +1,400 @@
+use std::{ops::ControlFlow, pin::pin};
+
+use dozer_types::log::{debug, info, trace};
+use lmdb::{Database, DatabaseFlags, RwTransaction, Transaction, WriteFlags};
+use tokio::io::AsyncRead;
+
+use crate::{
+    errors::StorageError,
+    generator::{FutureGeneratorContext, Generator, IntoGenerator},
+    yield_return_if_err, DumpItem, RestoreError, RwLmdbEnvironment,
+};
+
+use self::generator::{dup_data, dup_value_counts, DupData};
+
+use super::{
+    create_new_database, dump_array, dump_slice, dump_u64, restore_array, restore_slice,
+    restore_u64,
+};
+
+mod generator;
+
+pub async fn dump<'txn, T: Transaction>(
+    txn: &'txn T,
+    db: Database,
+    flags: DatabaseFlags,
+    context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+) {
+    let cursor = yield_return_if_err!(context, txn.open_ro_cursor(db));
+
+    // Do one run to find and write the number of keys.
+    let mut key_count = 0u64;
+    let generator =
+        pin!((|context| async move { dup_data(cursor, &context).await }).into_generator());
+    let mut iter = generator.into_iter();
+    while let Some(result) = iter.next() {
+        let dup_data = yield_return_if_err!(context, result);
+        if matches!(dup_data, DupData::First { .. }) {
+            key_count += 1;
+        }
+    }
+    let count_cursor = iter
+        .take_return()
+        .expect("Generator iterator must have return when exhausted");
+    dump_u64(key_count, context).await;
+    if key_count == 0 {
+        return;
+    }
+
+    // Construct data iterator.
+    let data_cursor = yield_return_if_err!(context, txn.open_ro_cursor(db));
+    let data_generator =
+        pin!((|context| async move { dup_data(data_cursor, &context).await }).into_generator());
+    let mut data_iter = data_generator.into_iter();
+
+    // Find first key value pair.
+    let result = data_iter.next().expect("There's at least one key");
+    let DupData::First { key, value } = yield_return_if_err!(context, result) else {
+        panic!("First item must be `First`");
+    };
+
+    // Write first key.
+    let key_len = if flags.contains(DatabaseFlags::INTEGER_KEY) {
+        let key_len = key.len() as u64;
+        dump_u64(key_len, context).await;
+        dump_array(key, key_len, context).await;
+        Some(key_len)
+    } else {
+        dump_slice(key, context).await;
+        None
+    };
+
+    // Construct value count iterator.
+    let count_generator =
+        pin!(
+            (|context| async move { dup_value_counts(count_cursor, &context).await })
+                .into_generator()
+        );
+    let mut count_iter = count_generator.into_iter();
+
+    // Write first value count.
+    let result = count_iter.next().expect("There's at least one key");
+    let value_count = yield_return_if_err!(context, result);
+    dump_u64(value_count, context).await;
+
+    // Write first value.
+    let value_len = if is_value_len_fixed(flags) {
+        let value_len = value.len() as u64;
+        dump_u64(value_len, context).await;
+        dump_array(value, value_len, context).await;
+        Some(value_len)
+    } else {
+        dump_slice(value, context).await;
+        None
+    };
+
+    // Write following values.
+    let (mut key, mut value) = match dump_following_values(&mut data_iter, value_len, context).await
+    {
+        ControlFlow::Continue((key, value)) => (key, value),
+        ControlFlow::Break(()) => return,
+    };
+
+    loop {
+        // Write key.
+        if let Some(key_len) = key_len {
+            dump_array(key, key_len, context).await;
+        } else {
+            dump_slice(key, context).await;
+        }
+
+        // Write value count.
+        let result = count_iter
+            .next()
+            .expect("Data iter said there're more keys");
+        let value_count = yield_return_if_err!(context, result);
+        dump_u64(value_count, context).await;
+
+        // Write first value.
+        if let Some(value_len) = value_len {
+            dump_array(value, value_len, context).await;
+        } else {
+            dump_slice(value, context).await;
+        }
+
+        // Write following values.
+        match dump_following_values(&mut data_iter, value_len, context).await {
+            ControlFlow::Continue((next_key, next_value)) => {
+                key = next_key;
+                value = next_value;
+            }
+            ControlFlow::Break(()) => return,
+        }
+    }
+}
+
+pub async fn restore<'txn, R: AsyncRead + Unpin>(
+    env: &mut RwLmdbEnvironment,
+    name: &str,
+    flags: DatabaseFlags,
+    reader: &mut R,
+) -> Result<Database, RestoreError> {
+    let db = create_new_database(env, name, flags)?;
+    info!("Created database {name} with flags {flags:?}");
+
+    // Read key count.
+    let key_count = restore_u64(reader).await?;
+    info!("Restoring {key_count} keys");
+    if key_count == 0 {
+        return Ok(db);
+    }
+
+    // Read key length.
+    let key_len = if flags.contains(DatabaseFlags::INTEGER_KEY) {
+        let key_len = restore_u64(reader).await?;
+        info!("Key length is {key_len}");
+        Some(key_len)
+    } else {
+        info!("Key length is variable");
+        None
+    };
+
+    // Read first key.
+    let key = if let Some(key_len) = key_len {
+        restore_array(reader, key_len).await?
+    } else {
+        restore_slice(reader).await?
+    };
+    info!("Restored first key");
+    trace!("First key is {:?}", key);
+
+    // Read first value count.
+    let value_count = restore_u64(reader).await?;
+    info!("First value count is {value_count}");
+
+    // Read value length.
+    let value_len = if is_value_len_fixed(flags) {
+        let value_len = restore_u64(reader).await?;
+        info!("Value length is {value_len}");
+        Some(value_len)
+    } else {
+        info!("Value length is variable");
+        None
+    };
+
+    let txn = env.txn_mut()?;
+    info!("Opened transaction");
+
+    // Read values that belong to the first key.
+    restore_values(txn, db, &key, value_count, value_len, reader).await?;
+
+    for i in 1..key_count {
+        // Read key.
+        let key = if let Some(key_len) = key_len {
+            restore_array(reader, key_len).await?
+        } else {
+            restore_slice(reader).await?
+        };
+        debug!("Restored key {i}");
+        trace!("Key is {:?}", key);
+
+        // Read value count.
+        let value_count = restore_u64(reader).await?;
+        debug!("Value count is {value_count}");
+
+        // Read values.
+        restore_values(txn, db, &key, value_count, value_len, reader).await?;
+    }
+
+    Ok(db)
+}
+
+/// If the iterator is complete or any error happens, return `ControlFlow::Break`,
+/// otherwise return `ControlFlow::Continue((key, value))`, where the key value is the first pair of next key.
+///
+/// Any error is already yielded to the context.
+async fn dump_following_values<'txn, I: Iterator<Item = Result<DupData<'txn>, lmdb::Error>>>(
+    iter: &mut I,
+    value_len: Option<u64>,
+    context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+) -> ControlFlow<(), (&'txn [u8], &'txn [u8])> {
+    loop {
+        match iter.next() {
+            Some(Ok(DupData::Following { value })) => {
+                if let Some(value_len) = value_len {
+                    dump_array(value, value_len, context).await;
+                } else {
+                    dump_slice(value, context).await;
+                }
+            }
+            Some(Ok(DupData::First { key, value })) => {
+                return ControlFlow::Continue((key, value));
+            }
+            Some(Err(e)) => {
+                context.yield_(Err(e.into())).await;
+                return ControlFlow::Break(());
+            }
+            None => {
+                return ControlFlow::Break(());
+            }
+        }
+    }
+}
+
+async fn restore_values(
+    txn: &mut RwTransaction<'_>,
+    db: Database,
+    key: &[u8],
+    value_count: u64,
+    value_len: Option<u64>,
+    reader: &mut (impl AsyncRead + Unpin),
+) -> Result<(), RestoreError> {
+    for i in 0..value_count {
+        let value = if let Some(value_len) = value_len {
+            restore_array(reader, value_len).await?
+        } else {
+            restore_slice(reader).await?
+        };
+        debug!("Restored value {i}");
+        trace!("Value is {value:?}");
+
+        txn.put(db, &key, &value, WriteFlags::empty())
+            .map_err(StorageError::Lmdb)?;
+        debug!("Inserted value {i}");
+    }
+    Ok(())
+}
+
+fn is_value_len_fixed(flags: DatabaseFlags) -> bool {
+    flags.contains(DatabaseFlags::DUP_FIXED) || flags.contains(DatabaseFlags::INTEGER_DUP)
+}
+
+#[cfg(test)]
+mod tests {
+    use dozer_types::tonic::async_trait;
+
+    use super::*;
+
+    use super::super::tests::*;
+
+    struct Dumper;
+
+    #[async_trait(?Send)]
+    impl Dump for Dumper {
+        async fn dump<'txn, T: Transaction>(
+            &self,
+            txn: &'txn T,
+            db: Database,
+            flags: DatabaseFlags,
+            context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+        ) {
+            dump(txn, db, flags, context).await
+        }
+    }
+
+    struct Restorer;
+
+    #[async_trait(?Send)]
+    impl Restore for Restorer {
+        async fn restore(
+            &self,
+            env: &mut RwLmdbEnvironment,
+            restore_name: &str,
+            flags: DatabaseFlags,
+            reader: &mut (impl AsyncRead + Unpin),
+        ) -> Result<Database, RestoreError> {
+            restore(env, restore_name, flags, reader).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dump_dup() {
+        let data: Vec<(&'static [u8], &'static [u8])> = vec![
+            (b"a", b"1"),
+            (b"a", b"2"),
+            (b"aa", b"3"),
+            (b"aa", b"4"),
+            (b"aaa", b"5"),
+            (b"aaa", b"6"),
+            (b"aaaa", b"7"),
+            (b"aaaa", b"8"),
+            (b"aaaaa", b"9"),
+            (b"aaaaa", b"10"),
+        ];
+        test_dump_restore(Dumper, Restorer, DatabaseFlags::DUP_SORT, &data).await;
+    }
+
+    #[tokio::test]
+    async fn test_dump_dup_integer_key() {
+        let data: Vec<(&'static [u8], &'static [u8])> = vec![
+            (b"0000", b"1"),
+            (b"0000", b"2"),
+            (b"0001", b"3"),
+            (b"0001", b"4"),
+            (b"0002", b"5"),
+            (b"0002", b"6"),
+            (b"0003", b"7"),
+            (b"0003", b"8"),
+            (b"0004", b"9"),
+            (b"0004", b"10"),
+        ];
+        test_dump_restore(
+            Dumper,
+            Restorer,
+            DatabaseFlags::DUP_SORT | DatabaseFlags::INTEGER_KEY,
+            &data,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_dump_dup_dup_fixed() {
+        let data: Vec<(&'static [u8], &'static [u8])> = vec![
+            (b"a", b"01"),
+            (b"a", b"02"),
+            (b"aa", b"03"),
+            (b"aa", b"04"),
+            (b"aaa", b"05"),
+            (b"aaa", b"06"),
+            (b"aaaa", b"07"),
+            (b"aaaa", b"08"),
+            (b"aaaaa", b"09"),
+            (b"aaaaa", b"10"),
+        ];
+        test_dump_restore(
+            Dumper,
+            Restorer,
+            DatabaseFlags::DUP_SORT | DatabaseFlags::DUP_FIXED,
+            &data,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_dump_dup_integer_key_dup_fixed() {
+        let data: Vec<(&'static [u8], &'static [u8])> = vec![
+            (b"0000", b"01"),
+            (b"0000", b"02"),
+            (b"0001", b"03"),
+            (b"0001", b"04"),
+            (b"0002", b"05"),
+            (b"0002", b"06"),
+            (b"0003", b"07"),
+            (b"0003", b"08"),
+            (b"0004", b"09"),
+            (b"0004", b"10"),
+        ];
+        test_dump_restore(
+            Dumper,
+            Restorer,
+            DatabaseFlags::DUP_SORT | DatabaseFlags::INTEGER_KEY | DatabaseFlags::DUP_FIXED,
+            &data,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_dump_dup_empty() {
+        test_dump_restore(Dumper, Restorer, DatabaseFlags::DUP_SORT, &[]).await;
+    }
+}

--- a/dozer-storage/src/lmdb_database/dump/mod.rs
+++ b/dozer-storage/src/lmdb_database/dump/mod.rs
@@ -1,0 +1,312 @@
+use std::ops::Deref;
+
+use dozer_types::thiserror::{self, Error};
+use lmdb::{Database, DatabaseFlags, Transaction};
+use tokio::io::{self, AsyncRead, AsyncReadExt};
+
+use crate::{
+    errors::StorageError,
+    generator::{FutureGeneratorContext, Once},
+    yield_return_if_err, LmdbEnvironment, RwLmdbEnvironment,
+};
+
+#[derive(Debug)]
+pub enum DumpItem<'txn> {
+    U8x8([u8; 8]),
+    U8x4([u8; 4]),
+    Slice(&'txn [u8]),
+}
+
+impl<'txn> Deref for DumpItem<'txn> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            DumpItem::U8x8(buf) => buf,
+            DumpItem::U8x4(buf) => buf,
+            DumpItem::Slice(buf) => buf,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RestoreError {
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+    #[error("from utf8: {0}")]
+    Utf8(#[from] std::string::FromUtf8Error),
+    #[error("invalid flags: {0}")]
+    InvalidFlags(u32),
+    #[error("storage: {0}")]
+    Storage(#[from] StorageError),
+    #[error("database exists: {0}")]
+    DatabaseExists(String),
+}
+
+pub async fn dump<'txn, T: Transaction>(
+    txn: &'txn T,
+    name: &'txn str,
+    db: Database,
+    context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+) {
+    dump_string(name, context).await;
+
+    let flags = yield_return_if_err!(context, txn.db_flags(db));
+    dump_u32(flags.bits(), context).await;
+
+    if flags.contains(DatabaseFlags::DUP_SORT) {
+        dup::dump(txn, db, flags, context).await;
+    } else {
+        no_dup::dump(txn, db, flags, context).await;
+    }
+}
+
+pub async fn restore<'txn, R: AsyncRead + Unpin>(
+    env: &mut RwLmdbEnvironment,
+    reader: &mut R,
+) -> Result<Database, RestoreError> {
+    let name = restore_string(reader).await?;
+
+    let flags = restore_u32(reader).await?;
+    let flags = DatabaseFlags::from_bits(flags).ok_or(RestoreError::InvalidFlags(flags))?;
+
+    if flags.contains(DatabaseFlags::DUP_SORT) {
+        dup::restore(env, &name, flags, reader).await
+    } else {
+        no_dup::restore(env, &name, flags, reader).await
+    }
+}
+
+fn create_new_database(
+    env: &mut RwLmdbEnvironment,
+    name: &str,
+    flags: DatabaseFlags,
+) -> Result<Database, RestoreError> {
+    match env.open_database(Some(name)) {
+        Ok(_) => Err(RestoreError::DatabaseExists(name.to_owned())),
+        Err(StorageError::Lmdb(lmdb::Error::NotFound)) => {
+            env.create_database(Some(name), flags).map_err(Into::into)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+mod dup;
+mod no_dup;
+
+fn dump_u64(
+    value: u64,
+    context: &FutureGeneratorContext<Result<DumpItem<'_>, StorageError>>,
+) -> Once {
+    context.yield_(Ok(DumpItem::U8x8(value.to_le_bytes())))
+}
+
+async fn restore_u64(reader: &mut (impl AsyncRead + Unpin)) -> Result<u64, RestoreError> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf).await?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn dump_u32(
+    value: u32,
+    context: &FutureGeneratorContext<Result<DumpItem<'_>, StorageError>>,
+) -> Once {
+    context.yield_(Ok(DumpItem::U8x4(value.to_le_bytes())))
+}
+
+async fn restore_u32(reader: &mut (impl AsyncRead + Unpin)) -> Result<u32, RestoreError> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf).await?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn dump_array<'a>(
+    array: &'a [u8],
+    len: u64,
+    context: &FutureGeneratorContext<Result<DumpItem<'a>, StorageError>>,
+) -> Once {
+    debug_assert!(array.len() as u64 == len);
+    context.yield_(Ok(DumpItem::Slice(array)))
+}
+
+async fn restore_array(
+    reader: &mut (impl AsyncRead + Unpin),
+    len: u64,
+) -> Result<Vec<u8>, RestoreError> {
+    let mut buf = vec![0u8; len as usize];
+    reader.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+async fn dump_string<'a>(
+    string: &'a str,
+    context: &FutureGeneratorContext<Result<DumpItem<'a>, StorageError>>,
+) {
+    dump_slice(string.as_bytes(), context).await;
+}
+
+async fn restore_string(reader: &mut (impl AsyncRead + Unpin)) -> Result<String, RestoreError> {
+    let buf = restore_slice(reader).await?;
+    String::from_utf8(buf).map_err(Into::into)
+}
+
+async fn dump_slice<'a>(
+    slice: &'a [u8],
+    context: &FutureGeneratorContext<Result<DumpItem<'a>, StorageError>>,
+) {
+    dump_u64(slice.len() as u64, context).await;
+    context.yield_(Ok(DumpItem::Slice(slice))).await;
+}
+
+async fn restore_slice(reader: &mut (impl AsyncRead + Unpin)) -> Result<Vec<u8>, RestoreError> {
+    let len = restore_u64(reader).await?;
+    let mut buf = vec![0u8; len as usize];
+    reader.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ops::Bound, path::Path, pin::pin};
+
+    use super::*;
+
+    use dozer_types::tonic::async_trait;
+    use lmdb::WriteFlags;
+    use tempdir::TempDir;
+    use tokio::io::AsyncWriteExt;
+
+    use crate::{
+        generator::{Generator, IntoGenerator},
+        lmdb_database::raw_iterator::RawIterator,
+        lmdb_storage::{LmdbEnvironmentManager, LmdbEnvironmentOptions},
+    };
+
+    fn create_env() -> (TempDir, RwLmdbEnvironment) {
+        let temp_dir = TempDir::new("test").unwrap();
+        let env = LmdbEnvironmentManager::create_rw(
+            temp_dir.path(),
+            "dump_tests_env",
+            LmdbEnvironmentOptions::default(),
+        )
+        .unwrap();
+        (temp_dir, env)
+    }
+
+    fn insert_data(env: &mut RwLmdbEnvironment, db: Database, data: &[(&[u8], &[u8])]) {
+        let txn = env.txn_mut().unwrap();
+        for (key, value) in data {
+            txn.put(db, key, value, WriteFlags::empty()).unwrap();
+        }
+        env.commit().unwrap();
+    }
+
+    #[async_trait(?Send)]
+    pub trait Dump {
+        async fn dump<'txn, T: Transaction>(
+            &self,
+            txn: &'txn T,
+            db: Database,
+            flags: DatabaseFlags,
+            context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+        );
+    }
+
+    async fn dump_database(
+        dumper: impl Dump,
+        env: &mut RwLmdbEnvironment,
+        db: Database,
+        flags: DatabaseFlags,
+        dump_path: &Path,
+    ) {
+        let mut file = pin!(tokio::fs::File::create(dump_path).await.unwrap());
+        let txn = env.begin_txn().unwrap();
+        let txn_borrow = &txn;
+        let generator =
+            (|context| async move { dumper.dump(txn_borrow, db, flags, &context).await })
+                .into_generator();
+        for item in pin!(generator).into_iter() {
+            let item = item.unwrap();
+            file.write_all(&item).await.unwrap();
+        }
+        file.flush().await.unwrap();
+    }
+
+    #[async_trait(?Send)]
+    pub trait Restore {
+        async fn restore(
+            &self,
+            env: &mut RwLmdbEnvironment,
+            restore_name: &str,
+            flags: DatabaseFlags,
+            reader: &mut (impl AsyncRead + Unpin),
+        ) -> Result<Database, RestoreError>;
+    }
+
+    async fn restore_database(
+        restorer: impl Restore,
+        env: &mut RwLmdbEnvironment,
+        restore_name: &str,
+        flags: DatabaseFlags,
+        dump_path: &Path,
+    ) -> Database {
+        let mut file = pin!(tokio::fs::File::open(dump_path).await.unwrap());
+        restorer
+            .restore(env, restore_name, flags, &mut file)
+            .await
+            .unwrap()
+    }
+
+    async fn dump_restore_database(
+        dumper: impl Dump,
+        restorer: impl Restore,
+        env: &mut RwLmdbEnvironment,
+        db: Database,
+        flags: DatabaseFlags,
+        dump_path: &Path,
+        restore_name: &str,
+    ) -> Database {
+        dump_database(dumper, env, db, flags, dump_path).await;
+        restore_database(restorer, env, restore_name, flags, dump_path).await
+    }
+
+    fn check_data_sorted<E: LmdbEnvironment>(env: &E, db: Database, data: &[(&[u8], &[u8])]) {
+        let txn = env.begin_txn().unwrap();
+        let cursor = txn.open_ro_cursor(db).unwrap();
+        let iter = RawIterator::new(cursor, Bound::Unbounded, true).unwrap();
+        for ((key, value), result) in data.into_iter().copied().zip(iter) {
+            let (key2, value2) = result.unwrap();
+            assert_eq!(key, key2);
+            assert_eq!(value, value2);
+        }
+    }
+
+    pub async fn test_dump_restore(
+        dumper: impl Dump,
+        restorer: impl Restore,
+        flags: DatabaseFlags,
+        data: &[(&[u8], &[u8])],
+    ) {
+        // Create database.
+        let (temp_dir, mut env) = create_env();
+        let db = env
+            .create_database(Some("test_dump_restore"), flags)
+            .unwrap();
+        insert_data(&mut env, db, data);
+
+        // Do dump-restore round trip.
+        let restore_db = dump_restore_database(
+            dumper,
+            restorer,
+            &mut env,
+            db,
+            flags,
+            &temp_dir.path().join("dump"),
+            "test_dump_restore_restore",
+        )
+        .await;
+
+        // Check the restored database.
+        check_data_sorted(&env, restore_db, data);
+    }
+}

--- a/dozer-storage/src/lmdb_database/dump/no_dup.rs
+++ b/dozer-storage/src/lmdb_database/dump/no_dup.rs
@@ -1,0 +1,179 @@
+use std::ops::Bound;
+
+use dozer_types::{
+    log::{debug, trace},
+    tracing::info,
+};
+use lmdb::{Database, DatabaseFlags, Transaction, WriteFlags};
+use tokio::io::AsyncRead;
+
+use crate::{
+    errors::StorageError, generator::FutureGeneratorContext,
+    lmdb_database::raw_iterator::RawIterator, yield_return_if_err, DumpItem, RestoreError,
+    RwLmdbEnvironment,
+};
+
+use super::{
+    create_new_database, dump_array, dump_slice, dump_u64, restore_array, restore_slice,
+    restore_u64,
+};
+
+pub async fn dump<'txn, T: Transaction>(
+    txn: &'txn T,
+    db: Database,
+    flags: DatabaseFlags,
+    context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+) {
+    let count = yield_return_if_err!(context, txn.stat(db)).entries() as u64;
+    dump_u64(count, context).await;
+
+    let cursor = yield_return_if_err!(context, txn.open_ro_cursor(db));
+    let mut iter = yield_return_if_err!(context, RawIterator::new(cursor, Bound::Unbounded, true));
+
+    let key_len = if flags.contains(DatabaseFlags::INTEGER_KEY) {
+        // Dump key length only once
+        if let Some(result) = iter.next() {
+            let (key, value) = yield_return_if_err!(context, result);
+            let key_len = key.len() as u64;
+            dump_u64(key_len, context).await;
+            dump_array(key, key_len, context).await;
+            dump_slice(value, context).await;
+            Some(key_len)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    for result in iter {
+        let (key, value) = yield_return_if_err!(context, result);
+        if let Some(key_len) = key_len {
+            dump_array(key, key_len, context).await;
+        } else {
+            dump_slice(key, context).await;
+        }
+        dump_slice(value, context).await;
+    }
+}
+
+pub async fn restore<'txn, R: AsyncRead + Unpin>(
+    env: &mut RwLmdbEnvironment,
+    name: &str,
+    flags: DatabaseFlags,
+    reader: &mut R,
+) -> Result<Database, RestoreError> {
+    let db = create_new_database(env, name, flags)?;
+    info!("Created database {name} with flags {flags:?}");
+
+    let count = restore_u64(reader).await?;
+    info!("Restoring {count} items");
+
+    let key_len = if flags.contains(DatabaseFlags::INTEGER_KEY) {
+        let key_len = restore_u64(reader).await?;
+        info!("Key length is {key_len}");
+        Some(key_len)
+    } else {
+        info!("Key length is variable");
+        None
+    };
+
+    let txn = env.txn_mut()?;
+    info!("Opened transaction");
+
+    for i in 0..count {
+        let key = if let Some(key_len) = key_len {
+            restore_array(reader, key_len).await?
+        } else {
+            restore_slice(reader).await?
+        };
+        debug!("Restored key {i}");
+        trace!("Key is {key:?}");
+
+        let value = restore_slice(reader).await?;
+        debug!("Restored value {i}");
+        trace!("Value is {value:?}");
+
+        txn.put(db, &key, &value, WriteFlags::APPEND)
+            .map_err(StorageError::Lmdb)?;
+        debug!("Inserted key {i}");
+    }
+
+    env.commit()?;
+    info!("Committed transaction");
+
+    Ok(db)
+}
+
+#[cfg(test)]
+mod tests {
+    use dozer_types::tonic::async_trait;
+
+    use super::*;
+
+    use super::super::tests::*;
+
+    struct Dumper;
+
+    #[async_trait(?Send)]
+    impl Dump for Dumper {
+        async fn dump<'txn, T: Transaction>(
+            &self,
+            txn: &'txn T,
+            db: Database,
+            flags: DatabaseFlags,
+            context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+        ) {
+            dump(txn, db, flags, context).await
+        }
+    }
+
+    struct Restorer;
+
+    #[async_trait(?Send)]
+    impl Restore for Restorer {
+        async fn restore(
+            &self,
+            env: &mut RwLmdbEnvironment,
+            restore_name: &str,
+            flags: DatabaseFlags,
+            reader: &mut (impl AsyncRead + Unpin),
+        ) -> Result<Database, RestoreError> {
+            restore(env, restore_name, flags, reader).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dump_no_dup() {
+        let data: Vec<(&'static [u8], &'static [u8])> = vec![
+            (b"a", b"1"),
+            (b"aa", b"2"),
+            (b"aaa", b"3"),
+            (b"aaaa", b"4"),
+            (b"aaaaa", b"5"),
+            (b"aaaaaa", b"6"),
+            (b"aaaaaaa", b"7"),
+            (b"aaaaaaaa", b"8"),
+            (b"aaaaaaaaa", b"9"),
+            (b"aaaaaaaaaa", b"10"),
+        ];
+        test_dump_restore(Dumper, Restorer, DatabaseFlags::empty(), &data).await;
+    }
+
+    #[tokio::test]
+    async fn test_dump_no_dup_integer_key() {
+        let data: Vec<(&'static [u8], &'static [u8])> = vec![
+            (b"0000", b"1"),
+            (b"0001", b"2"),
+            (b"0002", b"3"),
+            (b"0003", b"4"),
+            (b"0004", b"5"),
+            (b"0005", b"6"),
+            (b"0006", b"7"),
+            (b"0007", b"8"),
+            (b"0008", b"9"),
+            (b"0009", b"10"),
+        ];
+        test_dump_restore(Dumper, Restorer, DatabaseFlags::empty(), &data).await;
+    }
+}

--- a/dozer-storage/src/lmdb_database/dump/no_dup.rs
+++ b/dozer-storage/src/lmdb_database/dump/no_dup.rs
@@ -136,9 +136,9 @@ mod tests {
             txn: &'txn T,
             db: Database,
             flags: DatabaseFlags,
-            context: &FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
+            context: FutureGeneratorContext<Result<DumpItem<'txn>, StorageError>>,
         ) -> Result<(), ()> {
-            dump(txn, db, flags, context).await
+            dump(txn, db, flags, &context).await
         }
     }
 

--- a/dozer-storage/src/lmdb_database/mod.rs
+++ b/dozer-storage/src/lmdb_database/mod.rs
@@ -1,6 +1,21 @@
+mod dump;
 mod iterator;
 mod lmdb_val;
 mod raw_iterator;
 
+pub use dump::{dump, restore, DumpItem, RestoreError};
 pub use iterator::{Iterator, KeyIterator, ValueIterator};
 pub use lmdb_val::{BorrowEncode, Decode, Encode, Encoded, LmdbKey, LmdbKeyType, LmdbVal};
+
+#[macro_export]
+macro_rules! yield_return_if_err {
+    ($context:ident, $expr:expr) => {
+        match $expr {
+            Ok(val) => val,
+            Err(e) => {
+                $context.yield_(Err(e.into())).await;
+                return;
+            }
+        }
+    };
+}

--- a/dozer-storage/src/lmdb_database/mod.rs
+++ b/dozer-storage/src/lmdb_database/mod.rs
@@ -3,7 +3,7 @@ mod iterator;
 mod lmdb_val;
 mod raw_iterator;
 
-pub use dump::{dump, restore, DumpItem, RestoreError};
+pub use dump::{assert_database_equal, dump, restore, DumpItem, RestoreError};
 pub use iterator::{Iterator, KeyIterator, ValueIterator};
 pub use lmdb_val::{BorrowEncode, Decode, Encode, Encoded, LmdbKey, LmdbKeyType, LmdbVal};
 
@@ -14,7 +14,7 @@ macro_rules! yield_return_if_err {
             Ok(val) => val,
             Err(e) => {
                 $context.yield_(Err(e.into())).await;
-                return;
+                return Err(());
             }
         }
     };

--- a/dozer-storage/src/lmdb_option.rs
+++ b/dozer-storage/src/lmdb_option.rs
@@ -1,5 +1,5 @@
 use dozer_types::borrow::Cow;
-use lmdb::{RwTransaction, Transaction};
+use lmdb::{Database, RwTransaction, Transaction};
 
 use crate::{
     errors::StorageError,
@@ -38,6 +38,10 @@ impl<V: LmdbVal> LmdbOption<V> {
 
     pub fn store(&self, txn: &mut RwTransaction, value: V::Encode<'_>) -> Result<(), StorageError> {
         self.0.insert_overwrite(txn, &KEY, value)
+    }
+
+    pub fn database(&self) -> Database {
+        self.0.database()
     }
 }
 

--- a/dozer-storage/src/lmdb_set.rs
+++ b/dozer-storage/src/lmdb_set.rs
@@ -1,4 +1,4 @@
-use lmdb::{RoCursor, RwTransaction, Transaction};
+use lmdb::{Database, RoCursor, RwTransaction, Transaction};
 
 use crate::{
     errors::StorageError,
@@ -65,6 +65,10 @@ impl<K: LmdbKey> LmdbSet<K> {
         txn: &'txn T,
     ) -> Result<KeyIterator<'txn, RoCursor<'txn>, K>, StorageError> {
         self.0.keys(txn)
+    }
+
+    pub fn database(&self) -> Database {
+        self.0.database()
     }
 }
 

--- a/dozer-storage/src/tests.rs
+++ b/dozer-storage/src/tests.rs
@@ -1,2 +1,1 @@
-#[cfg(test)]
 mod lmdb_sys;

--- a/dozer-tests/src/sql_tests/logic_test.rs
+++ b/dozer-tests/src/sql_tests/logic_test.rs
@@ -55,8 +55,7 @@ impl AsyncDB for Dozer {
     type Error = DozerSqlLogicTestError;
 
     async fn run(&mut self, sql: &str) -> Result<DBOutput> {
-        use std::println as info;
-        info!("SQL [{}] is running", sql);
+        println!("SQL [{}] is running", sql);
 
         let ast = SqlParser::parse_sql(&AnsiDialect {}, sql)?;
         let statement: &Statement = &ast[0];


### PR DESCRIPTION
This PR adds three functions for cache dump and restore:

- `begin_dump_txn`: Creates a `DumpTransaction` for dumping the whole cache.
- `dump`: A generator that generates zero copy data slices, which consist of the whole cache dump.
- `restore`: Restores the cache from an `AsyncRead`.

It also adds a command line utility `dozer-cache`, which can be used to count the number of records in a cache, dump a cache to a file, or restore a cache from a previous dump file.