### PR TITLE
fix: Replication log could panic if received request during persisting

### DIFF
--- a/dozer-log/src/replication/tests.rs
+++ b/dozer-log/src/replication/tests.rs
@@ -105,9 +105,6 @@ async fn watch_partial_write_mutable() {
         ExecutorOperation::SnapshottingDone {
             connection_name: "1".to_string(),
         },
-        ExecutorOperation::SnapshottingDone {
-            connection_name: "2".to_string(),
-        },
     ];
     for op in &ops {
         log_mut.write(op.clone(), log.clone()).await.unwrap();
@@ -115,7 +112,7 @@ async fn watch_partial_write_mutable() {
     drop(log_mut);
 
     let ops_read = handle.await.unwrap().unwrap();
-    assert_eq!(ops_read, LogResponse::Operations(ops[1..2].to_vec()));
+    assert_eq!(ops_read, LogResponse::Operations(ops[1..].to_vec()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Bug senario:

1. Log has in memory ops [0, 499)
2. Log received operation 499 and begins to persist [0, 500)
3. Log received read request [498, 502). Now that [0, 500) is not persisted yet, it decides to add [498, 502) to watcher list.
4. Persisting is done. Now log has persisted [0, 500) and in memory [500, 500)
5. Log received operations 500 and 501. Now it has in memory [500, 502) and decides to trigger the watcher [498, 502), but 498 is not in memory anymore.

We should trigger any watcher that was part of persisted entry before removing in memory ops.

We used to do this, but at the wrong timing. We used to do it before persisting starts. It should happen after persisting is done.