### PR TITLE
feat: Support read of configs from multiple files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,11 @@ dozer-sql/data
 workspaces/
 
 # Local configuration for development
-/dozer-config.yaml
+/dozer-config.*
 dozer-config.test.*
 log4rs.yaml
 .DS_Store
+queries
 
 .dozer/
 logs/

--- a/dozer-cli/src/cli/mod.rs
+++ b/dozer-cli/src/cli/mod.rs
@@ -4,7 +4,5 @@ mod helper;
 mod init;
 pub mod types;
 
-pub use helper::{
-    init_dozer, init_dozer_with_default_config, list_sources, load_config_from_file, LOGO,
-};
+pub use helper::{init_dozer, list_sources, load_config_from_file, LOGO};
 pub use init::{generate_config_repl, generate_connection};

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -17,9 +17,9 @@ pub struct Cli {
         global = true,
         short = 'c',
         long,
-        default_value = DEFAULT_CONFIG_PATH_PATTERNS
+        default_values = DEFAULT_CONFIG_PATH_PATTERNS
     )]
-    pub config_path: String,
+    pub config_paths: Vec<String>,
     #[arg(global = true, long, hide = true)]
     pub config_token: Option<String>,
 

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -16,7 +16,7 @@ pub struct Cli {
     #[arg(
         global = true,
         short = 'c',
-        long,
+        long = "config-path",
         default_values = DEFAULT_CONFIG_PATH_PATTERNS
     )]
     pub config_paths: Vec<String>,

--- a/dozer-cli/src/cli/types.rs
+++ b/dozer-cli/src/cli/types.rs
@@ -4,7 +4,7 @@ use super::helper::{DESCRIPTION, LOGO};
 
 #[cfg(feature = "cloud")]
 use crate::cli::cloud::Cloud;
-use dozer_types::constants::DEFAULT_CONFIG_PATH;
+use dozer_types::constants::DEFAULT_CONFIG_PATH_PATTERNS;
 
 #[derive(Parser, Debug)]
 #[command(author, version, name = "dozer")]
@@ -17,7 +17,7 @@ pub struct Cli {
         global = true,
         short = 'c',
         long,
-        default_value = DEFAULT_CONFIG_PATH
+        default_value = DEFAULT_CONFIG_PATH_PATTERNS
     )]
     pub config_path: String,
     #[arg(global = true, long, hide = true)]

--- a/dozer-cli/src/cloud_app_context.rs
+++ b/dozer-cli/src/cloud_app_context.rs
@@ -1,7 +1,5 @@
 use crate::errors::CloudContextError;
-use crate::errors::CloudContextError::{
-    AppIdNotFound, ContextFileNotFound, FailedToGetDirectoryPath, FailedToReadAppId,
-};
+use crate::errors::CloudContextError::{AppIdNotFound, FailedToGetDirectoryPath};
 use dozer_types::models::app_config::Config;
 use dozer_types::models::cloud::Cloud;
 use dozer_types::serde_yaml;
@@ -18,24 +16,14 @@ impl CloudAppContext {
                 .into_os_string()
                 .into_string()
                 .map_err(|_| FailedToGetDirectoryPath)?,
-            "dozer-cloud.yaml"
+            "dozer-config.cloud.yaml"
         ))
     }
 
-    pub fn get_app_id() -> Result<String, CloudContextError> {
-        let file_path = Self::get_file_path()?;
-        match fs::metadata(&file_path) {
-            Ok(_) => {
-                let content = fs::read(file_path)?;
-                match String::from_utf8(content) {
-                    Ok(app_id) => {
-                        let c: Config = serde_yaml::from_str(&app_id).map_err(|_| AppIdNotFound)?;
-                        c.cloud.ok_or(AppIdNotFound)?.app_id.ok_or(AppIdNotFound)
-                    }
-                    Err(e) => Err(FailedToReadAppId(e)),
-                }
-            }
-            Err(_) => Err(ContextFileNotFound),
+    pub fn get_app_id(config: &Option<Cloud>) -> Result<String, CloudContextError> {
+        match &config {
+            None => Err(AppIdNotFound),
+            Some(cloud_config) => cloud_config.app_id.clone().ok_or(AppIdNotFound),
         }
     }
 

--- a/dozer-cli/src/cloud_helper.rs
+++ b/dozer-cli/src/cloud_helper.rs
@@ -1,4 +1,6 @@
-use crate::errors::CloudError::{CannotReadConfig, CannotReadFile, WrongPatternOfConfigFilesGlob};
+use crate::errors::ConfigCombineError::{
+    CannotReadConfig, CannotReadFile, WrongPatternOfConfigFilesGlob,
+};
 use dozer_types::grpc_types::cloud::File;
 use glob::glob;
 use std::fs;

--- a/dozer-cli/src/cloud_helper.rs
+++ b/dozer-cli/src/cloud_helper.rs
@@ -1,13 +1,15 @@
 use crate::errors::ConfigCombineError::{
     CannotReadConfig, CannotReadFile, WrongPatternOfConfigFilesGlob,
 };
+use dozer_types::constants::DEFAULT_CONFIG_PATH_PATTERNS;
 use dozer_types::grpc_types::cloud::File;
 use glob::glob;
 use std::fs;
 
 pub fn list_files() -> Result<Vec<File>, crate::errors::CloudError> {
     let mut files = vec![];
-    let patterns = ["*.yaml", "*.sql", "*.json"];
+    let mut patterns = DEFAULT_CONFIG_PATH_PATTERNS.to_vec();
+    patterns.push("*.json");
     for pattern in patterns {
         let files_glob = glob(pattern).map_err(WrongPatternOfConfigFilesGlob)?;
 

--- a/dozer-cli/src/config_helper.rs
+++ b/dozer-cli/src/config_helper.rs
@@ -1,0 +1,92 @@
+use crate::errors::ConfigCombineError;
+use crate::errors::ConfigCombineError::{
+    CannotReadConfig, CannotReadFile, WrongPatternOfConfigFilesGlob,
+};
+use dozer_types::serde_yaml;
+use dozer_types::serde_yaml::mapping::Entry;
+use dozer_types::serde_yaml::Mapping;
+use glob::glob;
+use std::fs;
+
+pub fn combine_config(config_path: &str) -> Result<String, ConfigCombineError> {
+    let mut combined_yaml = serde_yaml::Value::Mapping(Mapping::new());
+    let mut sqls = vec![];
+    let patterns: Vec<_> = config_path.split(',').collect();
+    for pattern in patterns {
+        let files_glob = glob(pattern).map_err(WrongPatternOfConfigFilesGlob)?;
+
+        for entry in files_glob {
+            let path = entry.map_err(CannotReadFile)?;
+            let name = path.clone().to_str().unwrap().to_string();
+            let content =
+                fs::read_to_string(path.clone()).map_err(|e| CannotReadConfig(path, e))?;
+
+            if name.contains(".yml") || name.contains(".yaml") {
+                let yaml: serde_yaml::Value = serde_yaml::from_str(&content)
+                    .map_err(|e| ConfigCombineError::ParseYaml(name.clone(), e))?;
+                merge_yaml(yaml, &mut combined_yaml)?;
+            } else if name.contains(".sql") {
+                let sql = if content.ends_with(';') {
+                    content.clone()
+                } else {
+                    content.clone() + ";"
+                };
+
+                sqls.push(sql);
+            }
+        }
+    }
+
+    if !sqls.is_empty() {
+        let joined_sql = sqls.join(" ");
+        let yaml = serde_yaml::Value::Mapping(Mapping::from_iter([(
+            serde_yaml::Value::String("sql".into()),
+            serde_yaml::Value::String(joined_sql),
+        )]));
+        merge_yaml(yaml, &mut combined_yaml)?;
+    }
+
+    // `serde_yaml::from_value` will return deserialization error, not sure why.
+    let combined_yaml_string = serde_yaml::to_string(&combined_yaml).unwrap();
+    Ok(combined_yaml_string)
+}
+
+fn merge_yaml(
+    from: serde_yaml::Value,
+    to: &mut serde_yaml::Value,
+) -> Result<(), ConfigCombineError> {
+    match (from, to) {
+        (serde_yaml::Value::Mapping(from), serde_yaml::Value::Mapping(to)) => {
+            for (key, value) in from {
+                match to.entry(key) {
+                    Entry::Occupied(mut entry) => {
+                        merge_yaml(value, entry.get_mut())?;
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(value);
+                    }
+                }
+            }
+            Ok(())
+        }
+        (serde_yaml::Value::Sequence(from), serde_yaml::Value::Sequence(to)) => {
+            for value in from {
+                to.push(value);
+            }
+            Ok(())
+        }
+        (serde_yaml::Value::Tagged(from), serde_yaml::Value::Tagged(to)) => {
+            if from.tag != to.tag {
+                return Err(ConfigCombineError::CannotMerge {
+                    from: serde_yaml::Value::Tagged(from),
+                    to: serde_yaml::Value::Tagged(to.clone()),
+                });
+            }
+            merge_yaml(from.value, &mut to.value)
+        }
+        (from, to) => Err(ConfigCombineError::CannotMerge {
+            from,
+            to: to.clone(),
+        }),
+    }
+}

--- a/dozer-cli/src/config_helper.rs
+++ b/dozer-cli/src/config_helper.rs
@@ -9,12 +9,11 @@ use dozer_types::serde_yaml::Mapping;
 use glob::glob;
 use std::fs;
 
-pub fn combine_config(config_path: &str) -> Result<String, ConfigCombineError> {
+pub fn combine_config(config_paths: Vec<String>) -> Result<String, ConfigCombineError> {
     let mut combined_yaml = serde_yaml::Value::Mapping(Mapping::new());
     let mut sqls = vec![];
-    let patterns: Vec<_> = config_path.split(',').collect();
-    for pattern in patterns {
-        let files_glob = glob(pattern).map_err(WrongPatternOfConfigFilesGlob)?;
+    for pattern in config_paths {
+        let files_glob = glob(&pattern).map_err(WrongPatternOfConfigFilesGlob)?;
 
         for entry in files_glob {
             let path = entry.map_err(CannotReadFile)?;

--- a/dozer-cli/src/config_helper.rs
+++ b/dozer-cli/src/config_helper.rs
@@ -20,7 +20,7 @@ pub fn combine_config(config_path: &str) -> Result<String, ConfigCombineError> {
             let path = entry.map_err(CannotReadFile)?;
             match path.clone().to_str() {
                 None => {
-                    warn!("Path {:?} is not valid", path)
+                    warn!("[Config] Path {:?} is not valid", path)
                 }
                 Some(name) => {
                     let content =
@@ -38,6 +38,8 @@ pub fn combine_config(config_path: &str) -> Result<String, ConfigCombineError> {
                         };
 
                         sqls.push(sql);
+                    } else {
+                        warn!("Config file \"{name}\" extension not supported");
                     }
                 }
             }

--- a/dozer-cli/src/config_helper.rs
+++ b/dozer-cli/src/config_helper.rs
@@ -2,12 +2,12 @@ use crate::errors::ConfigCombineError;
 use crate::errors::ConfigCombineError::{
     CannotReadConfig, CannotReadFile, CannotSerializeToString, WrongPatternOfConfigFilesGlob,
 };
+use dozer_types::log::warn;
 use dozer_types::serde_yaml;
 use dozer_types::serde_yaml::mapping::Entry;
 use dozer_types::serde_yaml::Mapping;
 use glob::glob;
 use std::fs;
-use dozer_types::log::warn;
 
 pub fn combine_config(config_path: &str) -> Result<String, ConfigCombineError> {
     let mut combined_yaml = serde_yaml::Value::Mapping(Mapping::new());

--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -2,7 +2,6 @@
 
 use glob::{GlobError, PatternError};
 use std::path::PathBuf;
-use std::string::FromUtf8Error;
 
 use dozer_api::{
     errors::{ApiError, AuthError, GenerationError, GrpcError},
@@ -95,6 +94,8 @@ pub enum CliError {
     FailedToCreateTokioRuntime(#[source] std::io::Error),
     #[error("Reqwest error: {0}")]
     Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
+    ConfigCombineError(#[from] ConfigCombineError),
 }
 
 #[derive(Error, Debug)]
@@ -104,15 +105,6 @@ pub enum CloudError {
 
     #[error("Cloud service returned error: {0:?}")]
     CloudServiceError(#[from] tonic::Status),
-
-    #[error("Cannot read configuration: {0:?}")]
-    CannotReadConfig(PathBuf, #[source] std::io::Error),
-
-    #[error("Wrong pattern of config files read glob: {0}")]
-    WrongPatternOfConfigFilesGlob(#[from] PatternError),
-
-    #[error("Cannot read file: {0}")]
-    CannotReadFile(#[from] GlobError),
 
     #[error("GRPC request failed, error: {} (GRPC status {})", .0.message(), .0.code())]
     GRPCCallError(#[source] tonic::Status),
@@ -128,6 +120,33 @@ pub enum CloudError {
 
     #[error(transparent)]
     CloudContextError(#[from] CloudContextError),
+
+    #[error(transparent)]
+    ConfigCombineError(#[from] ConfigCombineError),
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigCombineError {
+    #[error("Failed to parse yaml file {0}: {1}")]
+    ParseYaml(String, #[source] serde_yaml::Error),
+
+    #[error("Cannot merge yaml value {from:?} to {to:?}")]
+    CannotMerge {
+        from: serde_yaml::Value,
+        to: serde_yaml::Value,
+    },
+
+    #[error("Failed to parse config: {0}")]
+    ParseConfig(#[source] serde_yaml::Error),
+
+    #[error("Cannot read configuration: {0:?}")]
+    CannotReadConfig(PathBuf, #[source] std::io::Error),
+
+    #[error("Wrong pattern of config files read glob: {0}")]
+    WrongPatternOfConfigFilesGlob(#[from] PatternError),
+
+    #[error("Cannot read file: {0}")]
+    CannotReadFile(#[from] GlobError),
 }
 
 #[derive(Debug, Error)]
@@ -197,12 +216,6 @@ pub enum CloudContextError {
     #[error("Failed to get current directory path")]
     FailedToGetDirectoryPath,
 
-    #[error("Failed to read cloud app id. Error: {0}")]
-    FailedToReadAppId(#[from] FromUtf8Error),
-
-    #[error("Context file not found. You need to run \"deploy\" or \"app use\" first")]
-    ContextFileNotFound,
-
-    #[error("App id not found in configuration")]
+    #[error("App id not found in configuration. You need to run \"deploy\" or \"set-app\" first")]
     AppIdNotFound,
 }

--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -78,6 +78,8 @@ pub enum OrchestrationError {
 
 #[derive(Error, Debug)]
 pub enum CliError {
+    #[error("Configuration file path not provided")]
+    ConfigurationFilePathNotProvided,
     #[error("Can't find the configuration file at: {0:?}")]
     FailedToLoadFile(String),
     #[error("Unknown Command: {0:?}")]

--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -147,6 +147,9 @@ pub enum ConfigCombineError {
 
     #[error("Cannot read file: {0}")]
     CannotReadFile(#[from] GlobError),
+
+    #[error("Cannot serialize config to string: {0}")]
+    CannotSerializeToString(#[source] serde_yaml::Error),
 }
 
 #[derive(Debug, Error)]

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -21,6 +21,7 @@ use tokio::task::JoinHandle;
 pub mod cloud_app_context;
 #[cfg(feature = "cloud")]
 mod cloud_helper;
+mod config_helper;
 pub mod console_helper;
 #[cfg(feature = "cloud")]
 mod progress_printer;

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -179,7 +179,7 @@ fn run() -> Result<(), OrchestrationError> {
                 dozer.build(force)
             }
             Commands::Connectors(ConnectorCommand { filter }) => {
-                list_sources(&cli.config_path, cli.config_token, filter)
+                list_sources(cli.config_paths, cli.config_token, filter)
             }
             Commands::Clean => dozer.clean(),
             #[cfg(feature = "cloud")]
@@ -235,7 +235,7 @@ fn parse_and_generate() -> Result<Cli, OrchestrationError> {
 
 fn init_orchestrator(cli: &Cli) -> Result<SimpleOrchestrator, CliError> {
     dozer_tracing::init_telemetry_closure(None, None, || -> Result<SimpleOrchestrator, CliError> {
-        let res = init_dozer(cli.config_path.clone(), cli.config_token.clone());
+        let res = init_dozer(cli.config_paths.clone(), cli.config_token.clone());
 
         match res {
             Ok(dozer) => {

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -5,7 +5,7 @@ use dozer_cli::cli::generate_config_repl;
 use dozer_cli::cli::types::{
     ApiCommands, AppCommands, Cli, Commands, ConnectorCommand, RunCommands, SecurityCommands,
 };
-use dozer_cli::cli::{init_dozer, init_dozer_with_default_config, list_sources, LOGO};
+use dozer_cli::cli::{init_dozer, list_sources, LOGO};
 use dozer_cli::errors::{CliError, OrchestrationError};
 use dozer_cli::simple::SimpleOrchestrator;
 #[cfg(feature = "cloud")]
@@ -243,11 +243,11 @@ fn init_orchestrator(
     is_cloud_orchestrator: bool,
 ) -> Result<SimpleOrchestrator, CliError> {
     dozer_tracing::init_telemetry_closure(None, None, || -> Result<SimpleOrchestrator, CliError> {
-        let res = if is_cloud_orchestrator {
-            init_dozer_with_default_config()
-        } else {
-            init_dozer(cli.config_path.clone(), cli.config_token.clone())
-        };
+        let res = init_dozer(
+            cli.config_path.clone(),
+            cli.config_token.clone(),
+            !is_cloud_orchestrator,
+        );
 
         match res {
             Ok(dozer) => {

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -118,12 +118,7 @@ fn run() -> Result<(), OrchestrationError> {
     // and then initializing it after reading the configuration. This is a hacky workaround, but it works.
 
     let cli = parse_and_generate()?;
-    #[cfg(feature = "cloud")]
-    let is_cloud_orchestrator = matches!(cli.cmd, Some(Commands::Cloud(_)));
-    #[cfg(not(feature = "cloud"))]
-    let is_cloud_orchestrator = false;
-
-    let mut dozer = init_orchestrator(&cli, is_cloud_orchestrator)?;
+    let mut dozer = init_orchestrator(&cli)?;
 
     let (shutdown_sender, shutdown_receiver) = shutdown::new(&dozer.runtime);
     set_ctrl_handler(shutdown_sender);
@@ -238,16 +233,9 @@ fn parse_and_generate() -> Result<Cli, OrchestrationError> {
     })
 }
 
-fn init_orchestrator(
-    cli: &Cli,
-    is_cloud_orchestrator: bool,
-) -> Result<SimpleOrchestrator, CliError> {
+fn init_orchestrator(cli: &Cli) -> Result<SimpleOrchestrator, CliError> {
     dozer_tracing::init_telemetry_closure(None, None, || -> Result<SimpleOrchestrator, CliError> {
-        let res = init_dozer(
-            cli.config_path.clone(),
-            cli.config_token.clone(),
-            !is_cloud_orchestrator,
-        );
+        let res = init_dozer(cli.config_path.clone(), cli.config_token.clone());
 
         match res {
             Ok(dozer) => {

--- a/dozer-tests/src/e2e_tests/case.rs
+++ b/dozer-tests/src/e2e_tests/case.rs
@@ -37,7 +37,7 @@ pub struct Case {
 impl Case {
     pub fn load_from_case_dir(case_dir: PathBuf, connections_dir: PathBuf) -> Self {
         let dozer_config_path = find_dozer_config_path(&case_dir);
-        let dozer_config = load_config_from_file(&dozer_config_path, false)
+        let dozer_config = load_config_from_file(&dozer_config_path)
             .unwrap_or_else(|e| panic!("Cannot read file: {}: {:?}", &dozer_config_path, e));
         let mut connections = HashMap::new();
         for connection in &dozer_config.connections {

--- a/dozer-tests/src/e2e_tests/case.rs
+++ b/dozer-tests/src/e2e_tests/case.rs
@@ -37,7 +37,7 @@ pub struct Case {
 impl Case {
     pub fn load_from_case_dir(case_dir: PathBuf, connections_dir: PathBuf) -> Self {
         let dozer_config_path = find_dozer_config_path(&case_dir);
-        let dozer_config = load_config_from_file(&dozer_config_path)
+        let dozer_config = load_config_from_file(vec![dozer_config_path.clone()])
             .unwrap_or_else(|e| panic!("Cannot read file: {}: {:?}", &dozer_config_path, e));
         let mut connections = HashMap::new();
         for connection in &dozer_config.connections {

--- a/dozer-tests/src/e2e_tests/case.rs
+++ b/dozer-tests/src/e2e_tests/case.rs
@@ -37,7 +37,7 @@ pub struct Case {
 impl Case {
     pub fn load_from_case_dir(case_dir: PathBuf, connections_dir: PathBuf) -> Self {
         let dozer_config_path = find_dozer_config_path(&case_dir);
-        let dozer_config = load_config_from_file(&dozer_config_path)
+        let dozer_config = load_config_from_file(&dozer_config_path, false)
             .unwrap_or_else(|e| panic!("Cannot read file: {}: {:?}", &dozer_config_path, e));
         let mut connections = HashMap::new();
         for connection in &dozer_config.connections {

--- a/dozer-types/src/constants.rs
+++ b/dozer-types/src/constants.rs
@@ -1,5 +1,6 @@
 pub const DEFAULT_HOME_DIR: &str = "./.dozer";
-pub const DEFAULT_CONFIG_PATH: &str = "./dozer-config.*,./queries/*.sql";
+pub const DEFAULT_CONFIG_PATH: &str = "./dozer-config.yaml";
+pub const DEFAULT_CONFIG_PATH_PATTERNS: &str = "./dozer-config.*,./queries/*.sql";
 pub const DEFAULT_CLOUD_TARGET_URL: &str = "https://api.dev.getdozer.io";
 pub const DEFAULT_QUERIES_DIRECTORY: &str = "queries";
 pub const DEFAULT_LAMBDAS_DIRECTORY: &str = "lambdas";

--- a/dozer-types/src/constants.rs
+++ b/dozer-types/src/constants.rs
@@ -1,5 +1,5 @@
 pub const DEFAULT_HOME_DIR: &str = "./.dozer";
-pub const DEFAULT_CONFIG_PATH: &str = "./dozer-config.yaml";
+pub const DEFAULT_CONFIG_PATH: &str = "./dozer-config.*,./queries/*.sql";
 pub const DEFAULT_CLOUD_TARGET_URL: &str = "https://api.dev.getdozer.io";
 pub const DEFAULT_QUERIES_DIRECTORY: &str = "queries";
 pub const DEFAULT_LAMBDAS_DIRECTORY: &str = "lambdas";

--- a/dozer-types/src/constants.rs
+++ b/dozer-types/src/constants.rs
@@ -1,6 +1,6 @@
 pub const DEFAULT_HOME_DIR: &str = "./.dozer";
 pub const DEFAULT_CONFIG_PATH: &str = "./dozer-config.yaml";
-pub const DEFAULT_CONFIG_PATH_PATTERNS: &str = "./dozer-config.*,./queries/*.sql";
+pub const DEFAULT_CONFIG_PATH_PATTERNS: &[&str] = &["./dozer-config.*", "./queries/*.sql"];
 pub const DEFAULT_CLOUD_TARGET_URL: &str = "https://api.dev.getdozer.io";
 pub const DEFAULT_QUERIES_DIRECTORY: &str = "queries";
 pub const DEFAULT_LAMBDAS_DIRECTORY: &str = "lambdas";


### PR DESCRIPTION
With these changes, we support reading from multiple files. By default, it reads based on two patterns: `dozer-config.*`, `queries/*.sql`

Additionally, user can provide patterns with `-c` parameter, e.g. `-c ./dozer-config.yaml -c ./dozer-config.sources.yaml -c ./queries/simple.sql`