### PR TITLE
Support for syntax function<Type>() in SQL

### DIFF
--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -27,6 +27,7 @@ pest_derive = "2.5.6"
 regex = "1.8.1"
 sqlparser = {git = "https://github.com/getdozer/sqlparser-rs.git" }
 uuid = {version = "1.3.0", features = ["v1", "v4", "fast-rng"]}
+bigdecimal = { version = "0.3", features = ["serde"], optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"
@@ -34,3 +35,4 @@ proptest = "1.1.0"
 
 [features]
 python = ["dozer-types/python-auto-initialize"]
+bigdecimal = ["dep:bigdecimal", "sqlparser/bigdecimal"]

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2.15"
 pest = "2.6.0"
 pest_derive = "2.5.6"
 regex = "1.8.1"
-sqlparser = "0.32.0"
+sqlparser = {git = "https://github.com/getdozer/sqlparser-rs.git" }
 uuid = {version = "1.3.0", features = ["v1", "v4", "fast-rng"]}
 
 [dev-dependencies]

--- a/dozer-sql/src/pipeline/builder.rs
+++ b/dozer-sql/src/pipeline/builder.rs
@@ -12,7 +12,7 @@ use sqlparser::ast::{Join, SetOperator, SetQuantifier, TableFactor, TableWithJoi
 
 use sqlparser::{
     ast::{Query, Select, SetExpr, Statement},
-    dialect::AnsiDialect,
+    dialect::DozerDialect,
     parser::Parser,
 };
 use std::collections::HashMap;
@@ -75,7 +75,7 @@ pub fn statement_to_pipeline(
     pipeline: &mut AppPipeline<SchemaSQLContext>,
     override_name: Option<String>,
 ) -> Result<QueryContext, PipelineError> {
-    let dialect = AnsiDialect {};
+    let dialect = DozerDialect {};
     let mut ctx = QueryContext::default();
 
     let ast = Parser::parse_sql(&dialect, sql)

--- a/dozer-sql/src/pipeline/errors.rs
+++ b/dozer-sql/src/pipeline/errors.rs
@@ -119,6 +119,9 @@ pub enum PipelineError {
     #[error("Nested Join is not supported")]
     UnsupportedNestedJoin,
 
+    #[error("Pivot is not supported")]
+    UnsupportedPivot,
+
     #[error("Table Operator: {0} is not supported")]
     UnsupportedTableOperator(String),
 
@@ -279,6 +282,9 @@ pub enum ProductError {
 
     #[error("Error in the FROM clause, UNNEST is not supported")]
     UnsupportedUnnest,
+
+    #[error("Error in the FROM clause, Pivot is not supported")]
+    UnsupportedPivot,
 }
 
 #[derive(Error, Debug)]

--- a/dozer-sql/src/pipeline/expression/builder.rs
+++ b/dozer-sql/src/pipeline/expression/builder.rs
@@ -4,8 +4,8 @@ use dozer_types::{
 };
 use sqlparser::ast::{
     BinaryOperator as SqlBinaryOperator, DataType, DateTimeField, Expr as SqlExpr, Expr, Function,
-    FunctionArg, FunctionArgExpr, Ident, TrimWhereField, UnaryOperator as SqlUnaryOperator,
-    Value as SqlValue,
+    FunctionArg, FunctionArgExpr, Ident, Interval, TrimWhereField,
+    UnaryOperator as SqlUnaryOperator, Value as SqlValue,
 };
 
 use crate::pipeline::errors::PipelineError::{
@@ -114,13 +114,13 @@ impl ExpressionBuilder {
             SqlExpr::Extract { field, expr } => {
                 self.parse_sql_extract_operator(parse_aggregations, field, expr, schema)
             }
-            SqlExpr::Interval {
+            SqlExpr::Interval(Interval {
                 value,
                 leading_field,
                 leading_precision: _,
                 last_field: _,
                 fractional_seconds_precision: _,
-            } => {
+            }) => {
                 self.parse_sql_interval_expression(parse_aggregations, value, leading_field, schema)
             }
             SqlExpr::Case {

--- a/dozer-sql/src/pipeline/expression/python_udf.rs
+++ b/dozer-sql/src/pipeline/expression/python_udf.rs
@@ -19,10 +19,9 @@ pub fn evaluate_py_udf(
     record: &Record,
 ) -> Result<Field, PipelineError> {
     let values = args
-        .iter()
-        .take(args.len() - 1)
-        .map(|arg| arg.evaluate(record, schema))
-        .collect::<Result<Vec<_>, PipelineError>>()?;
+    .iter()
+    .map(|arg| arg.evaluate(record, schema))
+    .collect::<Result<Vec<_>, PipelineError>>()?;
 
     // Get the path of the Python interpreter in your virtual environment
     let env_path = env::var("VIRTUAL_ENV").map_err(|_| {

--- a/dozer-sql/src/pipeline/expression/python_udf.rs
+++ b/dozer-sql/src/pipeline/expression/python_udf.rs
@@ -19,9 +19,9 @@ pub fn evaluate_py_udf(
     record: &Record,
 ) -> Result<Field, PipelineError> {
     let values = args
-    .iter()
-    .map(|arg| arg.evaluate(record, schema))
-    .collect::<Result<Vec<_>, PipelineError>>()?;
+        .iter()
+        .map(|arg| arg.evaluate(record, schema))
+        .collect::<Result<Vec<_>, PipelineError>>()?;
 
     // Get the path of the Python interpreter in your virtual environment
     let env_path = env::var("VIRTUAL_ENV").map_err(|_| {

--- a/dozer-sql/src/pipeline/pipeline_builder/from_builder.rs
+++ b/dozer-sql/src/pipeline/pipeline_builder/from_builder.rs
@@ -248,6 +248,7 @@ pub fn is_table_operator(
         TableFactor::TableFunction { .. } => Err(PipelineError::UnsupportedTableFunction),
         TableFactor::UNNEST { .. } => Err(PipelineError::UnsupportedUnnest),
         TableFactor::NestedJoin { .. } => Err(PipelineError::UnsupportedNestedJoin),
+        TableFactor::Pivot { .. } => Err(PipelineError::UnsupportedPivot),
     }
 }
 

--- a/dozer-sql/src/pipeline/product/table/factory.rs
+++ b/dozer-sql/src/pipeline/product/table/factory.rs
@@ -99,5 +99,8 @@ pub fn get_name_or_alias(relation: &TableFactor) -> Result<NameOrAlias, Pipeline
             }
             Ok(NameOrAlias("dozer_nested".to_string(), None))
         }
+        TableFactor::Pivot { .. } => {
+            Err(PipelineError::ProductError(ProductError::UnsupportedPivot))
+        }
     }
 }

--- a/dozer-sql/src/pipeline/tests/utils.rs
+++ b/dozer-sql/src/pipeline/tests/utils.rs
@@ -1,12 +1,12 @@
 use crate::pipeline::errors::PipelineError;
 use sqlparser::{
     ast::{Query, Select, SetExpr, Statement},
-    dialect::AnsiDialect,
+    dialect::DozerDialect,
     parser::Parser,
 };
 
 pub fn get_select(sql: &str) -> Result<Box<Select>, PipelineError> {
-    let dialect = AnsiDialect {};
+    let dialect = DozerDialect {};
 
     let ast = Parser::parse_sql(&dialect, sql).unwrap();
 

--- a/dozer-tests/Cargo.toml
+++ b/dozer-tests/Cargo.toml
@@ -49,7 +49,7 @@ dozer-core = { path = "../dozer-core" }
 dozer-sql = { path = "../dozer-sql" }
 dozer-cache = { path = "../dozer-cache" }
 
-sqlparser = "0.32.0"
+sqlparser = {git = "https://github.com/getdozer/sqlparser-rs.git" }
 rusqlite = { version = "0.28.0", features = ["bundled", "column_decltype"] }
 csv = "1.2"
 tempdir = "0.3.7"

--- a/dozer-tests/src/sql_tests/full/py_udf.test
+++ b/dozer-tests/src/sql_tests/full/py_udf.test
@@ -1,0 +1,10 @@
+statement ok
+CREATE TABLE t1 (a integer NOT NULL, b integer NOT NULL)
+
+statement ok
+INSERT INTO t1(a, b) VALUES (2, 3)
+
+query II
+SELECT py_add<float>(a), py_sum<float>(a, b) from t1
+----
+3 5

--- a/dozer-tests/src/sql_tests/logic_test.rs
+++ b/dozer-tests/src/sql_tests/logic_test.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 // use arg::SqlLogicTestArgs;
 // use clap::Parser;
 use dozer_sql::sqlparser::ast::Statement;
-use dozer_sql::sqlparser::dialect::AnsiDialect;
+use dozer_sql::sqlparser::dialect::DozerDialect;
 use dozer_sql::sqlparser::parser::Parser as SqlParser;
 use dozer_types::types::Operation;
 use error::DozerSqlLogicTestError;
@@ -57,7 +57,7 @@ impl AsyncDB for Dozer {
     async fn run(&mut self, sql: &str) -> Result<DBOutput> {
         println!("SQL [{}] is running", sql);
 
-        let ast = SqlParser::parse_sql(&AnsiDialect {}, sql)?;
+        let ast = SqlParser::parse_sql(&DozerDialect {}, sql)?;
         let statement: &Statement = &ast[0];
         match statement {
             // If sql is create table, run `source_db` to get table schema


### PR DESCRIPTION
closes #1677

The new syntax was implemented in a local fork of the `sqlparser-rs` crate with a special SQL dialect named `DozerDialect`, which is based on the ANSI dialect. 

Tests have been added as well.

/claim #1677