### PR TITLE
chore: added toolchain toml to pin version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.70.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
chore: added toolchain toml to pin version

matching with cloud: https://github.com/getdozer/dozer-cloud/pull/344/files#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4e