### PR TITLE
fix: append only

### DIFF
--- a/dozer-ingestion/benches/connectors.sample.yaml
+++ b/dozer-ingestion/benches/connectors.sample.yaml
@@ -30,8 +30,8 @@
         path: ./taxi-objectstore
       tables:
         - !Table
-          name: trips
-          prefix: data
-          file_type: parquet
-          extension: .parquet
+            name: trips
+            config: !Parquet
+              path: data
+              extension: .parquet
     name: ny_taxi

--- a/dozer-ingestion/src/connectors/object_store/connector.rs
+++ b/dozer-ingestion/src/connectors/object_store/connector.rs
@@ -189,10 +189,8 @@ impl<T: DozerObjectStore> Connector for ObjectStoreConnector<T> {
 
         let updated_state = join_all(handles).await;
         let mut state_hash = HashMap::new();
-        for res in updated_state {
-            if let Ok((id, state)) = res {
-                state_hash.insert(id, state);
-            }
+        for (id, state) in updated_state.into_iter().flatten() {
+            state_hash.insert(id, state);
         }
 
         sender

--- a/dozer-ingestion/src/connectors/object_store/csv/csv_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/csv/csv_table.rs
@@ -49,7 +49,7 @@ impl<T: DozerObjectStore + Send> CsvTable<T> {
         }
     }
 
-    async fn _read(
+    async fn read(
         &self,
         id: u32,
         table: &TableInfo,
@@ -282,11 +282,11 @@ impl<T: DozerObjectStore + Send> TableWatcher for CsvTable<T> {
 
     async fn ingest(
         &self,
-        _id: usize,
-        _table: &TableInfo,
-        _sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        id: usize,
+        table: &TableInfo,
+        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
-        // self.read(id as u32, table, sender).await?;
+        self.read(id as u32, table, sender).await?;
         Ok(())
     }
 }

--- a/dozer-ingestion/src/connectors/object_store/csv/csv_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/csv/csv_table.rs
@@ -25,8 +25,8 @@ use deltalake::{
     datafusion::{datasource::listing::ListingTableUrl, prelude::SessionContext},
     Path as DeltaPath,
 };
-use tokio::task::JoinHandle;
 use dozer_types::ingestion_types::IngestionMessageKind;
+use tokio::task::JoinHandle;
 
 use crate::{
     connectors::{self, object_store::helper::map_listing_options},

--- a/dozer-ingestion/src/connectors/object_store/delta/delta_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/delta/delta_table.rs
@@ -9,7 +9,9 @@ use dozer_types::{
 };
 use futures::StreamExt;
 use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
 use tonic::async_trait;
+use dozer_types::ingestion_types::IngestionMessageKind;
 
 use crate::{
     connectors::{
@@ -124,8 +126,8 @@ impl<T: DozerObjectStore + Send> TableWatcher for DeltaTable<T> {
         &self,
         _id: usize,
         table: &TableInfo,
-        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
-    ) -> Result<(), ConnectorError> {
+        sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
+    ) -> Result<JoinHandle<()>, ConnectorError> {
         let params = self.store_config.table_params(&table.name)?;
 
         let ctx = SessionContext::new();
@@ -154,7 +156,7 @@ impl<T: DozerObjectStore + Send> TableWatcher for DeltaTable<T> {
         };
 
         let identifier = self.id as u32;
-        tokio::spawn(async move {
+        let h = tokio::spawn(async move {
             let data = ctx
                 .read_table(Arc::new(delta_table))
                 .unwrap()
@@ -202,7 +204,7 @@ impl<T: DozerObjectStore + Send> TableWatcher for DeltaTable<T> {
                         },
                     };
 
-                    if let Err(e) = sender.send(Ok(Some(evt))).await {
+                    if let Err(e) = sender.send(Ok(Some(IngestionMessageKind::OperationEvent(evt)))).await {
                         error!("Failed to send ingestion message: {}", e);
                     }
 
@@ -230,14 +232,14 @@ impl<T: DozerObjectStore + Send> TableWatcher for DeltaTable<T> {
         //     .handle_message(IngestionMessage::new_snapshotting_done(0, seq_no))
         //     .map_err(ConnectorError::IngestorError)?;
 
-        Ok(())
+        Ok(h)
     }
 
     async fn ingest(
         &self,
         _id: usize,
         _table: &TableInfo,
-        _sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        _sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
         Ok(())
     }

--- a/dozer-ingestion/src/connectors/object_store/delta/delta_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/delta/delta_table.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use deltalake::{datafusion::prelude::SessionContext, s3_storage_options};
+use dozer_types::ingestion_types::IngestionMessageKind;
 use dozer_types::{
     arrow_types::from_arrow::{map_schema_to_dozer, map_value_to_dozer_field},
     ingestion_types::DeltaConfig,
@@ -11,7 +12,6 @@ use futures::StreamExt;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use tonic::async_trait;
-use dozer_types::ingestion_types::IngestionMessageKind;
 
 use crate::{
     connectors::{
@@ -204,7 +204,10 @@ impl<T: DozerObjectStore + Send> TableWatcher for DeltaTable<T> {
                         },
                     };
 
-                    if let Err(e) = sender.send(Ok(Some(IngestionMessageKind::OperationEvent(evt)))).await {
+                    if let Err(e) = sender
+                        .send(Ok(Some(IngestionMessageKind::OperationEvent(evt))))
+                        .await
+                    {
                         error!("Failed to send ingestion message: {}", e);
                     }
 

--- a/dozer-ingestion/src/connectors/object_store/parquet/parquet_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/parquet/parquet_table.rs
@@ -10,6 +10,7 @@ use deltalake::{
     Path as DeltaPath,
 };
 
+use dozer_types::ingestion_types::IngestionMessageKind;
 use dozer_types::{
     chrono::{DateTime, Utc},
     ingestion_types::ParquetConfig,
@@ -21,7 +22,6 @@ use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use tonic::async_trait;
-use dozer_types::ingestion_types::IngestionMessageKind;
 
 use crate::{
     connectors::{

--- a/dozer-ingestion/src/connectors/object_store/parquet/parquet_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/parquet/parquet_table.rs
@@ -47,7 +47,7 @@ impl<T: DozerObjectStore + Send> ParquetTable<T> {
         }
     }
 
-    async fn _read(
+    async fn read(
         &self,
         id: u32,
         table: &TableInfo,
@@ -280,11 +280,11 @@ impl<T: DozerObjectStore + Send> TableWatcher for ParquetTable<T> {
 
     async fn ingest(
         &self,
-        _id: usize,
-        _table: &TableInfo,
-        _sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        id: usize,
+        table: &TableInfo,
+        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
-        // self.read(id as u32, table, sender).await?;
+        self.read(id as u32, table, sender).await?;
         Ok(())
     }
 }

--- a/dozer-ingestion/src/connectors/object_store/readme.md
+++ b/dozer-ingestion/src/connectors/object_store/readme.md
@@ -17,10 +17,10 @@ connections:
           bucket_name: {{ BUCKET }}
         tables:
           - !Table
-            name: userdata
-            prefix: userdata_parquet
-            file_type: parquet
-            extension: .parquet #optional
+              name: userdata
+              config: !Parquet
+                path: userdata_parquet
+                extension: .parquet #optional
 
   - db_type: ObjectStore
     name: data_local
@@ -30,7 +30,7 @@ connections:
       tables:
         - !Table
             name: taxi_data
-            prefix: taxi_data
-            file_type: csv
-            extension: .csv
+            config: !CSV
+              path: taxi_data
+              extension: .csv
 ```

--- a/dozer-ingestion/src/connectors/object_store/table_reader.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_reader.rs
@@ -104,7 +104,10 @@ impl<T: Clone + Send + Sync> TableReader<T> {
                     },
                 };
 
-                sender.send(Ok(Some(IngestionMessageKind::OperationEvent(evt)))).await.unwrap();
+                sender
+                    .send(Ok(Some(IngestionMessageKind::OperationEvent(evt))))
+                    .await
+                    .unwrap();
             }
         }
 

--- a/dozer-ingestion/src/connectors/object_store/table_reader.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_reader.rs
@@ -1,6 +1,6 @@
 use crate::connectors::object_store::adapters::DozerObjectStore;
 use crate::connectors::TableInfo;
-use crate::errors::ObjectStoreConnectorError::{RecvError, TableReaderError};
+use crate::errors::ObjectStoreConnectorError::TableReaderError;
 use crate::errors::ObjectStoreTableReaderError::{
     ColumnsSelectFailed, StreamExecutionError, TableReadFailed,
 };
@@ -12,15 +12,13 @@ use deltalake::datafusion::datasource::listing::{
 
 use deltalake::datafusion::prelude::SessionContext;
 use dozer_types::arrow_types::from_arrow::{map_schema_to_dozer, map_value_to_dozer_field};
-use dozer_types::ingestion_types::IngestionMessage;
+use dozer_types::ingestion_types::IngestionMessageKind;
 use dozer_types::log::error;
 use dozer_types::types::{Operation, Record, SchemaIdentifier};
 use futures::StreamExt;
 use std::sync::Arc;
-use tokio::sync::mpsc::{channel, Sender};
+use tokio::sync::mpsc::Sender;
 use tonic::async_trait;
-
-use super::watcher::Watcher;
 
 pub struct TableReader<T: Clone + Send + Sync> {
     pub(crate) config: T,
@@ -37,7 +35,7 @@ impl<T: Clone + Send + Sync> TableReader<T> {
         table_path: ListingTableUrl,
         listing_options: ListingOptions,
         table: &TableInfo,
-        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ObjectStoreConnectorError> {
         let resolved_schema = listing_options
             .infer_schema(&ctx.state(), &table_path)
@@ -106,7 +104,7 @@ impl<T: Clone + Send + Sync> TableReader<T> {
                     },
                 };
 
-                sender.send(Ok(Some(evt))).await.unwrap();
+                sender.send(Ok(Some(IngestionMessageKind::OperationEvent(evt)))).await.unwrap();
             }
         }
 
@@ -129,46 +127,9 @@ pub trait Reader<T> {
 impl<T: DozerObjectStore> Reader<T> for TableReader<T> {
     async fn read_tables(
         &self,
-        tables: &[TableInfo],
-        ingestor: &Ingestor,
+        _tables: &[TableInfo],
+        _ingestor: &Ingestor,
     ) -> Result<(), ConnectorError> {
-        ingestor
-            .handle_message(IngestionMessage::new_snapshotting_started(0_u64, 0))
-            .map_err(ObjectStoreConnectorError::IngestorError)?;
-
-        let mut left_tables_count = tables.len();
-        let (tx, mut rx) = channel(16);
-
-        for (id, table) in tables.iter().enumerate() {
-            self.watch(id as u32, table, tx.clone()).await.unwrap();
-        }
-
-        let mut idx = 1;
-        loop {
-            let message = rx
-                .recv()
-                .await
-                .ok_or(ConnectorError::ObjectStoreConnectorError(RecvError))??;
-            match message {
-                None => {
-                    left_tables_count -= 1;
-                    if left_tables_count == 0 {
-                        break;
-                    }
-                }
-                Some(evt) => {
-                    ingestor
-                        .handle_message(IngestionMessage::new_op(0, idx, evt))
-                        .map_err(ConnectorError::IngestorError)?;
-                    idx += 1;
-                }
-            }
-        }
-
-        ingestor
-            .handle_message(IngestionMessage::new_snapshotting_done(0, idx))
-            .map_err(ObjectStoreConnectorError::IngestorError)?;
-
         Ok(())
     }
 }

--- a/dozer-ingestion/src/connectors/object_store/table_watcher.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_watcher.rs
@@ -2,7 +2,9 @@ use crate::{
     connectors::TableInfo,
     errors::{ConnectorError, ObjectStoreConnectorError},
 };
+use std::collections::HashMap;
 
+use dozer_types::chrono::{DateTime, Utc};
 use dozer_types::ingestion_types::IngestionMessageKind;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
@@ -49,7 +51,7 @@ pub trait TableWatcher {
         id: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
-    ) -> Result<JoinHandle<()>, ConnectorError>;
+    ) -> Result<JoinHandle<(usize, HashMap<object_store::path::Path, DateTime<Utc>>)>, ConnectorError>;
 
     async fn ingest(
         &self,

--- a/dozer-ingestion/src/connectors/object_store/table_watcher.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_watcher.rs
@@ -3,10 +3,10 @@ use crate::{
     errors::{ConnectorError, ObjectStoreConnectorError},
 };
 
+use dozer_types::ingestion_types::IngestionMessageKind;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use tonic::async_trait;
-use dozer_types::ingestion_types::IngestionMessageKind;
 
 #[derive(Debug, Eq, Clone)]
 pub struct FileInfo {

--- a/dozer-ingestion/src/connectors/object_store/table_watcher.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_watcher.rs
@@ -3,9 +3,10 @@ use crate::{
     errors::{ConnectorError, ObjectStoreConnectorError},
 };
 
-use dozer_types::types::Operation;
 use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
 use tonic::async_trait;
+use dozer_types::ingestion_types::IngestionMessageKind;
 
 #[derive(Debug, Eq, Clone)]
 pub struct FileInfo {
@@ -37,7 +38,7 @@ pub trait TableWatcher {
         &self,
         id: usize,
         table: &TableInfo,
-        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
         self.ingest(id, table, sender.clone()).await?;
         Ok(())
@@ -47,13 +48,13 @@ pub trait TableWatcher {
         &self,
         id: usize,
         table: &TableInfo,
-        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
-    ) -> Result<(), ConnectorError>;
+        sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
+    ) -> Result<JoinHandle<()>, ConnectorError>;
 
     async fn ingest(
         &self,
         id: usize,
         table: &TableInfo,
-        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError>;
 }

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -1,3 +1,4 @@
+use tokio::runtime::Runtime;
 use crate::connectors::object_store::connector::ObjectStoreConnector;
 use crate::connectors::Connector;
 use crate::ingestion::{IngestionConfig, Ingestor};
@@ -146,9 +147,13 @@ async fn test_csv_read() {
         .await
         .unwrap();
 
-    tokio::spawn(async move {
-        connector.start(&ingestor, tables).await.unwrap();
-    });
+    let rt = Runtime::new().unwrap();
+    rt.block_on(
+        async move {
+            connector.start(&ingestor, tables).await.unwrap();
+        }
+    );
+
 
     let row = iterator.next();
     if let Some(IngestionMessage {

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -5,7 +5,6 @@ use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::ingestion_types::IngestionMessageKind;
 use dozer_types::ingestion_types::LocalDetails;
 use dozer_types::node::OpIdentifier;
-use tokio::runtime::Runtime;
 
 use crate::connectors::object_store::helper::map_listing_options;
 use crate::connectors::object_store::tests::test_utils::get_local_storage_config;

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -1,4 +1,3 @@
-use tokio::runtime::Runtime;
 use crate::connectors::object_store::connector::ObjectStoreConnector;
 use crate::connectors::Connector;
 use crate::ingestion::{IngestionConfig, Ingestor};
@@ -6,6 +5,7 @@ use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::ingestion_types::IngestionMessageKind;
 use dozer_types::ingestion_types::LocalDetails;
 use dozer_types::node::OpIdentifier;
+use tokio::runtime::Runtime;
 
 use crate::connectors::object_store::helper::map_listing_options;
 use crate::connectors::object_store::tests::test_utils::get_local_storage_config;
@@ -147,13 +147,9 @@ async fn test_csv_read() {
         .await
         .unwrap();
 
-    let rt = Runtime::new().unwrap();
-    rt.block_on(
-        async move {
-            connector.start(&ingestor, tables).await.unwrap();
-        }
-    );
-
+    tokio::spawn(async move {
+        connector.start(&ingestor, tables).await.unwrap();
+    });
 
     let row = iterator.next();
     if let Some(IngestionMessage {

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -90,19 +90,8 @@ async fn test_read_parquet_file() {
         panic!("Unexpected message");
     }
 
-    let row = iterator.next();
-    if let Some(IngestionMessage {
-        identifier: OpIdentifier { seq_in_tx, .. },
-        kind: IngestionMessageKind::SnapshottingDone,
-    }) = row
-    {
-        assert_eq!(seq_in_tx, 1);
-    } else {
-        panic!("Unexpected message");
-    }
-
-    let mut i = 2;
-    while i < 10 {
+    let mut i = 1;
+    while i < 9 {
         let row = iterator.next();
         if let Some(IngestionMessage {
             identifier: OpIdentifier { seq_in_tx, .. },
@@ -129,6 +118,17 @@ async fn test_read_parquet_file() {
         }
 
         i += 1;
+    }
+
+    let row = iterator.next();
+    if let Some(IngestionMessage {
+        identifier: OpIdentifier { seq_in_tx, .. },
+        kind: IngestionMessageKind::SnapshottingDone,
+    }) = row
+    {
+        assert_eq!(seq_in_tx, 9);
+    } else {
+        panic!("Unexpected message");
     }
 }
 
@@ -161,19 +161,9 @@ async fn test_csv_read() {
         panic!("Unexpected message");
     }
 
-    let row = iterator.next();
-    if let Some(IngestionMessage {
-        identifier: OpIdentifier { seq_in_tx, .. },
-        kind: IngestionMessageKind::SnapshottingDone,
-    }) = row
-    {
-        assert_eq!(seq_in_tx, 1);
-    } else {
-        panic!("Unexpected message");
-    }
-
-    let mut i = 2;
-    while i < 20 {
+    let mut i = 1;
+    while i < 21 {
+        // no. of row in the csv data
         let row = iterator.next();
         if let Some(IngestionMessage {
             identifier: OpIdentifier { seq_in_tx, .. },
@@ -205,6 +195,17 @@ async fn test_csv_read() {
         }
 
         i += 1;
+    }
+
+    let row = iterator.next();
+    if let Some(IngestionMessage {
+        identifier: OpIdentifier { seq_in_tx, .. },
+        kind: IngestionMessageKind::SnapshottingDone,
+    }) = row
+    {
+        assert_eq!(seq_in_tx, 21);
+    } else {
+        panic!("Unexpected message");
     }
 }
 

--- a/dozer-ingestion/src/connectors/object_store/watcher.rs
+++ b/dozer-ingestion/src/connectors/object_store/watcher.rs
@@ -15,8 +15,8 @@ use crate::{
     errors::{ConnectorError, ObjectStoreConnectorError, ObjectStoreObjectError},
 };
 
-use std::path::Path;
 use dozer_types::ingestion_types::IngestionMessageKind;
+use std::path::Path;
 
 use super::{adapters::DozerObjectStore, table_reader::TableReader};
 

--- a/dozer-ingestion/src/connectors/object_store/watcher.rs
+++ b/dozer-ingestion/src/connectors/object_store/watcher.rs
@@ -4,7 +4,7 @@ use deltalake::{
     datafusion::{datasource::listing::ListingTableUrl, prelude::SessionContext},
     Path as DeltaPath,
 };
-use dozer_types::{tracing::info, types::Operation};
+use dozer_types::tracing::info;
 use futures::StreamExt;
 use object_store::ObjectStore;
 use tokio::sync::mpsc::Sender;
@@ -16,6 +16,7 @@ use crate::{
 };
 
 use std::path::Path;
+use dozer_types::ingestion_types::IngestionMessageKind;
 
 use super::{adapters::DozerObjectStore, table_reader::TableReader};
 
@@ -51,7 +52,7 @@ pub trait Watcher<T> {
         &self,
         id: u32,
         table: &TableInfo,
-        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError>;
 }
 
@@ -61,7 +62,7 @@ impl<T: DozerObjectStore> Watcher<T> for TableReader<T> {
         &self,
         id: u32,
         table: &TableInfo,
-        sender: Sender<Result<Option<Operation>, ObjectStoreConnectorError>>,
+        sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
         let params = self.config.table_params(&table.name)?;
         let store = Arc::new(params.object_store);

--- a/dozer-ingestion/src/ingestion/ingestor.rs
+++ b/dozer-ingestion/src/ingestion/ingestor.rs
@@ -50,7 +50,7 @@ impl IngestionIterator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// `Ingestor` is the sender side of a spsc channel. The receiver side is `IngestionIterator`.
 ///
 /// `IngestionMessage` is the message type that is sent over the channel.

--- a/dozer-ingestion/tests/test_suite/basic.rs
+++ b/dozer-ingestion/tests/test_suite/basic.rs
@@ -74,7 +74,7 @@ pub async fn run_test_suite_basic_data_ready<T: DataReadyConnectorTest>() {
     }
 
     // There should be at least one message.
-    // assert!(num_operations > 0);
+    assert!(num_operations > 0);
 }
 
 pub async fn run_test_suite_basic_insert_only<T: InsertOnlyConnectorTest>() {

--- a/dozer-ingestion/tests/test_suite/basic.rs
+++ b/dozer-ingestion/tests/test_suite/basic.rs
@@ -74,7 +74,7 @@ pub async fn run_test_suite_basic_data_ready<T: DataReadyConnectorTest>() {
     }
 
     // There should be at least one message.
-    assert!(num_operations > 0);
+    // assert!(num_operations > 0);
 }
 
 pub async fn run_test_suite_basic_insert_only<T: InsertOnlyConnectorTest>() {

--- a/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
@@ -91,7 +91,7 @@ fn create_connector(
         }),
         tables: vec![Table {
             config: Some(TableConfig::Parquet(ParquetConfig {
-                path: format!("/{table_name}"),
+                path: table_name.to_string(),
                 extension: ".parquet".to_string(),
             })),
             name: table_name,

--- a/dozer-tests/src/e2e_tests/cases/dozer-samples-connectors-local-storage/dozer-config.yaml
+++ b/dozer-tests/src/e2e_tests/cases/dozer-samples-connectors-local-storage/dozer-config.yaml
@@ -4,10 +4,10 @@ connections:
         path: data
       tables:
         - !Table
-          name: trips
-          config: !Parquet
-            path: trips
-            extension: .parquet
+            name: trips
+            config: !Parquet
+              path: trips
+              extension: .parquet
     name: ny_taxi
 
 sql: |


### PR DESCRIPTION
when we try to uncomment the read() function and try to run both snapshot and watch in the start()
```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: ObjectStoreConnectorError(InternalDataFusionError(ObjectStore(JoinError { source: JoinError::Cancelled(Id(32)) })))'
```

when we do this

```
tokio::spawn(async move {
    connector.start(&ingestor, tables).await.unwrap();
});
```

Tokio tasks are cancelled in two situations:
You call abort on the JoinHandle.
The runtime that you spawned the task on is shut down.
If you do neither of those things, then it wont be cancelled.