### PR TITLE
Fix snowflake parallel running instances

### DIFF
--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -41,6 +41,7 @@ uuid = { version = "1.3.1", features = ["serde", "v4"] }
 rustls = { version = "0.21.0", features = ["dangerous_configuration"] }
 tokio-postgres-rustls = "0.10.0"
 rustls-native-certs = "0.6.2"
+rand = "0.8.5"
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -41,7 +41,7 @@ uuid = { version = "1.3.1", features = ["serde", "v4"] }
 rustls = { version = "0.21.0", features = ["dangerous_configuration"] }
 tokio-postgres-rustls = "0.10.0"
 rustls-native-certs = "0.6.2"
-rand = "0.8.5"
+rand = {version = "0.8.5", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
@@ -56,7 +56,7 @@ hex = "0.4.3"
 
 [features]
 # Defines a feature named `odbc` that does not enable any other features.
-snowflake = ["dep:odbc", "dep:include_dir"]
+snowflake = ["dep:odbc", "dep:include_dir", "dep:rand"]
 ethereum = ["dep:web3"]
 kafka = ["dep:rdkafka", "dep:schema_registry_converter"]
 

--- a/dozer-ingestion/src/connectors/snowflake/connection/client.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connection/client.rs
@@ -21,11 +21,10 @@ use odbc::{
     ColumnDescriptor, Connection, Cursor, Data, DiagnosticRecord, Executed, HasResult, NoData,
     ResultSetState, Statement,
 };
-use std::collections::HashMap;
-use std::fmt::Write;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
-
+use std::collections::HashMap;
+use std::fmt::Write;
 
 fn convert_decimal(bytes: &[u8], scale: u16) -> Result<Field, SnowflakeSchemaError> {
     let is_negative = bytes[bytes.len() - 4] == 255;
@@ -106,14 +105,14 @@ pub fn convert_data(
                         value.month as u32,
                         value.day as u32,
                     )
-                        .map_or_else(|| Err(InvalidDateError), Ok)?;
+                    .map_or_else(|| Err(InvalidDateError), Ok)?;
                     let time = NaiveTime::from_hms_nano_opt(
                         value.hour as u32,
                         value.minute as u32,
                         value.second as u32,
                         value.fraction,
                     )
-                        .map_or_else(|| Err(InvalidTimeError), Ok)?;
+                    .map_or_else(|| Err(InvalidTimeError), Ok)?;
                     Ok(Field::from(NaiveDateTime::new(date, time)))
                 }
             }
@@ -130,7 +129,7 @@ pub fn convert_data(
                         value.month as u32,
                         value.day as u32,
                     )
-                        .map_or_else(|| Err(InvalidDateError), Ok)?;
+                    .map_or_else(|| Err(InvalidDateError), Ok)?;
                     Ok(Field::from(date))
                 }
             }

--- a/dozer-ingestion/src/connectors/snowflake/connector/snowflake.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connector/snowflake.rs
@@ -128,8 +128,6 @@ async fn run(
     ingestor: &Ingestor,
     from_seq: Option<(u64, u64)>,
 ) -> Result<(), ConnectorError> {
-    let client = Client::new(&config);
-
     // SNAPSHOT part - run it when stream table doesn't exist
     let stream_client = Client::new(&config);
     let mut interval = time::interval(Duration::from_secs(5));
@@ -143,15 +141,15 @@ async fn run(
                 match from_seq {
                     None | Some((0, _)) => {
                         info!("[{}][{}] Creating new stream", name, table.name);
-                        StreamConsumer::drop_stream(&client, &table.name)?;
-                        StreamConsumer::create_stream(&client, &table.name)?;
+                        StreamConsumer::drop_stream(&stream_client, &table.name)?;
+                        StreamConsumer::create_stream(&stream_client, &table.name)?;
                     }
                     Some((lsn, seq)) => {
                         info!(
                             "[{}][{}] Continuing ingestion from {}/{}",
                             name, table.name, lsn, seq
                         );
-                        if let Ok(false) = StreamConsumer::is_stream_created(&client, &table.name) {
+                        if let Ok(false) = StreamConsumer::is_stream_created(&stream_client, &table.name) {
                             return Err(ConnectorError::SnowflakeError(
                                 SnowflakeError::SnowflakeStreamError(
                                     SnowflakeStreamError::StreamNotFound,

--- a/dozer-ingestion/src/connectors/snowflake/connector/snowflake.rs
+++ b/dozer-ingestion/src/connectors/snowflake/connector/snowflake.rs
@@ -149,7 +149,9 @@ async fn run(
                             "[{}][{}] Continuing ingestion from {}/{}",
                             name, table.name, lsn, seq
                         );
-                        if let Ok(false) = StreamConsumer::is_stream_created(&stream_client, &table.name) {
+                        if let Ok(false) =
+                            StreamConsumer::is_stream_created(&stream_client, &table.name)
+                        {
                             return Err(ConnectorError::SnowflakeError(
                                 SnowflakeError::SnowflakeStreamError(
                                     SnowflakeStreamError::StreamNotFound,

--- a/dozer-ingestion/src/connectors/snowflake/stream_consumer.rs
+++ b/dozer-ingestion/src/connectors/snowflake/stream_consumer.rs
@@ -16,12 +16,12 @@ impl StreamConsumer {
         Self {}
     }
 
-    pub fn get_stream_table_name(table_name: &str) -> String {
-        format!("dozer_{table_name}_stream")
+    pub fn get_stream_table_name(table_name: &str, client_name: &str) -> String {
+        format!("dozer_{table_name}_{client_name}_stream")
     }
 
-    pub fn get_stream_temp_table_name(table_name: &str) -> String {
-        format!("dozer_{table_name}_stream_temp")
+    pub fn get_stream_temp_table_name(table_name: &str, client_name: &str) -> String {
+        format!("dozer_{table_name}_{client_name}_stream_temp")
     }
 
     pub fn is_stream_created(client: &Client, table_name: &str) -> Result<bool, ConnectorError> {
@@ -31,7 +31,7 @@ impl StreamConsumer {
             .unwrap();
 
         client
-            .stream_exist(&conn, &Self::get_stream_table_name(table_name))
+            .stream_exist(&conn, &Self::get_stream_table_name(table_name, &client.get_name()))
             .map_err(ConnectorError::SnowflakeError)
     }
 
@@ -43,7 +43,7 @@ impl StreamConsumer {
 
         let query = format!(
             "DROP STREAM IF EXISTS {}",
-            Self::get_stream_table_name(table_name),
+            Self::get_stream_table_name(table_name, &client.get_name()),
         );
 
         client.exec(&conn, query)
@@ -57,7 +57,7 @@ impl StreamConsumer {
 
         let query = format!(
             "CREATE STREAM {} on table {} SHOW_INITIAL_ROWS = TRUE",
-            Self::get_stream_table_name(table_name),
+            Self::get_stream_table_name(table_name, &client.get_name()),
             table_name,
         );
 
@@ -66,7 +66,7 @@ impl StreamConsumer {
         if !result {
             let query = format!(
                 "CREATE STREAM {} on view {} SHOW_INITIAL_ROWS = TRUE",
-                Self::get_stream_table_name(table_name),
+                Self::get_stream_table_name(table_name, &client.get_name()),
                 table_name
             );
             client.exec(&conn, query)?;
@@ -132,8 +132,8 @@ impl StreamConsumer {
             .connect_with_connection_string(&client.get_conn_string())
             .unwrap();
 
-        let temp_table_name = Self::get_stream_temp_table_name(table_name);
-        let stream_name = Self::get_stream_table_name(table_name);
+        let temp_table_name = Self::get_stream_temp_table_name(table_name, &client.get_name());
+        let stream_name = Self::get_stream_table_name(table_name, &client.get_name());
         let temp_table_exist = client.table_exist(&conn, &temp_table_name)?;
 
         if !temp_table_exist {

--- a/dozer-ingestion/src/connectors/snowflake/stream_consumer.rs
+++ b/dozer-ingestion/src/connectors/snowflake/stream_consumer.rs
@@ -31,7 +31,10 @@ impl StreamConsumer {
             .unwrap();
 
         client
-            .stream_exist(&conn, &Self::get_stream_table_name(table_name, &client.get_name()))
+            .stream_exist(
+                &conn,
+                &Self::get_stream_table_name(table_name, &client.get_name()),
+            )
             .map_err(ConnectorError::SnowflakeError)
     }
 

--- a/dozer-ingestion/src/connectors/snowflake/test_utils.rs
+++ b/dozer-ingestion/src/connectors/snowflake/test_utils.rs
@@ -20,5 +20,8 @@ pub fn remove_streams(connection: Connection, table_name: &str) -> Result<bool, 
         .connect_with_connection_string(&client.get_conn_string())
         .unwrap();
 
-    client.drop_stream(&conn, &StreamConsumer::get_stream_table_name(table_name, &client.get_name()))
+    client.drop_stream(
+        &conn,
+        &StreamConsumer::get_stream_table_name(table_name, &client.get_name()),
+    )
 }

--- a/dozer-ingestion/src/connectors/snowflake/test_utils.rs
+++ b/dozer-ingestion/src/connectors/snowflake/test_utils.rs
@@ -20,5 +20,5 @@ pub fn remove_streams(connection: Connection, table_name: &str) -> Result<bool, 
         .connect_with_connection_string(&client.get_conn_string())
         .unwrap();
 
-    client.drop_stream(&conn, &StreamConsumer::get_stream_table_name(table_name))
+    client.drop_stream(&conn, &StreamConsumer::get_stream_table_name(table_name, &client.get_name()))
 }


### PR DESCRIPTION
This PR adds uniq random ID into stream/temp_table name to avoid conflicts running two dozer instances simultaneously 