### PR TITLE
Fix snowflake client fetch_tables ordering

### DIFF
--- a/dozer-ingestion/src/connectors/snowflake/connection/client.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connection/client.rs
@@ -12,6 +12,7 @@ use crate::errors::SnowflakeSchemaError::{
 };
 use crate::errors::SnowflakeStreamError::TimeTravelNotAvailableError;
 use dozer_types::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use dozer_types::indexmap::IndexMap;
 use dozer_types::rust_decimal::Decimal;
 use dozer_types::types::*;
 use odbc::ffi::{SqlDataType, SQL_DATE_STRUCT, SQL_TIMESTAMP_STRUCT};
@@ -439,8 +440,8 @@ impl Client {
 
                 let schema = schema_result?;
 
-                let mut schemas: HashMap<String, Result<Schema, SnowflakeSchemaError>> =
-                    HashMap::new();
+                let mut schemas: IndexMap<String, Result<Schema, SnowflakeSchemaError>> =
+                    IndexMap::new();
                 let iterator = ResultIterator {
                     cols,
                     stmt: Some(data),
@@ -512,6 +513,15 @@ impl Client {
                         }
                     }
                 }
+
+                schemas.sort_by(|_, a, _, b| {
+                    a.as_ref()
+                        .unwrap()
+                        .identifier
+                        .unwrap()
+                        .id
+                        .cmp(&b.as_ref().unwrap().identifier.unwrap().id)
+                });
 
                 Ok(schemas
                     .into_iter()


### PR DESCRIPTION
This PR fixes random issues (due to hash map arbitrary ordering). `schemas (HashMap)` was converted into a vector, which had to be ordered in the same way as input `tables_indexes` which wasn't the case due to HashMap arbitrary ordering  and table name ordering `ORDER BY TABLE_NAME, ORDINAL_POSITION`  