### PR TITLE
feat: Register errors from error manager in jaeger

### DIFF
--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -125,9 +125,15 @@ fn run() -> Result<(), OrchestrationError> {
     set_ctrl_handler(shutdown_sender);
 
     // Now we have access to telemetry configuration. Telemetry must be initialized in tokio runtime.
-    let _telemetry = dozer.runtime.block_on(async {
-        Telemetry::new(Some(&dozer.config.app_name), dozer.config.telemetry.clone())
-    });
+    let app_name = dozer.config.app_name.clone();
+    let app_id = dozer
+        .config
+        .cloud
+        .as_ref()
+        .map(|cloud| cloud.app_id.clone().unwrap_or(app_name));
+    let _telemetry = dozer
+        .runtime
+        .block_on(async { Telemetry::new(app_id.as_deref(), dozer.config.telemetry.clone()) });
 
     if let Some(cmd) = cli.cmd {
         // run individual servers

--- a/dozer-core/src/error_manager.rs
+++ b/dozer-core/src/error_manager.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::AtomicU32;
 
+use dozer_types::tracing::error_span;
 use dozer_types::{errors::internal::BoxedError, log::error};
 
 /// `ErrorManager` records and counts the number of errors happened.
@@ -27,7 +28,9 @@ impl ErrorManager {
     }
 
     pub fn report(&self, error: BoxedError) {
+        error_span!("reported error", error = true, e = error);
         error!("{}", error);
+
         let count = self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         if let Some(threshold) = self.threshold {
             if count >= threshold {


### PR DESCRIPTION
Example of config (`dozer-config.telemetry.yaml`)
```
telemetry:
  trace: !Jaeger
    JaegerTelemetryConfig:
```    