### PR TITLE
feature: Store app id to context file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ db/test
 dozer-ingestion/db/test/
 Cargo.lock
 dozer-core/.data
+.dozer-cloud
 
 .vscode
 *.code-workspace

--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -24,10 +24,10 @@ pub enum CloudCommands {
     Deploy(DeployCommandArgs),
     /// Update existing application on Dozer Cloud
     Update(UpdateCommandArgs),
-    Delete(AppCommand),
+    Delete,
     List(ListCommandArgs),
-    Status(AppCommand),
-    Monitor(AppCommand),
+    Status,
+    Monitor,
     /// Inspect application logs
     Logs(LogCommandArgs),
     Login(CompanyCommand),
@@ -40,6 +40,9 @@ pub enum CloudCommands {
     /// Dozer app secrets management
     #[command(subcommand)]
     Secrets(SecretsCommand),
+    /// Dozer app secrets management
+    #[command(subcommand)]
+    App(AppCommand),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -55,9 +58,6 @@ pub fn default_num_replicas() -> i32 {
 
 #[derive(Debug, Args, Clone)]
 pub struct UpdateCommandArgs {
-    /// The id of the application to update
-    #[arg(short, long)]
-    pub app_id: String,
     /// Number of replicas to serve Dozer APIs
     #[arg(short, long)]
     pub num_replicas: Option<i32>,
@@ -68,17 +68,13 @@ pub struct CompanyCommand {
     pub company_name: String,
 }
 
-#[derive(Debug, Args, Clone)]
-pub struct AppCommand {
-    #[arg(short = 'a', long)]
-    pub app_id: String,
+#[derive(Debug, Subcommand, Clone)]
+pub enum AppCommand {
+    Use { app_id: String },
 }
 
 #[derive(Debug, Args, Clone)]
 pub struct LogCommandArgs {
-    /// The id of the application to update
-    #[arg(short, long)]
-    pub app_id: String,
     /// Whether to follow the logs
     #[arg(short, long)]
     pub follow: bool,
@@ -105,17 +101,11 @@ pub enum VersionCommand {
     Status {
         /// The version to inspect
         version: u32,
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
     /// Creates a new version of the application with the given deployment
     Create {
         /// The deployment of the application to create a new version from
         deployment: u32,
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
     /// Sets a version as the "current" version of the application
     ///
@@ -123,9 +113,6 @@ pub enum VersionCommand {
     SetCurrent {
         /// The version to set as current
         version: u32,
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
 }
 
@@ -135,9 +122,6 @@ pub enum ApiCommand {
     SetNumReplicas {
         /// The number of replicas to set
         num_replicas: i32,
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
 }
 
@@ -150,10 +134,6 @@ pub enum SecretsCommand {
 
         /// Value of secret
         value: String,
-
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
     /// Update secret value
     Update {
@@ -162,33 +142,17 @@ pub enum SecretsCommand {
 
         /// Value of secret
         value: String,
-
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
     /// Delete secret
     Delete {
         /// Name of secret
         name: String,
-
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
     /// Get secret
     Get {
         /// Name of secret
         name: String,
-
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
     },
     /// List all app secrets
-    List {
-        /// The application id.
-        #[clap(short, long)]
-        app_id: String,
-    },
+    List {},
 }

--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -40,7 +40,7 @@ pub enum CloudCommands {
     /// Dozer app secrets management
     #[command(subcommand)]
     Secrets(SecretsCommand),
-    /// Dozer app secrets management
+    /// Dozer app context management
     #[command(subcommand)]
     App(AppCommand),
 }

--- a/dozer-cli/src/cloud_app_context.rs
+++ b/dozer-cli/src/cloud_app_context.rs
@@ -1,0 +1,41 @@
+use crate::errors::CloudContextError;
+use crate::errors::CloudContextError::{FailedToGetDirectoryPath, FailedToReadAppId};
+use std::io::Write;
+use std::{env, fs};
+
+pub struct CloudAppContext {}
+
+impl CloudAppContext {
+    fn get_file_path() -> Result<String, CloudContextError> {
+        Ok(format!(
+            "{}/{}",
+            env::current_dir()?
+                .into_os_string()
+                .into_string()
+                .map_err(|_| FailedToGetDirectoryPath)?,
+            ".dozer-cloud"
+        ))
+    }
+
+    pub fn get_app_id() -> Result<String, CloudContextError> {
+        let file_path = Self::get_file_path()?;
+        let content = fs::read(file_path)?;
+        match String::from_utf8(content) {
+            Ok(app_id) => Ok(app_id),
+            Err(e) => Err(FailedToReadAppId(e)),
+        }
+    }
+
+    pub fn save_app_id(app_id: String) -> Result<(), CloudContextError> {
+        let file_path = Self::get_file_path()?;
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(file_path)?;
+
+        f.write_all(app_id.as_bytes())?;
+
+        Ok(())
+    }
+}

--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -2,6 +2,7 @@
 
 use glob::{GlobError, PatternError};
 use std::path::PathBuf;
+use std::string::FromUtf8Error;
 
 use dozer_api::{
     errors::{ApiError, AuthError, GenerationError, GrpcError},
@@ -72,6 +73,8 @@ pub enum OrchestrationError {
     DuplicateTable(String),
     #[error("No endpoints initialized in the config provided")]
     EmptyEndpoints,
+    #[error(transparent)]
+    CloudContextError(#[from] CloudContextError),
 }
 
 #[derive(Error, Debug)]
@@ -122,6 +125,9 @@ pub enum CloudError {
 
     #[error("Response header {DOZER_SERVER_NAME_HEADER} is missing")]
     MissingResponseHeader,
+
+    #[error(transparent)]
+    CloudContextError(#[from] CloudContextError),
 }
 
 #[derive(Debug, Error)]
@@ -163,8 +169,8 @@ pub enum CloudLoginError {
     #[error(transparent)]
     CloudCredentialError(#[from] CloudCredentialError),
 }
-#[derive(Debug, Error)]
 
+#[derive(Debug, Error)]
 pub enum CloudCredentialError {
     #[error(transparent)]
     SerializationError(#[from] dozer_types::serde_yaml::Error),
@@ -181,4 +187,16 @@ pub enum CloudCredentialError {
     MissingCredentialFile,
     #[error("There's no profile with given name - Please try to login again")]
     MissingProfile,
+}
+
+#[derive(Debug, Error)]
+pub enum CloudContextError {
+    #[error("Failed to create access directory: {0}")]
+    FailedToAccessDirectory(#[from] std::io::Error),
+
+    #[error("Failed to get current directory path")]
+    FailedToGetDirectoryPath,
+
+    #[error("Failed to get current directory path")]
+    FailedToReadAppId(#[from] FromUtf8Error),
 }

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -75,10 +75,9 @@ pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, Pipeline
     statement_to_pipeline(sql, &mut pipeline, None)
 }
 
-use crate::cli::cloud::AppCommand;
 #[cfg(feature = "cloud")]
 use crate::cli::cloud::{
-    Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs, UpdateCommandArgs,
+    AppCommand, Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs, UpdateCommandArgs,
 };
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -18,6 +18,8 @@ use std::{
 };
 use tokio::task::JoinHandle;
 #[cfg(feature = "cloud")]
+pub mod cloud_app_context;
+#[cfg(feature = "cloud")]
 mod cloud_helper;
 pub mod console_helper;
 #[cfg(feature = "cloud")]
@@ -52,12 +54,13 @@ pub trait CloudOrchestrator {
         -> Result<(), OrchestrationError>;
     fn update(&mut self, cloud: Cloud, update: UpdateCommandArgs)
         -> Result<(), OrchestrationError>;
-    fn delete(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;
+    fn delete(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
     fn list(&mut self, cloud: Cloud, list: ListCommandArgs) -> Result<(), OrchestrationError>;
-    fn status(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;
-    fn monitor(&mut self, cloud: Cloud, app_id: String) -> Result<(), OrchestrationError>;
+    fn status(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
+    fn monitor(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
     fn trace_logs(&mut self, cloud: Cloud, logs: LogCommandArgs) -> Result<(), OrchestrationError>;
     fn login(&mut self, cloud: Cloud, company_name: String) -> Result<(), OrchestrationError>;
+    fn set_app(&mut self, command: AppCommand) -> Result<(), OrchestrationError>;
 }
 
 // Re-exports
@@ -72,6 +75,7 @@ pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, Pipeline
     statement_to_pipeline(sql, &mut pipeline, None)
 }
 
+use crate::cli::cloud::AppCommand;
 #[cfg(feature = "cloud")]
 use crate::cli::cloud::{
     Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs, UpdateCommandArgs,

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -163,15 +163,16 @@ fn run() -> Result<(), OrchestrationError> {
             Commands::Cloud(cloud) => match cloud.command.clone() {
                 CloudCommands::Deploy(deploy) => dozer.deploy(cloud, deploy),
                 CloudCommands::List(list) => dozer.list(cloud, list),
-                CloudCommands::Status(app) => dozer.status(cloud, app.app_id),
-                CloudCommands::Monitor(app) => dozer.monitor(cloud, app.app_id),
+                CloudCommands::Status => dozer.status(cloud),
+                CloudCommands::Monitor => dozer.monitor(cloud),
                 CloudCommands::Update(update) => dozer.update(cloud, update),
-                CloudCommands::Delete(app) => dozer.delete(cloud, app.app_id),
+                CloudCommands::Delete => dozer.delete(cloud),
                 CloudCommands::Logs(logs) => dozer.trace_logs(cloud, logs),
                 CloudCommands::Version(version) => dozer.version(cloud, version),
                 CloudCommands::Api(api) => dozer.api(cloud, api),
                 CloudCommands::Login(company) => dozer.login(cloud, company.company_name),
                 CloudCommands::Secrets(_) => Ok(()),
+                CloudCommands::App(command) => dozer.set_app(command),
             },
             Commands::Init => {
                 panic!("This should not happen as it is handled in parse_and_generate");


### PR DESCRIPTION
This PR contains changes for cloud commands:
- During first deployment of app, `.dozer-cloud` file is created and app id is stored there
- Context app id can be changed with `dozer cloud app use {app_id}`
- All commands reads app id from context file instead of command args