### PR TITLE
fix: Handle rest path collision

### DIFF
--- a/dozer-api/src/rest/mod.rs
+++ b/dozer-api/src/rest/mod.rs
@@ -81,7 +81,7 @@ impl ApiServer {
     fn create_app_entry(
         security: Option<ApiSecurity>,
         cors: CorsOptions,
-        cache_endpoints: Vec<Arc<CacheEndpoint>>,
+        mut cache_endpoints: Vec<Arc<CacheEndpoint>>,
     ) -> App<
         impl ServiceFactory<
             ServiceRequest,
@@ -116,6 +116,9 @@ impl ApiServer {
             Condition::new(is_auth_configured, HttpAuthentication::bearer(validate));
 
         let cors_middleware = Self::get_cors(cors);
+
+        //reverse sort cache endpoints by path length to ensure that the most specific path is matched first
+        cache_endpoints.sort_by(|a, b| b.endpoint.path.len().cmp(&a.endpoint.path.len()));
 
         cache_endpoints
             .into_iter()

--- a/dozer-api/src/rest/tests/routes.rs
+++ b/dozer-api/src/rest/tests/routes.rs
@@ -1,14 +1,12 @@
 use std::{fmt::Debug, sync::Arc};
 
 use super::super::{ApiServer, CorsOptions};
-use crate::{
-    generator::oapi::generator::OpenApiGenerator, test_utils, CacheEndpoint,
-};
+use crate::{generator::oapi::generator::OpenApiGenerator, test_utils, CacheEndpoint};
 use actix_http::{body::MessageBody, Request};
 use actix_web::dev::{Service, ServiceResponse};
 use dozer_cache::Phase;
+use dozer_types::models::api_endpoint::ApiEndpoint;
 use dozer_types::serde_json::{json, Value};
-use dozer_types::models::api_endpoint::{ApiEndpoint};
 
 #[test]
 fn test_generate_oapi() {

--- a/dozer-api/src/rest/tests/routes.rs
+++ b/dozer-api/src/rest/tests/routes.rs
@@ -1,11 +1,14 @@
 use std::{fmt::Debug, sync::Arc};
 
 use super::super::{ApiServer, CorsOptions};
-use crate::{generator::oapi::generator::OpenApiGenerator, test_utils, CacheEndpoint};
+use crate::{
+    generator::oapi::generator::OpenApiGenerator, test_utils, CacheEndpoint,
+};
 use actix_http::{body::MessageBody, Request};
 use actix_web::dev::{Service, ServiceResponse};
 use dozer_cache::Phase;
 use dozer_types::serde_json::{json, Value};
+use dozer_types::models::api_endpoint::{ApiEndpoint};
 
 #[test]
 fn test_generate_oapi() {
@@ -199,4 +202,54 @@ async fn get_endpoint_paths_test() {
 
     let body: Vec<String> = actix_web::test::read_body_json(res).await;
     assert_eq!(body, vec![endpoint.path.clone()]);
+}
+
+#[actix_web::test]
+async fn path_collision_test() {
+    let first_endpoint = ApiEndpoint {
+        name: "films".to_string(),
+        path: "/foo".to_string(),
+        table_name: "film".to_string(),
+        ..Default::default()
+    };
+
+    let second_endpoint = ApiEndpoint {
+        name: "films_second".to_string(),
+        path: "/foo/second".to_string(),
+        table_name: "film".to_string(),
+        ..Default::default()
+    };
+
+    let api_server = ApiServer::create_app_entry(
+        None,
+        CorsOptions::Permissive,
+        vec![
+            Arc::new(
+                CacheEndpoint::open(
+                    &*test_utils::initialize_cache(&first_endpoint.name, None),
+                    Default::default(),
+                    first_endpoint.clone(),
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                CacheEndpoint::open(
+                    &*test_utils::initialize_cache(&second_endpoint.name, None),
+                    Default::default(),
+                    second_endpoint.clone(),
+                )
+                .unwrap(),
+            ),
+        ],
+    );
+    let app = actix_web::test::init_service(api_server).await;
+
+    let req = actix_web::test::TestRequest::get()
+        .uri("/foo/second/query")
+        .to_request();
+
+    let res = actix_web::test::call_service(&app, req).await;
+
+    //assert the route matched something
+    assert_ne!(res.status(), 404);
 }


### PR DESCRIPTION
https://github.com/getdozer/dozer/issues/1547

Reverse sorts rest endpoints before attaching to app so that overlapping routes are not incorrectly matched.