### PR TITLE
refactor: improve CLI experience

### DIFF
--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -18,8 +18,13 @@ pub struct Cloud {
     default_value = DEFAULT_CLOUD_TARGET_URL
     )]
     pub target_url: String,
+
+    #[arg(global = true, short)]
+    pub app_id: Option<String>,
+
     #[arg(global = true, short)]
     pub profile: Option<String>,
+
     #[command(subcommand)]
     pub command: CloudCommands,
 }
@@ -30,12 +35,14 @@ pub enum CloudCommands {
     /// Deploy application to Dozer Cloud
     Deploy(DeployCommandArgs),
     /// Dozer app context management
-    App(AppCommandsWrapper),
+    #[command(subcommand)]
+    App(AppCommand),
     /// Dozer API server management
     #[command(subcommand)]
     Api(ApiCommand),
     /// Dozer app secrets management
-    Secrets(SecretsCommandWrapper),
+    #[command(subcommand)]
+    Secrets(SecretsCommand),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -53,34 +60,13 @@ pub fn default_num_replicas() -> i32 {
 }
 
 #[derive(Debug, Args, Clone)]
-pub struct UpdateCommandArgs {
-    /// Number of replicas to serve Dozer APIs
-    #[arg(short, long)]
-    pub num_replicas: Option<i32>,
-
-    #[arg(short, value_parser = parse_key_val)]
-    pub secrets: Vec<Secret>,
-}
-
-#[derive(Debug, Args, Clone)]
 pub struct OrganisationCommand {
     #[arg(long = "organisation-name")]
     pub organisation_name: String,
 }
 
-#[derive(Debug, Args, Clone)]
-pub struct AppCommandsWrapper {
-    #[arg(global = true, short)]
-    pub app_id: Option<String>,
-
-    #[command(subcommand)]
-    pub command: AppCommand,
-}
-
 #[derive(Debug, Subcommand, Clone)]
 pub enum AppCommand {
-    /// Update existing application on Dozer Cloud
-    Update(UpdateCommandArgs),
     Delete,
     Status,
     Monitor,
@@ -89,7 +75,7 @@ pub enum AppCommand {
     /// Application version management
     #[command(subcommand)]
     Version(VersionCommand),
-    Use {
+    SetApp {
         app_id: String,
     },
     List(ListCommandArgs),
@@ -145,15 +131,6 @@ pub enum ApiCommand {
         /// The number of replicas to set
         num_replicas: i32,
     },
-}
-
-#[derive(Debug, Args, Clone)]
-pub struct SecretsCommandWrapper {
-    #[arg(global = true, short)]
-    pub app_id: Option<String>,
-
-    #[command(subcommand)]
-    pub command: SecretsCommand,
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -8,6 +8,9 @@ use std::error::Error;
 #[derive(Debug, Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub struct Cloud {
+    // Workaround to hide config_path from help in cloud
+    #[arg(hide = true)]
+    pub config_path: Option<String>,
     #[arg(
     global = true,
     short = 't',
@@ -27,14 +30,12 @@ pub enum CloudCommands {
     /// Deploy application to Dozer Cloud
     Deploy(DeployCommandArgs),
     /// Dozer app context management
-    #[command(subcommand)]
-    App(AppCommand),
+    App(AppCommandsWrapper),
     /// Dozer API server management
     #[command(subcommand)]
     Api(ApiCommand),
     /// Dozer app secrets management
-    #[command(subcommand)]
-    Secrets(SecretsCommand),
+    Secrets(SecretsCommandWrapper),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -60,10 +61,20 @@ pub struct UpdateCommandArgs {
     #[arg(short, value_parser = parse_key_val)]
     pub secrets: Vec<Secret>,
 }
+
 #[derive(Debug, Args, Clone)]
 pub struct OrganisationCommand {
     #[arg(long = "organisation-name")]
     pub organisation_name: String,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct AppCommandsWrapper {
+    #[arg(global = true, short)]
+    pub app_id: Option<String>,
+
+    #[command(subcommand)]
+    pub command: AppCommand,
 }
 
 #[derive(Debug, Subcommand, Clone)]
@@ -134,6 +145,15 @@ pub enum ApiCommand {
         /// The number of replicas to set
         num_replicas: i32,
     },
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct SecretsCommandWrapper {
+    #[arg(global = true, short)]
+    pub app_id: Option<String>,
+
+    #[command(subcommand)]
+    pub command: SecretsCommand,
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -15,7 +15,7 @@ pub struct Cloud {
     default_value = DEFAULT_CLOUD_TARGET_URL
     )]
     pub target_url: String,
-    #[arg(global = true, long)]
+    #[arg(global = true, short)]
     pub profile: Option<String>,
     #[command(subcommand)]
     pub command: CloudCommands,
@@ -23,7 +23,7 @@ pub struct Cloud {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum CloudCommands {
-    Login(CompanyCommand),
+    Login(OrganisationCommand),
     /// Deploy application to Dozer Cloud
     Deploy(DeployCommandArgs),
     /// Dozer app context management
@@ -61,9 +61,9 @@ pub struct UpdateCommandArgs {
     pub secrets: Vec<Secret>,
 }
 #[derive(Debug, Args, Clone)]
-pub struct CompanyCommand {
-    #[arg(long = "company-name")]
-    pub company_name: String,
+pub struct OrganisationCommand {
+    #[arg(long = "organisation-name")]
+    pub organisation_name: String,
 }
 
 #[derive(Debug, Subcommand, Clone)]

--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -35,8 +35,18 @@ pub enum CloudCommands {
     /// Deploy application to Dozer Cloud
     Deploy(DeployCommandArgs),
     /// Dozer app context management
+    Delete,
+    Status,
+    Monitor,
+    /// Inspect application logs
+    Logs(LogCommandArgs),
+    /// Application version management
     #[command(subcommand)]
-    App(AppCommand),
+    Version(VersionCommand),
+    SetApp {
+        app_id: String,
+    },
+    List(ListCommandArgs),
     /// Dozer API server management
     #[command(subcommand)]
     Api(ApiCommand),
@@ -63,22 +73,6 @@ pub fn default_num_replicas() -> i32 {
 pub struct OrganisationCommand {
     #[arg(long = "organisation-name")]
     pub organisation_name: String,
-}
-
-#[derive(Debug, Subcommand, Clone)]
-pub enum AppCommand {
-    Delete,
-    Status,
-    Monitor,
-    /// Inspect application logs
-    Logs(LogCommandArgs),
-    /// Application version management
-    #[command(subcommand)]
-    Version(VersionCommand),
-    SetApp {
-        app_id: String,
-    },
-    List(ListCommandArgs),
 }
 
 #[derive(Debug, Args, Clone)]

--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -23,29 +23,18 @@ pub struct Cloud {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum CloudCommands {
+    Login(CompanyCommand),
     /// Deploy application to Dozer Cloud
     Deploy(DeployCommandArgs),
-    /// Update existing application on Dozer Cloud
-    Update(UpdateCommandArgs),
-    Delete,
-    List(ListCommandArgs),
-    Status,
-    Monitor,
-    /// Inspect application logs
-    Logs(LogCommandArgs),
-    Login(CompanyCommand),
-    /// Application version management
+    /// Dozer app context management
     #[command(subcommand)]
-    Version(VersionCommand),
+    App(AppCommand),
     /// Dozer API server management
     #[command(subcommand)]
     Api(ApiCommand),
     /// Dozer app secrets management
     #[command(subcommand)]
     Secrets(SecretsCommand),
-    /// Dozer app context management
-    #[command(subcommand)]
-    App(AppCommand),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -79,7 +68,20 @@ pub struct CompanyCommand {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum AppCommand {
-    Use { app_id: String },
+    /// Update existing application on Dozer Cloud
+    Update(UpdateCommandArgs),
+    Delete,
+    Status,
+    Monitor,
+    /// Inspect application logs
+    Logs(LogCommandArgs),
+    /// Application version management
+    #[command(subcommand)]
+    Version(VersionCommand),
+    Use {
+        app_id: String,
+    },
+    List(ListCommandArgs),
 }
 
 #[derive(Debug, Args, Clone)]

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -22,8 +22,6 @@ pub struct Cli {
     pub config_path: String,
     #[arg(global = true, long)]
     pub config_token: Option<String>,
-    #[arg(global = true, short = 'e', long, default_value = None)]
-    pub err_threshold: Option<u32>,
 
     #[clap(subcommand)]
     pub cmd: Option<Commands>,

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -37,10 +37,16 @@ pub enum Commands {
         about = "Initialize and lock schema definitions. Once initialized, schemas cannot be changed"
     )]
     Build(Build),
-    #[command(about = "Run App Server")]
+    #[command(about = "Run App Server", hide = true)]
     App(App),
-    #[command(about = "Run Api Server")]
+    #[command(about = "Run Api Server", hide = true)]
     Api(Api),
+    #[command(about = "Run App or Api Server")]
+    Run(Run),
+    #[command(about = "Show Sources")]
+    Connectors(ConnectorCommand),
+    #[command(about = "Change security settings")]
+    Security(Security),
     #[cfg(feature = "cloud")]
     #[command(about = "Deploy cloud applications")]
     Cloud(Cloud),
@@ -58,6 +64,37 @@ pub struct Api {
 pub struct Build {
     #[arg(short = 'f')]
     pub force: Option<Option<String>>,
+}
+
+#[derive(Debug, Args)]
+pub struct Run {
+    #[command(subcommand)]
+    pub command: RunCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RunCommands {
+    Api,
+    App,
+}
+
+#[derive(Debug, Args)]
+pub struct Security {
+    #[command(subcommand)]
+    pub command: SecurityCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SecurityCommands {
+    #[command(
+        author,
+        version,
+        about = "Generate master token",
+        long_about = "Master Token can be used to create other run time tokens \
+        that encapsulate different permissions.",
+        alias = "nx"
+    )]
+    GenerateToken,
 }
 
 #[derive(Debug, Args)]
@@ -93,8 +130,6 @@ pub enum ApiCommands {
 #[derive(Debug, Subcommand)]
 pub enum AppCommands {
     Run,
-    #[command(about = "Show Sources")]
-    Connectors(ConnectorCommand),
 }
 
 #[derive(Debug, Args)]

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -34,7 +34,8 @@ pub enum Commands {
     #[command(about = "Clean home directory")]
     Clean,
     #[command(
-        about = "Initialize and lock schema definitions. Once initialized, schemas cannot be changed"
+        about = "Initialize and lock schema definitions. Once initialized, schemas cannot be changed",
+        alias = "migrate"
     )]
     Build(Build),
     #[command(about = "Run App Server", hide = true)]

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -38,16 +38,14 @@ pub enum Commands {
     #[command(
         about = "Initialize and lock schema definitions. Once initialized, schemas cannot be changed"
     )]
-    Migrate(Migrate),
+    Build(Build),
+    #[command(about = "Run App Server")]
+    App(App),
+    #[command(about = "Run Api Server")]
+    Api(Api),
     #[cfg(feature = "cloud")]
     #[command(about = "Deploy cloud applications")]
     Cloud(Cloud),
-    #[command(about = "Run Api Server")]
-    Api(Api),
-    #[command(about = "Run App Server")]
-    App(App),
-    #[command(about = "Show Sources")]
-    Connector(Connector),
 }
 
 #[derive(Debug, Args)]
@@ -59,7 +57,7 @@ pub struct Api {
 
 #[derive(Debug, Args)]
 #[command(args_conflicts_with_subcommands = true)]
-pub struct Migrate {
+pub struct Build {
     #[arg(short = 'f')]
     pub force: Option<Option<String>>,
 }
@@ -81,13 +79,6 @@ pub struct App {
     pub command: AppCommands,
 }
 
-#[derive(Debug, Args)]
-#[command(args_conflicts_with_subcommands = true)]
-pub struct Connector {
-    #[command(subcommand)]
-    pub command: ConnectorCommands,
-}
-
 #[derive(Debug, Subcommand)]
 pub enum ApiCommands {
     Run,
@@ -104,6 +95,8 @@ pub enum ApiCommands {
 #[derive(Debug, Subcommand)]
 pub enum AppCommands {
     Run,
+    #[command(subcommand, about = "Show Sources")]
+    Connectors,
 }
 
 #[derive(Debug, Subcommand)]

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -93,11 +93,12 @@ pub enum ApiCommands {
 #[derive(Debug, Subcommand)]
 pub enum AppCommands {
     Run,
-    #[command(subcommand, about = "Show Sources")]
-    Connectors,
+    #[command(about = "Show Sources")]
+    Connectors(ConnectorCommand),
 }
 
-#[derive(Debug, Subcommand)]
-pub enum ConnectorCommands {
-    Ls,
+#[derive(Debug, Args)]
+pub struct ConnectorCommand {
+    #[arg(short = 'f')]
+    pub filter: Option<String>,
 }

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -20,7 +20,7 @@ pub struct Cli {
         default_value = DEFAULT_CONFIG_PATH
     )]
     pub config_path: String,
-    #[arg(global = true, long)]
+    #[arg(global = true, long, hide = true)]
     pub config_token: Option<String>,
 
     #[clap(subcommand)]

--- a/dozer-cli/src/cloud_app_context.rs
+++ b/dozer-cli/src/cloud_app_context.rs
@@ -1,7 +1,10 @@
 use crate::errors::CloudContextError;
 use crate::errors::CloudContextError::{
-    ContextFileNotFound, FailedToGetDirectoryPath, FailedToReadAppId,
+    AppIdNotFound, ContextFileNotFound, FailedToGetDirectoryPath, FailedToReadAppId,
 };
+use dozer_types::models::app_config::Config;
+use dozer_types::models::cloud::Cloud;
+use dozer_types::serde_yaml;
 use std::io::Write;
 use std::{env, fs};
 
@@ -15,7 +18,7 @@ impl CloudAppContext {
                 .into_os_string()
                 .into_string()
                 .map_err(|_| FailedToGetDirectoryPath)?,
-            ".dozer-cloud"
+            "dozer-cloud.yaml"
         ))
     }
 
@@ -25,7 +28,10 @@ impl CloudAppContext {
             Ok(_) => {
                 let content = fs::read(file_path)?;
                 match String::from_utf8(content) {
-                    Ok(app_id) => Ok(app_id),
+                    Ok(app_id) => {
+                        let c: Config = serde_yaml::from_str(&app_id).map_err(|_| AppIdNotFound)?;
+                        c.cloud.ok_or(AppIdNotFound)?.app_id.ok_or(AppIdNotFound)
+                    }
                     Err(e) => Err(FailedToReadAppId(e)),
                 }
             }
@@ -41,7 +47,16 @@ impl CloudAppContext {
             .truncate(true)
             .open(file_path)?;
 
-        f.write_all(app_id.as_bytes())?;
+        let config = Config {
+            cloud: Some(Cloud {
+                app_id: Some(app_id),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let config_string = serde_yaml::to_string(&config).unwrap();
+        f.write_all(config_string.as_bytes())?;
 
         Ok(())
     }

--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -31,8 +31,8 @@ pub enum OrchestrationError {
     CloudLoginFailed(#[from] CloudLoginError),
     #[error("Credential Error: {0}")]
     CredentialError(#[from] CloudCredentialError),
-    #[error("Failed to migrate: {0}")]
-    MigrateFailed(#[from] MigrationError),
+    #[error("Failed to build: {0}")]
+    BuildFailed(#[from] BuildError),
     #[error("Failed to generate token: {0}")]
     GenerateTokenFailed(#[source] AuthError),
     #[error("Missing api config or security input")]
@@ -45,7 +45,7 @@ pub enum OrchestrationError {
     GrpcServerFailed(#[from] GrpcError),
     #[error("Failed to initialize internal server: {0}")]
     InternalServerFailed(#[source] tonic::transport::Error),
-    #[error("{0}: Failed to initialize cache. Have you run `dozer migrate`?")]
+    #[error("{0}: Failed to initialize cache. Have you run `dozer build`?")]
     CacheInitFailed(#[source] CacheError),
     #[error("Failed to build cache from log: {0}")]
     CacheBuildFailed(#[source] CacheError),
@@ -131,7 +131,7 @@ pub enum CloudError {
 }
 
 #[derive(Debug, Error)]
-pub enum MigrationError {
+pub enum BuildError {
     #[error("Got mismatching primary key for `{endpoint_name}`. Expected: `{expected:?}`, got: `{actual:?}`")]
     MismatchPrimaryKey {
         endpoint_name: String,

--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -202,4 +202,7 @@ pub enum CloudContextError {
 
     #[error("Context file not found. You need to run \"deploy\" or \"app use\" first")]
     ContextFileNotFound,
+
+    #[error("App id not found in configuration")]
+    AppIdNotFound,
 }

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -52,26 +52,16 @@ pub trait Orchestrator {
 pub trait CloudOrchestrator {
     fn deploy(&mut self, cloud: Cloud, deploy: DeployCommandArgs)
         -> Result<(), OrchestrationError>;
-    fn delete(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
+    fn delete(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
     fn list(&mut self, cloud: Cloud, list: ListCommandArgs) -> Result<(), OrchestrationError>;
-    fn status(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
-    fn monitor(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
-    fn trace_logs(
-        &mut self,
-        cloud: Cloud,
-        logs: LogCommandArgs,
-        app_id: Option<String>,
-    ) -> Result<(), OrchestrationError>;
+    fn status(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
+    fn monitor(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
+    fn trace_logs(&mut self, cloud: Cloud, logs: LogCommandArgs) -> Result<(), OrchestrationError>;
     fn login(&mut self, cloud: Cloud, company_name: String) -> Result<(), OrchestrationError>;
     fn execute_secrets_command(
         &mut self,
         cloud: Cloud,
         command: SecretsCommand,
-    ) -> Result<(), OrchestrationError>;
-    fn execute_app_command(
-        &mut self,
-        cloud: Cloud,
-        command: AppCommand,
     ) -> Result<(), OrchestrationError>;
 }
 
@@ -89,7 +79,7 @@ pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, Pipeline
 
 #[cfg(feature = "cloud")]
 use crate::cli::cloud::{
-    AppCommand, Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs, SecretsCommand,
+    Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs, SecretsCommand,
 };
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -96,7 +96,7 @@ pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, Pipeline
 #[cfg(feature = "cloud")]
 use crate::cli::cloud::{
     AppCommandsWrapper, Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs,
-    UpdateCommandArgs, SecretsCommandWrapper
+    SecretsCommandWrapper, UpdateCommandArgs,
 };
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -52,12 +52,6 @@ pub trait Orchestrator {
 pub trait CloudOrchestrator {
     fn deploy(&mut self, cloud: Cloud, deploy: DeployCommandArgs)
         -> Result<(), OrchestrationError>;
-    fn update(
-        &mut self,
-        cloud: Cloud,
-        update: UpdateCommandArgs,
-        app_id: Option<String>,
-    ) -> Result<(), OrchestrationError>;
     fn delete(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
     fn list(&mut self, cloud: Cloud, list: ListCommandArgs) -> Result<(), OrchestrationError>;
     fn status(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
@@ -72,12 +66,12 @@ pub trait CloudOrchestrator {
     fn execute_secrets_command(
         &mut self,
         cloud: Cloud,
-        command: SecretsCommandWrapper,
+        command: SecretsCommand,
     ) -> Result<(), OrchestrationError>;
     fn execute_app_command(
         &mut self,
         cloud: Cloud,
-        command: AppCommandsWrapper,
+        command: AppCommand,
     ) -> Result<(), OrchestrationError>;
 }
 
@@ -93,11 +87,9 @@ pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, Pipeline
     statement_to_pipeline(sql, &mut pipeline, None)
 }
 
+use crate::cli::cloud::{AppCommand, SecretsCommand};
 #[cfg(feature = "cloud")]
-use crate::cli::cloud::{
-    AppCommandsWrapper, Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs,
-    SecretsCommandWrapper, UpdateCommandArgs,
-};
+use crate::cli::cloud::{Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs};
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;
 

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -27,7 +27,7 @@ mod progress_printer;
 mod utils;
 
 pub trait Orchestrator {
-    fn migrate(&mut self, force: bool) -> Result<(), OrchestrationError>;
+    fn build(&mut self, force: bool) -> Result<(), OrchestrationError>;
     fn clean(&mut self) -> Result<(), OrchestrationError>;
     fn run_all(
         &mut self,

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -52,23 +52,32 @@ pub trait Orchestrator {
 pub trait CloudOrchestrator {
     fn deploy(&mut self, cloud: Cloud, deploy: DeployCommandArgs)
         -> Result<(), OrchestrationError>;
-    fn update(&mut self, cloud: Cloud, update: UpdateCommandArgs)
-        -> Result<(), OrchestrationError>;
-    fn delete(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
+    fn update(
+        &mut self,
+        cloud: Cloud,
+        update: UpdateCommandArgs,
+        app_id: Option<String>,
+    ) -> Result<(), OrchestrationError>;
+    fn delete(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
     fn list(&mut self, cloud: Cloud, list: ListCommandArgs) -> Result<(), OrchestrationError>;
-    fn status(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
-    fn monitor(&mut self, cloud: Cloud) -> Result<(), OrchestrationError>;
-    fn trace_logs(&mut self, cloud: Cloud, logs: LogCommandArgs) -> Result<(), OrchestrationError>;
+    fn status(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
+    fn monitor(&mut self, cloud: Cloud, app_id: Option<String>) -> Result<(), OrchestrationError>;
+    fn trace_logs(
+        &mut self,
+        cloud: Cloud,
+        logs: LogCommandArgs,
+        app_id: Option<String>,
+    ) -> Result<(), OrchestrationError>;
     fn login(&mut self, cloud: Cloud, company_name: String) -> Result<(), OrchestrationError>;
     fn execute_secrets_command(
         &mut self,
         cloud: Cloud,
-        command: SecretsCommand,
+        command: SecretsCommandWrapper,
     ) -> Result<(), OrchestrationError>;
     fn execute_app_command(
         &mut self,
         cloud: Cloud,
-        command: AppCommand,
+        command: AppCommandsWrapper,
     ) -> Result<(), OrchestrationError>;
 }
 
@@ -86,8 +95,8 @@ pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, Pipeline
 
 #[cfg(feature = "cloud")]
 use crate::cli::cloud::{
-    AppCommand, Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs, SecretsCommand,
-    UpdateCommandArgs,
+    AppCommandsWrapper, Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs,
+    UpdateCommandArgs, SecretsCommandWrapper
 };
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -87,9 +87,10 @@ pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, Pipeline
     statement_to_pipeline(sql, &mut pipeline, None)
 }
 
-use crate::cli::cloud::{AppCommand, SecretsCommand};
 #[cfg(feature = "cloud")]
-use crate::cli::cloud::{Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs};
+use crate::cli::cloud::{
+    AppCommand, Cloud, DeployCommandArgs, ListCommandArgs, LogCommandArgs, SecretsCommand,
+};
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;
 

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -65,7 +65,11 @@ pub trait CloudOrchestrator {
         cloud: Cloud,
         command: SecretsCommand,
     ) -> Result<(), OrchestrationError>;
-    fn set_app(&mut self, command: AppCommand) -> Result<(), OrchestrationError>;
+    fn execute_app_command(
+        &mut self,
+        cloud: Cloud,
+        command: AppCommand,
+    ) -> Result<(), OrchestrationError>;
 }
 
 // Re-exports

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -147,7 +147,7 @@ fn run() -> Result<(), OrchestrationError> {
                 AppCommands::Run => {
                     render_logo();
 
-                    dozer.run_apps(shutdown_receiver, None, cli.err_threshold)
+                    dozer.run_apps(shutdown_receiver, None, None)
                 }
                 AppCommands::Connectors => list_sources(&cli.config_path, cli.config_token),
             },
@@ -172,7 +172,7 @@ fn run() -> Result<(), OrchestrationError> {
     } else {
         render_logo();
 
-        dozer.run_all(shutdown_receiver, cli.err_threshold)
+        dozer.run_all(shutdown_receiver, None)
     }
 }
 

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 #[cfg(feature = "cloud")]
 use dozer_cli::cli::cloud::CloudCommands;
 use dozer_cli::cli::generate_config_repl;
-use dozer_cli::cli::types::{ApiCommands, AppCommands, Cli, Commands};
+use dozer_cli::cli::types::{ApiCommands, AppCommands, Cli, Commands, ConnectorCommand};
 use dozer_cli::cli::{init_dozer, init_dozer_with_default_config, list_sources, LOGO};
 use dozer_cli::errors::{CliError, OrchestrationError};
 use dozer_cli::simple::SimpleOrchestrator;
@@ -149,7 +149,9 @@ fn run() -> Result<(), OrchestrationError> {
 
                     dozer.run_apps(shutdown_receiver, None, None)
                 }
-                AppCommands::Connectors => list_sources(&cli.config_path, cli.config_token),
+                AppCommands::Connectors(ConnectorCommand { filter }) => {
+                    list_sources(&cli.config_path, cli.config_token, filter)
+                }
             },
             Commands::Build(migrate) => {
                 let force = migrate.force.is_some();

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -14,6 +14,7 @@ use dozer_types::tracing::{error, info};
 use serde::Deserialize;
 use tokio::time;
 
+use dozer_cli::cli::cloud::OrganisationCommand;
 use std::cmp::Ordering;
 use std::process;
 use std::time::Duration;
@@ -163,7 +164,9 @@ fn run() -> Result<(), OrchestrationError> {
             Commands::Cloud(cloud) => match cloud.command.clone() {
                 CloudCommands::Deploy(deploy) => dozer.deploy(cloud, deploy),
                 CloudCommands::Api(api) => dozer.api(cloud, api),
-                CloudCommands::Login(company) => dozer.login(cloud, company.company_name),
+                CloudCommands::Login(OrganisationCommand { organisation_name }) => {
+                    dozer.login(cloud, organisation_name)
+                }
                 CloudCommands::Secrets(command) => dozer.execute_secrets_command(cloud, command),
                 CloudCommands::App(command) => dozer.execute_app_command(cloud, command),
             },

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 #[cfg(feature = "cloud")]
 use dozer_cli::cli::cloud::CloudCommands;
 use dozer_cli::cli::generate_config_repl;
-use dozer_cli::cli::types::{ApiCommands, AppCommands, Cli, Commands, ConnectorCommands};
+use dozer_cli::cli::types::{ApiCommands, AppCommands, Cli, Commands};
 use dozer_cli::cli::{init_dozer, init_dozer_with_default_config, list_sources, LOGO};
 use dozer_cli::errors::{CliError, OrchestrationError};
 use dozer_cli::simple::SimpleOrchestrator;
@@ -149,11 +149,9 @@ fn run() -> Result<(), OrchestrationError> {
 
                     dozer.run_apps(shutdown_receiver, None, cli.err_threshold)
                 }
+                AppCommands::Connectors => list_sources(&cli.config_path, cli.config_token),
             },
-            Commands::Connector(sources) => match sources.command {
-                ConnectorCommands::Ls => list_sources(&cli.config_path, cli.config_token),
-            },
-            Commands::Migrate(migrate) => {
+            Commands::Build(migrate) => {
                 let force = migrate.force.is_some();
 
                 dozer.migrate(force)
@@ -162,17 +160,10 @@ fn run() -> Result<(), OrchestrationError> {
             #[cfg(feature = "cloud")]
             Commands::Cloud(cloud) => match cloud.command.clone() {
                 CloudCommands::Deploy(deploy) => dozer.deploy(cloud, deploy),
-                CloudCommands::List(list) => dozer.list(cloud, list),
-                CloudCommands::Status => dozer.status(cloud),
-                CloudCommands::Monitor => dozer.monitor(cloud),
-                CloudCommands::Update(update) => dozer.update(cloud, update),
-                CloudCommands::Delete => dozer.delete(cloud),
-                CloudCommands::Logs(logs) => dozer.trace_logs(cloud, logs),
-                CloudCommands::Version(version) => dozer.version(cloud, version),
                 CloudCommands::Api(api) => dozer.api(cloud, api),
                 CloudCommands::Login(company) => dozer.login(cloud, company.company_name),
                 CloudCommands::Secrets(command) => dozer.execute_secrets_command(cloud, command),
-                CloudCommands::App(command) => dozer.set_app(command),
+                CloudCommands::App(command) => dozer.execute_app_command(cloud, command),
             },
             Commands::Init => {
                 panic!("This should not happen as it is handled in parse_and_generate");

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -14,6 +14,8 @@ use dozer_types::tracing::{error, info};
 use serde::Deserialize;
 use tokio::time;
 
+#[cfg(feature = "cloud")]
+use dozer_cli::cloud_app_context::CloudAppContext;
 use std::cmp::Ordering;
 use std::process;
 use std::time::Duration;
@@ -167,7 +169,17 @@ fn run() -> Result<(), OrchestrationError> {
                     dozer.login(cloud, organisation_name)
                 }
                 CloudCommands::Secrets(command) => dozer.execute_secrets_command(cloud, command),
-                CloudCommands::App(command) => dozer.execute_app_command(cloud, command),
+                CloudCommands::Delete => dozer.delete(cloud),
+                CloudCommands::Status => dozer.status(cloud),
+                CloudCommands::Monitor => dozer.monitor(cloud),
+                CloudCommands::Logs(logs) => dozer.trace_logs(cloud, logs),
+                CloudCommands::Version(version) => dozer.version(cloud, version),
+                CloudCommands::List(list) => dozer.list(cloud, list),
+                CloudCommands::SetApp { app_id } => {
+                    CloudAppContext::save_app_id(app_id.clone())?;
+                    info!("Using \"{app_id}\" app");
+                    Ok(())
+                }
             },
             Commands::Init => {
                 panic!("This should not happen as it is handled in parse_and_generate");

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 #[cfg(feature = "cloud")]
-use dozer_cli::cli::cloud::CloudCommands;
+use dozer_cli::cli::cloud::{CloudCommands, OrganisationCommand};
 use dozer_cli::cli::generate_config_repl;
 use dozer_cli::cli::types::{ApiCommands, AppCommands, Cli, Commands, ConnectorCommand};
 use dozer_cli::cli::{init_dozer, init_dozer_with_default_config, list_sources, LOGO};
@@ -14,7 +14,6 @@ use dozer_types::tracing::{error, info};
 use serde::Deserialize;
 use tokio::time;
 
-use dozer_cli::cli::cloud::OrganisationCommand;
 use std::cmp::Ordering;
 use std::process;
 use std::time::Duration;

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -155,10 +155,10 @@ fn run() -> Result<(), OrchestrationError> {
                     list_sources(&cli.config_path, cli.config_token, filter)
                 }
             },
-            Commands::Build(migrate) => {
-                let force = migrate.force.is_some();
+            Commands::Build(build) => {
+                let force = build.force.is_some();
 
-                dozer.migrate(force)
+                dozer.build(force)
             }
             Commands::Clean => dozer.clean(),
             #[cfg(feature = "cloud")]

--- a/dozer-cli/src/simple/cloud_orchestrator.rs
+++ b/dozer-cli/src/simple/cloud_orchestrator.rs
@@ -23,7 +23,7 @@ use dozer_types::grpc_types::cloud::{
 use dozer_types::grpc_types::cloud::{
     DeploymentStatus, SetCurrentVersionRequest, SetNumApiInstancesRequest, UpsertVersionRequest,
 };
-use dozer_types::log::{debug, info};
+use dozer_types::log::info;
 use dozer_types::prettytable::{row, table};
 use futures::{select, FutureExt, StreamExt};
 use tonic::transport::Endpoint;
@@ -34,7 +34,7 @@ use super::cloud::version::{get_version_status, version_is_up_to_date, version_s
 
 async fn get_cloud_client(cloud: &Cloud) -> Result<DozerCloudClient<TokenLayer>, CloudError> {
     let credential = CredentialInfo::load(cloud.profile.to_owned())?;
-    debug!("Cloud service url: {:?}", credential.target_url);
+    info!("Connecting to cloud service \"{:?}\"", credential.target_url);
     let target_url = credential.target_url.clone();
     let endpoint = Endpoint::from_shared(target_url.to_owned())?;
     let channel = Endpoint::connect(&endpoint).await?;

--- a/dozer-cli/src/simple/cloud_orchestrator.rs
+++ b/dozer-cli/src/simple/cloud_orchestrator.rs
@@ -34,10 +34,7 @@ use super::cloud::version::{get_version_status, version_is_up_to_date, version_s
 
 async fn get_cloud_client(cloud: &Cloud) -> Result<DozerCloudClient<TokenLayer>, CloudError> {
     let credential = CredentialInfo::load(cloud.profile.to_owned())?;
-    info!(
-        "Connecting to cloud service \"{:?}\"",
-        credential.target_url
-    );
+    info!("Connecting to cloud service \"{}\"", credential.target_url);
     let target_url = credential.target_url.clone();
     let endpoint = Endpoint::from_shared(target_url.to_owned())?;
     let channel = Endpoint::connect(&endpoint).await?;

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -224,7 +224,7 @@ impl Orchestrator for SimpleOrchestrator {
         Err(OrchestrationError::MissingSecurityConfig)
     }
 
-    fn migrate(&mut self, force: bool) -> Result<(), OrchestrationError> {
+    fn build(&mut self, force: bool) -> Result<(), OrchestrationError> {
         let home_dir = HomeDir::new(self.config.home_dir.as_ref(), self.config.cache_dir.clone());
 
         info!(
@@ -330,7 +330,7 @@ impl Orchestrator for SimpleOrchestrator {
 
         let (tx, rx) = channel::unbounded::<bool>();
 
-        self.migrate(false)?;
+        self.build(false)?;
 
         let mut dozer_pipeline = self.clone();
         let pipeline_thread =

--- a/dozer-ingestion/README.md
+++ b/dozer-ingestion/README.md
@@ -51,7 +51,7 @@ Detailed explanation of the data structures and method contracts can be found in
 
 Dozer uses connector methods in 3 different commands. During `connector ls` execution, dozer just fetches schemas. To get schemas we use `list_tables`, `list_columns` and `get_schemas` methods.
 
-The other two dozer commands which use connectors are `migrate` and `app run`. During both command execution, first, we validate the connection and schema using `validate_connection`, `validate_tables` and `get_schemas` methods. After that `app run` command also calls `start` method and the connector starts data ingestion.
+The other two dozer commands which use connectors are `build` and `app run`. During both command execution, first, we validate the connection and schema using `validate_connection`, `validate_tables` and `get_schemas` methods. After that `app run` command also calls `start` method and the connector starts data ingestion.
 
 ## Source configuration
 

--- a/dozer-tests/src/e2e_tests/cases/error_non_existing_primary_key/error.json
+++ b/dozer-tests/src/e2e_tests/cases/error_non_existing_primary_key/error.json
@@ -1,5 +1,5 @@
 {
-    "MigrateFailure": {
+    "BuildFailure": {
         "message": "Field not found at position id"
     }
 }

--- a/dozer-tests/src/e2e_tests/checker/mod.rs
+++ b/dozer-tests/src/e2e_tests/checker/mod.rs
@@ -27,13 +27,13 @@ pub async fn check_error_expectation(
     error_expectation: &ErrorExpectation,
 ) {
     match error_expectation {
-        ErrorExpectation::MigrateFailure { message } => {
-            check_migrate_failure(dozer_command, dozer_config_path, message.as_deref());
+        ErrorExpectation::BuildFailure { message } => {
+            check_build_failure(dozer_command, dozer_config_path, message.as_deref());
         }
     }
 }
 
-fn check_migrate_failure(
+fn check_build_failure(
     mut dozer_command: impl FnMut() -> (Command, Vec<Cleanup>),
     dozer_config_path: &str,
     message: Option<&str>,
@@ -45,7 +45,7 @@ fn check_migrate_failure(
     }
     {
         let (mut command, _cleanups) = dozer_command();
-        command.args(["--config-path", dozer_config_path, "migrate"]);
+        command.args(["--config-path", dozer_config_path, "build"]);
         assert_command_fails(command, message);
     }
 }

--- a/dozer-tests/src/e2e_tests/expectation.rs
+++ b/dozer-tests/src/e2e_tests/expectation.rs
@@ -55,7 +55,7 @@ fn find_expectations_path(case_dir: &Path) -> Option<String> {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(crate = "dozer_types::serde")]
 pub enum ErrorExpectation {
-    MigrateFailure { message: Option<String> },
+    BuildFailure { message: Option<String> },
 }
 
 impl ErrorExpectation {

--- a/dozer-tests/src/e2e_tests/runner/local.rs
+++ b/dozer-tests/src/e2e_tests/runner/local.rs
@@ -89,7 +89,7 @@ fn spawn_dozer_same_process(dozer_bin: &str, dozer_config_path: &str) -> Vec<Cle
 fn spawn_dozer_two_processes(dozer_bin: &str, dozer_config_path: &str) -> Vec<Cleanup> {
     run_command(
         dozer_bin,
-        &["--config-path", dozer_config_path, "migrate"],
+        &["--config-path", dozer_config_path, "build"],
         None,
     );
     let mut cleanups = vec![];

--- a/dozer-types/src/models/app_config.rs
+++ b/dozer-types/src/models/app_config.rs
@@ -15,27 +15,34 @@ use serde::{
 /// The configuration for the app
 pub struct Config {
     #[prost(string, tag = "2")]
+    #[serde(skip_serializing_if = "String::is_empty")]
     /// name of the app
     pub app_name: String,
 
     #[prost(string, tag = "3")]
-    #[serde(default = "default_home_dir")]
+    #[serde(skip_serializing_if = "String::is_empty", default = "default_home_dir")]
     ///directory for all process; Default: ./.dozer
     pub home_dir: String,
 
     #[prost(string, tag = "4")]
-    #[serde(default = "default_cache_dir")]
+    #[serde(
+        skip_serializing_if = "String::is_empty",
+        default = "default_cache_dir"
+    )]
     ///directory for cache. Default: ./.dozer/cache
     pub cache_dir: String,
 
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[prost(message, repeated, tag = "5")]
     /// connections to databases: Eg: Postgres, Snowflake, etc
     pub connections: Vec<Connection>,
 
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[prost(message, repeated, tag = "6")]
     /// sources to ingest data related to particular connection
     pub sources: Vec<Source>,
 
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[prost(message, repeated, tag = "7")]
     /// api endpoints to expose
     pub endpoints: Vec<ApiEndpoint>,

--- a/dozer-types/src/models/cloud.rs
+++ b/dozer-types/src/models/cloud.rs
@@ -3,9 +3,23 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, prost::Message)]
 pub struct Cloud {
     #[prost(oneof = "UpdateCurrentVersionStrategy", tags = "1,2")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub update_current_version_strategy: Option<UpdateCurrentVersionStrategy>,
     #[prost(optional, string, tag = "3")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub instance_type: Option<String>,
+    #[prost(optional, string, tag = "4")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+    #[prost(optional, string, tag = "5")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[prost(optional, uint32, tag = "6")]
+    #[serde(
+        default = "default_num_replicas",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub num_replicas: Option<u32>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, prost::Oneof)]
@@ -20,4 +34,8 @@ impl Default for UpdateCurrentVersionStrategy {
     fn default() -> Self {
         UpdateCurrentVersionStrategy::OnCreate(())
     }
+}
+
+fn default_num_replicas() -> Option<u32> {
+    Some(2)
 }


### PR DESCRIPTION
Changes:
- Reorder commands for `cloud` subcommand
- Rename `migrate` to `build`
- Add filter to `connectors` command
- `app run` and `api run` moved to `run` subcommand. Now it is accessible `run app` and `run api`
- Removed `err-threshold` argument
- Hiden `config-token`
- Renamed `company-name` to `organisation-name`
- Create cloud section in app config and store `app_id` in `dozer-cloud.yaml` file
- Combine `cloud update` and `cloud deploy` commands
