### PR TITLE
chore: Remove `Schema::identifier`

### DIFF
--- a/dozer-api/src/generator/protoc/generator/implementation.rs
+++ b/dozer-api/src/generator/protoc/generator/implementation.rs
@@ -205,7 +205,7 @@ impl<'a> ProtoGeneratorImpl<'a> {
                 }
             };
 
-        let names = Names::new(schema_name, &Schema::empty());
+        let names = Names::new(schema_name, &Schema::default());
         let service_name = format!("{}.{}", &names.package_name, &names.plural_pascal_name);
         let service = descriptor
             .get_service_by_name(&service_name)

--- a/dozer-api/src/grpc/typed/tests/utils.rs
+++ b/dozer-api/src/grpc/typed/tests/utils.rs
@@ -1,9 +1,6 @@
 use super::super::helper::count_response_to_typed_response;
 use super::super::helper::query_response_to_typed_response;
-use crate::{
-    generator::protoc::generator::ProtoGenerator,
-    test_utils::{self, get_sample_records},
-};
+use crate::{generator::protoc::generator::ProtoGenerator, test_utils::get_sample_records};
 use std::env;
 
 #[test]
@@ -12,10 +9,9 @@ fn test_records_to_typed_response() {
     let path = res.join("src/grpc/typed/tests/generated_films.bin");
     let bytes = std::fs::read(path).unwrap();
 
-    let (schema, _) = test_utils::get_schema();
     let service_desc = ProtoGenerator::read_schema(&bytes, "films").unwrap();
 
-    let records = get_sample_records(schema);
+    let records = get_sample_records();
     let res = query_response_to_typed_response(records, service_desc.query.response_desc.clone())
         .unwrap();
     let records = res
@@ -30,10 +26,9 @@ fn test_count_records_to_typed_response() {
     let path = res.join("src/grpc/typed/tests/generated_films.bin");
     let bytes = std::fs::read(path).unwrap();
 
-    let (schema, _) = test_utils::get_schema();
     let service_desc = ProtoGenerator::read_schema(&bytes, "films").unwrap();
 
-    let records = get_sample_records(schema);
+    let records = get_sample_records();
     let res =
         count_response_to_typed_response(records.len(), service_desc.count.response_desc.clone())
             .unwrap();

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -3,7 +3,7 @@ use dozer_types::serde_json::{json, Value};
 use dozer_types::types::{Field, Record, SchemaWithIndex, SourceDefinition};
 use dozer_types::{
     models::api_endpoint::{ApiEndpoint, ApiIndex},
-    types::{FieldDefinition, FieldType, IndexDefinition, Schema, SchemaIdentifier},
+    types::{FieldDefinition, FieldType, IndexDefinition, Schema},
 };
 
 use dozer_cache::cache::{CacheRecord, LmdbRwCacheManager, RwCacheManager};
@@ -48,10 +48,6 @@ pub fn get_schema() -> SchemaWithIndex {
         .collect();
     (
         Schema {
-            identifier: Some(SchemaIdentifier {
-                id: 3003108387,
-                version: 1,
-            }),
             fields,
             primary_index: vec![0],
         },
@@ -121,7 +117,7 @@ pub fn initialize_cache(
             Default::default(),
         )
         .unwrap();
-    let records = get_sample_records(schema);
+    let records = get_sample_records();
     for record in records {
         cache.insert(&record.record).unwrap();
     }
@@ -131,7 +127,7 @@ pub fn initialize_cache(
     Box::new(cache_manager)
 }
 
-pub fn get_sample_records(schema: Schema) -> Vec<CacheRecord> {
+pub fn get_sample_records() -> Vec<CacheRecord> {
     let records_value: Vec<Value> = get_films();
     let mut records = vec![];
     for (record_index, record_str) in records_value.into_iter().enumerate() {
@@ -141,16 +137,13 @@ pub fn get_sample_records(schema: Schema) -> Vec<CacheRecord> {
         if let (Some(film_id), Some(description), Some(release_year)) =
             (film_id, description, release_year)
         {
-            let record = Record::new(
-                schema.identifier,
-                vec![
-                    Field::UInt(film_id),
-                    Field::String(description.to_string()),
-                    Field::Null,
-                    Field::UInt(release_year),
-                    Field::Null,
-                ],
-            );
+            let record = Record::new(vec![
+                Field::UInt(film_id),
+                Field::String(description.to_string()),
+                Field::Null,
+                Field::UInt(release_year),
+                Field::Null,
+            ]);
             records.push(CacheRecord::new(record_index as _, 1, record));
         }
     }

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -7,13 +7,13 @@ use dozer_cache::cache::{
 };
 use dozer_types::parking_lot::Mutex;
 use dozer_types::serde_json::Value;
-use dozer_types::types::{Field, Record, Schema};
+use dozer_types::types::{Field, Record};
 
-fn insert(cache: &Mutex<Box<dyn RwCache>>, schema: &Schema, n: usize, commit_size: usize) {
+fn insert(cache: &Mutex<Box<dyn RwCache>>, n: usize, commit_size: usize) {
     let mut cache = cache.lock();
 
     let val = format!("bar_{n}");
-    let mut record = Record::new(schema.identifier, vec![Field::String(val)]);
+    let mut record = Record::new(vec![Field::String(val)]);
 
     cache.insert(&mut record).unwrap();
 
@@ -76,7 +76,7 @@ fn cache(c: &mut Criterion) {
         &iterations,
         |b, &_s| {
             b.iter(|| {
-                insert(&cache, &schema, idx, commit_size);
+                insert(&cache, idx, commit_size);
                 idx += 1;
             })
         },

--- a/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
@@ -134,11 +134,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_dump_restore() {
-        let (mut cache, indexing_thread_pool, schema, _) = create_cache(test_utils::schema_1);
+        let (mut cache, indexing_thread_pool, _, _) = create_cache(test_utils::schema_1);
 
-        insert_rec_1(&mut cache, &schema, (0, Some("a".to_string()), None));
-        insert_rec_1(&mut cache, &schema, (1, None, Some(2)));
-        insert_rec_1(&mut cache, &schema, (2, Some("b".to_string()), Some(3)));
+        insert_rec_1(&mut cache, (0, Some("a".to_string()), None));
+        insert_rec_1(&mut cache, (1, None, Some(2)));
+        insert_rec_1(&mut cache, (2, Some("b".to_string()), Some(3)));
         cache.commit().unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
@@ -32,7 +32,6 @@ fn ignore_insert_error_when_type_nothing() {
 
     let initial_values = vec![Field::Int(1), Field::String("Film name old".to_string())];
     let record = Record {
-        schema_id: schema.identifier,
         values: initial_values.clone(),
         lifetime: None,
     };
@@ -64,7 +63,6 @@ fn update_after_insert_error_when_type_update() {
 
     let initial_values = vec![Field::Int(1), Field::String("Film name old".to_string())];
     let record = Record {
-        schema_id: schema.identifier,
         values: initial_values.clone(),
         lifetime: None,
     };
@@ -82,7 +80,6 @@ fn update_after_insert_error_when_type_update() {
         Field::String("Second insert name".to_string()),
     ];
     let second_record = Record {
-        schema_id: schema.identifier,
         values: second_insert_values.clone(),
         lifetime: None,
     };
@@ -112,7 +109,6 @@ fn return_insert_error_when_type_panic() {
 
     let initial_values = vec![Field::Int(1), Field::String("Film name old".to_string())];
     let record = Record {
-        schema_id: schema.identifier,
         values: initial_values.clone(),
         lifetime: None,
     };
@@ -145,12 +141,10 @@ fn ignore_update_error_when_type_nothing() {
     ];
 
     let initial_record = Record {
-        schema_id: schema.identifier,
         values: initial_values.clone(),
         lifetime: None,
     };
     let update_record = Record {
-        schema_id: schema.identifier,
         values: update_values,
         lifetime: None,
     };
@@ -177,12 +171,10 @@ fn update_after_update_error_when_type_upsert() {
     ];
 
     let initial_record = Record {
-        schema_id: schema.identifier,
         values: initial_values.clone(),
         lifetime: None,
     };
     let update_record = Record {
-        schema_id: schema.identifier,
         values: update_values.clone(),
         lifetime: None,
     };
@@ -198,7 +190,7 @@ fn update_after_update_error_when_type_upsert() {
 
 #[test]
 fn return_update_error_when_type_panic() {
-    let (mut env, schema) = init_env(ConflictResolution {
+    let (mut env, _) = init_env(ConflictResolution {
         on_insert: None,
         on_update: Some(OnUpdateResolutionTypes::Panic(())),
         on_delete: None,
@@ -211,12 +203,10 @@ fn return_update_error_when_type_panic() {
     ];
 
     let initial_record = Record {
-        schema_id: schema.identifier,
         values: initial_values,
         lifetime: None,
     };
     let update_record = Record {
-        schema_id: schema.identifier,
         values: update_values,
         lifetime: None,
     };
@@ -228,7 +218,7 @@ fn return_update_error_when_type_panic() {
 
 #[test]
 fn ignore_delete_error_when_type_nothing() {
-    let (mut env, schema) = init_env(ConflictResolution {
+    let (mut env, _) = init_env(ConflictResolution {
         on_insert: None,
         on_update: None,
         on_delete: Some(OnDeleteResolutionTypes::Nothing(())),
@@ -236,7 +226,6 @@ fn ignore_delete_error_when_type_nothing() {
 
     let initial_values = vec![Field::Int(1), Field::Null];
     let initial_record = Record {
-        schema_id: schema.identifier,
         values: initial_values,
         lifetime: None,
     };
@@ -252,7 +241,7 @@ fn ignore_delete_error_when_type_nothing() {
 
 #[test]
 fn return_delete_error_when_type_panic() {
-    let (mut env, schema) = init_env(ConflictResolution {
+    let (mut env, _) = init_env(ConflictResolution {
         on_insert: None,
         on_update: None,
         on_delete: Some(OnDeleteResolutionTypes::Panic(())),
@@ -260,7 +249,6 @@ fn return_delete_error_when_type_panic() {
 
     let initial_values = vec![Field::Int(1), Field::Null];
     let initial_record = Record {
-        schema_id: schema.identifier,
         values: initial_values,
         lifetime: None,
     };

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/dump_restore.rs
@@ -138,7 +138,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_dump_restore() {
-        let schema = Schema::empty();
+        let schema = Schema::default();
         let mut env = RwMainEnvironment::new(
             Some(&(schema, vec![])),
             None,
@@ -147,7 +147,7 @@ pub mod tests {
         )
         .unwrap();
 
-        let record = Record::new(None, vec![]);
+        let record = Record::new(vec![]);
         env.insert(&record).unwrap();
         env.insert(&record).unwrap();
         env.delete(&record).unwrap();

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/hash_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/hash_tests.rs
@@ -6,7 +6,7 @@ use super::RwMainEnvironment;
 
 #[test]
 fn test_hash_insert_delete_insert() {
-    let schema = Schema::empty();
+    let schema = Schema::default();
     let mut env = RwMainEnvironment::new(
         Some(&(schema, vec![])),
         None,
@@ -15,7 +15,7 @@ fn test_hash_insert_delete_insert() {
     )
     .unwrap();
 
-    let record = Record::new(None, vec![]);
+    let record = Record::new(vec![]);
 
     let UpsertResult::Inserted { meta } = env.insert(&record).unwrap() else {
         panic!("Expected UpsertResult::Inserted");

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
@@ -613,7 +613,6 @@ impl RoMainEnvironment {
 pub mod dump_restore;
 
 fn debug_check_schema_record_consistency(schema: &Schema, record: &Record) {
-    debug_assert_eq!(schema.identifier, record.schema_id);
     debug_assert_eq!(schema.fields.len(), record.values.len());
     for (field, value) in schema.fields.iter().zip(record.values.iter()) {
         if field.nullable && value == &Field::Null {

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/lmdb_val_impl.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/lmdb_val_impl.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let operation = Operation::Insert {
             record_meta: RecordMeta::new(1, 1),
-            record: Record::new(None, vec![1.into(), 2.into(), 3.into()]),
+            record: Record::new(vec![1.into(), 2.into(), 3.into()]),
         };
         let encoded = operation.borrow().encode().unwrap();
         let decoded = Operation::decode(encoded.as_ref()).unwrap().into_owned();

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
@@ -57,7 +57,7 @@ fn test_operation_log_append_only() {
     let txn = env.txn_mut().unwrap();
     let append_only = true;
 
-    let records = vec![Record::new(None, vec![]); 10];
+    let records = vec![Record::new(vec![]); 10];
     for (index, record) in records.iter().enumerate() {
         let record_meta = log.insert_new(txn, None, record).unwrap();
         assert_eq!(record_meta.id, index as u64);
@@ -101,7 +101,7 @@ fn test_operation_log_with_primary_key() {
     let append_only = false;
 
     // Insert a record.
-    let record = Record::new(None, vec![]);
+    let record = Record::new(vec![]);
     let primary_key = b"primary_key";
     let key = MetadataKey::PrimaryKey(primary_key);
     let mut record_meta = log.insert_new(txn, Some(key), &record).unwrap();
@@ -224,7 +224,7 @@ fn test_operation_log_without_primary_key() {
     let append_only = false;
 
     // Insert a record.
-    let record = Record::new(None, vec![]);
+    let record = Record::new(vec![]);
     let key = MetadataKey::Hash(&record, 0);
     let mut record_meta = log.insert_new(txn, Some(key), &record).unwrap();
     assert_eq!(record_meta.id, 0);

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
@@ -128,7 +128,6 @@ pub mod tests {
     #[tokio::test]
     async fn test_dump_restore() {
         let schema = Schema {
-            identifier: None,
             fields: vec![FieldDefinition {
                 name: "test".to_string(),
                 typ: FieldType::String,
@@ -146,12 +145,10 @@ pub mod tests {
         .unwrap();
 
         let record_a = Record {
-            schema_id: None,
             values: vec![Field::String("a".to_string())],
             lifetime: None,
         };
         let record_b = Record {
-            schema_id: None,
             values: vec![Field::String("b".to_string())],
             lifetime: None,
         };

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_secondary_indexes() {
-        let (mut cache, indexing_thread_pool, schema, secondary_indexes) =
+        let (mut cache, indexing_thread_pool, _, secondary_indexes) =
             create_cache(test_utils::schema_1);
 
         let items = vec![
@@ -114,7 +114,7 @@ mod tests {
         ];
 
         for val in items.clone() {
-            lmdb_utils::insert_rec_1(&mut cache, &schema, val);
+            lmdb_utils::insert_rec_1(&mut cache, val);
         }
         cache.commit().unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
@@ -132,7 +132,6 @@ mod tests {
 
         for a in [1i64, 2, 3, 4] {
             let record = Record {
-                schema_id: schema.identifier,
                 values: vec![Field::Int(a), Field::Null, Field::Null],
                 lifetime: None,
             };
@@ -168,8 +167,7 @@ mod tests {
 
     #[test]
     fn test_full_text_secondary_index_with_duplicated_words() {
-        let (mut cache, indexing_thread_pool, schema, _) =
-            create_cache(test_utils::schema_full_text);
+        let (mut cache, indexing_thread_pool, _, _) = create_cache(test_utils::schema_full_text);
 
         let items = vec![(
             Some("another test".to_string()),
@@ -177,13 +175,12 @@ mod tests {
         )];
 
         for val in items {
-            lmdb_utils::insert_full_text(&mut cache, &schema, val);
+            lmdb_utils::insert_full_text(&mut cache, val);
         }
 
         {
             let a = "another test".to_string();
             let record = Record {
-                schema_id: schema.identifier,
                 values: vec![Field::String(a), Field::Null],
                 lifetime: None,
             };

--- a/dozer-cache/src/cache/lmdb/cache_manager.rs
+++ b/dozer-cache/src/cache/lmdb/cache_manager.rs
@@ -259,7 +259,7 @@ mod tests {
         let labels = cache_manager
             .create_cache(
                 Default::default(),
-                Schema::empty(),
+                Schema::default(),
                 vec![],
                 &Default::default(),
                 Default::default(),

--- a/dozer-cache/src/cache/lmdb/tests/basic.rs
+++ b/dozer-cache/src/cache/lmdb/tests/basic.rs
@@ -42,11 +42,11 @@ fn get_schema() {
 #[test]
 fn insert_get_and_delete_record() {
     let val = "bar".to_string();
-    let (mut cache, indexing_thread_pool, schema) = _setup();
+    let (mut cache, indexing_thread_pool, _) = _setup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 0);
 
-    let record = Record::new(schema.identifier, vec![Field::String(val.clone())]);
+    let record = Record::new(vec![Field::String(val.clone())]);
     let UpsertResult::Inserted { meta } = cache.insert(&record).unwrap() else {
         panic!("Must be inserted")
     };
@@ -63,7 +63,6 @@ fn insert_get_and_delete_record() {
     assert_eq!(
         cache
             .delete(&Record {
-                schema_id: schema.identifier,
                 values: vec![Field::String(val)],
                 lifetime: None,
             })
@@ -83,9 +82,9 @@ fn insert_get_and_delete_record() {
 
 #[test]
 fn insert_and_update_record() {
-    let (mut cache, _, schema) = _setup();
-    let foo = Record::new(schema.identifier, vec![Field::String("foo".to_string())]);
-    let bar = Record::new(schema.identifier, vec![Field::String("bar".to_string())]);
+    let (mut cache, _, _) = _setup();
+    let foo = Record::new(vec![Field::String("foo".to_string())]);
+    let bar = Record::new(vec![Field::String("bar".to_string())]);
     let UpsertResult::Inserted { meta } = cache.insert(&foo).unwrap() else {
         panic!("Must be inserted")
     };
@@ -102,10 +101,9 @@ fn insert_and_update_record() {
 fn insert_and_query_record_impl(
     mut cache: LmdbRwCache,
     indexing_thread_pool: Arc<Mutex<IndexingThreadPool>>,
-    schema: Schema,
 ) {
     let val = "bar".to_string();
-    let record = Record::new(schema.identifier, vec![Field::String(val)]);
+    let record = Record::new(vec![Field::String(val)]);
 
     cache.insert(&record).unwrap();
     cache.commit().unwrap();
@@ -130,10 +128,10 @@ fn insert_and_query_record_impl(
 
 #[test]
 fn insert_and_query_record() {
-    let (cache, indexing_thread_pool, schema) = _setup();
-    insert_and_query_record_impl(cache, indexing_thread_pool, schema);
-    let (cache, indexing_thread_pool, schema) = _setup_empty_primary_index();
-    insert_and_query_record_impl(cache, indexing_thread_pool, schema);
+    let (cache, indexing_thread_pool, _) = _setup();
+    insert_and_query_record_impl(cache, indexing_thread_pool);
+    let (cache, indexing_thread_pool, _) = _setup_empty_primary_index();
+    insert_and_query_record_impl(cache, indexing_thread_pool);
 }
 
 #[test]
@@ -143,14 +141,12 @@ fn update_record_when_primary_changes() {
 
     let initial_values = vec![Field::String("1".into())];
     let initial_record = Record {
-        schema_id: schema.identifier,
         values: initial_values.clone(),
         lifetime: None,
     };
 
     let updated_values = vec![Field::String("2".into())];
     let updated_record = Record {
-        schema_id: schema.identifier,
         values: updated_values.clone(),
         lifetime: None,
     };

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -41,7 +41,7 @@ fn read_and_write() {
     ];
 
     for val in items.clone() {
-        lmdb_utils::insert_rec_1(&mut cache_writer, &schema.0, val.clone());
+        lmdb_utils::insert_rec_1(&mut cache_writer, val.clone());
     }
     cache_writer.commit().unwrap();
 

--- a/dozer-cache/src/cache/lmdb/tests/utils.rs
+++ b/dozer-cache/src/cache/lmdb/tests/utils.rs
@@ -32,34 +32,20 @@ pub fn create_cache(
     (cache, indexing_thread_pool, schema.0, schema.1)
 }
 
-pub fn insert_rec_1(
-    cache: &mut LmdbRwCache,
-    schema: &Schema,
-    (a, b, c): (i64, Option<String>, Option<i64>),
-) {
-    let record = Record::new(
-        schema.identifier,
-        vec![
-            Field::Int(a),
-            b.map_or(Field::Null, Field::String),
-            c.map_or(Field::Null, Field::Int),
-        ],
-    );
+pub fn insert_rec_1(cache: &mut LmdbRwCache, (a, b, c): (i64, Option<String>, Option<i64>)) {
+    let record = Record::new(vec![
+        Field::Int(a),
+        b.map_or(Field::Null, Field::String),
+        c.map_or(Field::Null, Field::Int),
+    ]);
     cache.insert(&record).unwrap();
 }
 
-pub fn insert_full_text(
-    cache: &mut LmdbRwCache,
-    schema: &Schema,
-    (a, b): (Option<String>, Option<String>),
-) {
-    let record = Record::new(
-        schema.identifier,
-        vec![
-            a.map_or(Field::Null, Field::String),
-            b.map_or(Field::Null, Field::Text),
-        ],
-    );
+pub fn insert_full_text(cache: &mut LmdbRwCache, (a, b): (Option<String>, Option<String>)) {
+    let record = Record::new(vec![
+        a.map_or(Field::Null, Field::String),
+        b.map_or(Field::Null, Field::Text),
+    ]);
     cache.insert(&record).unwrap();
 }
 

--- a/dozer-cache/src/cache/test_utils.rs
+++ b/dozer-cache/src/cache/test_utils.rs
@@ -1,5 +1,5 @@
 use dozer_types::types::{
-    FieldDefinition, IndexDefinition, Schema, SchemaIdentifier, SchemaWithIndex, SourceDefinition,
+    FieldDefinition, IndexDefinition, Schema, SchemaWithIndex, SourceDefinition,
 };
 
 use super::expression::{FilterExpression, QueryExpression, Skip};
@@ -7,7 +7,6 @@ use super::expression::{FilterExpression, QueryExpression, Skip};
 pub fn schema_0() -> SchemaWithIndex {
     (
         Schema {
-            identifier: Some(SchemaIdentifier { id: 0, version: 1 }),
             fields: vec![FieldDefinition {
                 name: "foo".to_string(),
                 typ: dozer_types::types::FieldType::String,
@@ -23,7 +22,6 @@ pub fn schema_0() -> SchemaWithIndex {
 pub fn schema_1() -> SchemaWithIndex {
     (
         Schema {
-            identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
             fields: vec![
                 FieldDefinition {
                     name: "a".to_string(),
@@ -59,7 +57,6 @@ pub fn schema_1() -> SchemaWithIndex {
 pub fn schema_full_text() -> SchemaWithIndex {
     (
         Schema {
-            identifier: Some(SchemaIdentifier { id: 2, version: 1 }),
             fields: vec![
                 FieldDefinition {
                     name: "foo".to_string(),
@@ -84,7 +81,6 @@ pub fn schema_full_text() -> SchemaWithIndex {
 pub fn schema_empty_primary_index() -> SchemaWithIndex {
     (
         Schema {
-            identifier: Some(SchemaIdentifier { id: 3, version: 1 }),
             fields: vec![FieldDefinition {
                 name: "foo".to_string(),
                 typ: dozer_types::types::FieldType::String,
@@ -100,7 +96,6 @@ pub fn schema_empty_primary_index() -> SchemaWithIndex {
 pub fn schema_multi_indices() -> SchemaWithIndex {
     (
         Schema {
-            identifier: Some(SchemaIdentifier { id: 4, version: 1 }),
             fields: vec![
                 FieldDefinition {
                     name: "id".to_string(),

--- a/dozer-cli/src/simple/build.rs
+++ b/dozer-cli/src/simple/build.rs
@@ -14,9 +14,7 @@ use dozer_types::{
         },
         app_config::LogStorage,
     },
-    types::{
-        FieldDefinition, FieldType, IndexDefinition, Schema, SchemaIdentifier, SchemaWithIndex,
-    },
+    types::{FieldDefinition, FieldType, IndexDefinition, Schema, SchemaWithIndex},
 };
 
 use crate::errors::BuildError;
@@ -130,8 +128,6 @@ pub fn modify_schema(
     };
 
     schema.primary_index = index;
-
-    schema.identifier = Some(SchemaIdentifier { id: 0, version: 1 });
 
     let secondary_index_config = get_secondary_index_config(api_endpoint);
     let secondary_indexes = generate_secondary_indexes(&schema.fields, &secondary_index_config)?;

--- a/dozer-core/src/executor/receiver_loop.rs
+++ b/dozer-core/src/executor/receiver_loop.rs
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn receiver_loop_forwards_op() {
         let (mut test_loop, senders) = TestReceiverLoop::new(2);
-        let record = Record::new(None, vec![Field::Int(1)]);
+        let record = Record::new(vec![Field::Int(1)]);
         senders[0]
             .send(ExecutorOperation::Op {
                 op: Operation::Insert {

--- a/dozer-core/src/forwarder.rs
+++ b/dozer-core/src/forwarder.rs
@@ -228,7 +228,7 @@ impl SourceChannelManager {
         self.curr_txid = message.identifier.txid;
         self.curr_seq_in_tx = message.identifier.seq_in_tx;
         match message.kind {
-            IngestionMessageKind::OperationEvent(op) => {
+            IngestionMessageKind::OperationEvent { op, .. } => {
                 self.manager.send_op(op, port)?;
                 self.num_uncommitted_ops += 1;
                 self.trigger_commit_if_needed(request_termination)

--- a/dozer-core/src/tests/dag_base_create_errors.rs
+++ b/dozer-core/src/tests/dag_base_create_errors.rs
@@ -32,7 +32,7 @@ impl CreateErrSourceFactory {
 impl SourceFactory<NoneContext> for CreateErrSourceFactory {
     fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         "id".to_string(),
@@ -172,7 +172,7 @@ impl ProcessorFactory<NoneContext> for CreateErrProcessorFactory {
         _input_schemas: &HashMap<PortHandle, (Schema, NoneContext)>,
     ) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         "id".to_string(),

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -287,7 +287,7 @@ impl ErrGeneratorSourceFactory {
 impl SourceFactory<NoneContext> for ErrGeneratorSourceFactory {
     fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         "id".to_string(),
@@ -354,14 +354,12 @@ impl Source for ErrGeneratorSource {
                 IngestionMessage::new_op(
                     n,
                     0,
+                    0,
                     Operation::Insert {
-                        new: Record::new(
-                            None,
-                            vec![
-                                Field::String(format!("key_{n}")),
-                                Field::String(format!("value_{n}")),
-                            ],
-                        ),
+                        new: Record::new(vec![
+                            Field::String(format!("key_{n}")),
+                            Field::String(format!("value_{n}")),
+                        ]),
                     },
                 ),
                 GENERATOR_SOURCE_OUTPUT_PORT,

--- a/dozer-core/src/tests/dag_schemas.rs
+++ b/dozer-core/src/tests/dag_schemas.rs
@@ -25,7 +25,7 @@ struct TestUsersSourceFactory {}
 impl SourceFactory<NoneContext> for TestUsersSourceFactory {
     fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         "user_id".to_string(),
@@ -79,7 +79,7 @@ struct TestCountriesSourceFactory {}
 impl SourceFactory<NoneContext> for TestCountriesSourceFactory {
     fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         "country_id".to_string(),
@@ -134,7 +134,6 @@ impl ProcessorFactory<NoneContext> for TestJoinProcessorFactory {
             Schema {
                 fields: joined,
                 primary_index: vec![],
-                identifier: None,
             },
             NoneContext {},
         ))

--- a/dozer-core/src/tests/sources.rs
+++ b/dozer-core/src/tests/sources.rs
@@ -37,7 +37,7 @@ impl GeneratorSourceFactory {
 impl SourceFactory<NoneContext> for GeneratorSourceFactory {
     fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         "id".to_string(),
@@ -106,14 +106,12 @@ impl Source for GeneratorSource {
                 IngestionMessage::new_op(
                     n,
                     0,
+                    0,
                     Operation::Insert {
-                        new: Record::new(
-                            None,
-                            vec![
-                                Field::String(format!("key_{n}")),
-                                Field::String(format!("value_{n}")),
-                            ],
-                        ),
+                        new: Record::new(vec![
+                            Field::String(format!("key_{n}")),
+                            Field::String(format!("value_{n}")),
+                        ]),
                     },
                 ),
                 GENERATOR_SOURCE_OUTPUT_PORT,
@@ -154,7 +152,7 @@ impl DualPortGeneratorSourceFactory {
 impl SourceFactory<NoneContext> for DualPortGeneratorSourceFactory {
     fn get_output_schema(&self, _port: &PortHandle) -> Result<(Schema, NoneContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         "id".to_string(),
@@ -231,14 +229,12 @@ impl Source for DualPortGeneratorSource {
                 IngestionMessage::new_op(
                     n,
                     0,
+                    0,
                     Operation::Insert {
-                        new: Record::new(
-                            None,
-                            vec![
-                                Field::String(format!("key_{n}")),
-                                Field::String(format!("value_{n}")),
-                            ],
-                        ),
+                        new: Record::new(vec![
+                            Field::String(format!("key_{n}")),
+                            Field::String(format!("value_{n}")),
+                        ]),
                     },
                 ),
                 DUAL_PORT_GENERATOR_SOURCE_OUTPUT_PORT_1,
@@ -247,14 +243,12 @@ impl Source for DualPortGeneratorSource {
                 IngestionMessage::new_op(
                     n,
                     0,
+                    0,
                     Operation::Insert {
-                        new: Record::new(
-                            None,
-                            vec![
-                                Field::String(format!("key_{n}")),
-                                Field::String(format!("value_{n}")),
-                            ],
-                        ),
+                        new: Record::new(vec![
+                            Field::String(format!("key_{n}")),
+                            Field::String(format!("value_{n}")),
+                        ]),
                     },
                 ),
                 DUAL_PORT_GENERATOR_SOURCE_OUTPUT_PORT_2,

--- a/dozer-ingestion/src/connectors/delta_lake/connector.rs
+++ b/dozer-ingestion/src/connectors/delta_lake/connector.rs
@@ -11,13 +11,12 @@ use tonic::async_trait;
 
 #[derive(Debug)]
 pub struct DeltaLakeConnector {
-    pub id: u64,
     config: DeltaLakeConfig,
 }
 
 impl DeltaLakeConnector {
-    pub fn new(id: u64, config: DeltaLakeConfig) -> Self {
-        Self { id, config }
+    pub fn new(config: DeltaLakeConfig) -> Self {
+        Self { config }
     }
 }
 
@@ -73,7 +72,7 @@ impl Connector for DeltaLakeConnector {
             })
             .collect::<Vec<_>>();
         let schema_helper = SchemaHelper::new(self.config.clone());
-        let source_schemas = schema_helper.get_schemas(self.id, &table_infos).await?;
+        let source_schemas = schema_helper.get_schemas(&table_infos).await?;
 
         let mut result = vec![];
         for (source_schema, table_info) in source_schemas.into_iter().zip(table_infos) {
@@ -105,7 +104,7 @@ impl Connector for DeltaLakeConnector {
             })
             .collect::<Vec<_>>();
         let schema_helper = SchemaHelper::new(self.config.clone());
-        schema_helper.get_schemas(self.id, &table_infos).await
+        schema_helper.get_schemas(&table_infos).await
     }
 
     async fn start(&self, ingestor: &Ingestor, tables: Vec<TableInfo>) -> ConnectorResult<()> {

--- a/dozer-ingestion/src/connectors/delta_lake/test/deltalake_test.rs
+++ b/dozer-ingestion/src/connectors/delta_lake/test/deltalake_test.rs
@@ -18,7 +18,7 @@ async fn get_schema_from_deltalake() {
         tables: vec![delta_table],
     };
 
-    let connector = DeltaLakeConnector::new(1, config);
+    let connector = DeltaLakeConnector::new(config);
     let (_, schemas) = connector.list_all_schemas().await.unwrap();
     let field = schemas[0].schema.fields[0].clone();
     assert_eq!(&field.name, "value");
@@ -39,7 +39,7 @@ async fn read_deltalake() {
         tables: vec![delta_table],
     };
 
-    let connector = DeltaLakeConnector::new(1, config);
+    let connector = DeltaLakeConnector::new(config);
 
     let config = IngestionConfig::default();
     let (ingestor, iterator) = Ingestor::initialize_channel(config);
@@ -53,7 +53,11 @@ async fn read_deltalake() {
     let mut values = vec![];
     for (idx, IngestionMessage { identifier, kind }) in iterator.enumerate() {
         assert_eq!(idx, identifier.seq_in_tx as usize);
-        if let IngestionMessageKind::OperationEvent(Operation::Insert { new }) = kind {
+        if let IngestionMessageKind::OperationEvent {
+            op: Operation::Insert { new },
+            ..
+        } = kind
+        {
             values.extend(new.values);
         }
     }

--- a/dozer-ingestion/src/connectors/ethereum/log/tests/helper.rs
+++ b/dozer-ingestion/src/connectors/ethereum/log/tests/helper.rs
@@ -53,7 +53,6 @@ pub async fn get_eth_producer(
 ) -> Result<(), ConnectorError> {
     let address = format!("{:?}", contract.address());
     let eth_connector = EthLogConnector::new(
-        1,
         EthLogConfig {
             wss_url,
             filter: Some(EthFilter {
@@ -73,13 +72,9 @@ pub async fn get_eth_producer(
         "eth_test".to_string(),
     );
 
-    let (table_infos, schemas) = eth_connector.list_all_schemas().await?;
-    for (table_info, schema) in table_infos.iter().zip(schemas) {
-        info!(
-            "Schema: {}, Id: {}",
-            table_info.name,
-            schema.schema.identifier.unwrap().id
-        );
+    let (table_infos, _) = eth_connector.list_all_schemas().await?;
+    for table_info in table_infos.iter() {
+        info!("Schema: {}", table_info.name);
     }
 
     eth_connector.start(&ingestor, table_infos).await
@@ -112,7 +107,7 @@ pub async fn run_eth_sample(
     let mut op_index = HashSet::new();
     while let Some(IngestionMessage {
         identifier,
-        kind: IngestionMessageKind::OperationEvent(op),
+        kind: IngestionMessageKind::OperationEvent { table_index: 0, op },
     }) = iterator.next_timeout(Duration::from_millis(400))
     {
         // Duplicates are to be expected in ethereum connector

--- a/dozer-ingestion/src/connectors/ethereum/trace/connector.rs
+++ b/dozer-ingestion/src/connectors/ethereum/trace/connector.rs
@@ -13,7 +13,6 @@ use tonic::async_trait;
 
 #[derive(Debug)]
 pub struct EthTraceConnector {
-    pub id: u64,
     pub config: EthTraceConfig,
     pub conn_name: String,
 }
@@ -21,12 +20,8 @@ pub struct EthTraceConnector {
 pub const ETH_TRACE_TABLE: &str = "eth_traces";
 pub const RETRIES: u16 = 10;
 impl EthTraceConnector {
-    pub fn new(id: u64, config: EthTraceConfig, conn_name: String) -> Self {
-        Self {
-            id,
-            config,
-            conn_name,
-        }
+    pub fn new(config: EthTraceConfig, conn_name: String) -> Self {
+        Self { config, conn_name }
     }
 }
 
@@ -152,7 +147,10 @@ pub async fn run(
 
                         for op in ops {
                             ingestor
-                                .handle_message(IngestionMessage::new_op(batch.0, 0, op))
+                                .handle_message(IngestionMessage::new_op(
+                                    batch.0, 0, // We have only one table
+                                    0, op,
+                                ))
                                 .map_err(ConnectorError::IngestorError)?;
                         }
                     }

--- a/dozer-ingestion/src/connectors/ethereum/trace/helper.rs
+++ b/dozer-ingestion/src/connectors/ethereum/trace/helper.rs
@@ -1,9 +1,7 @@
 use dozer_types::log::{debug, error};
 use dozer_types::serde;
 use dozer_types::serde_json::{self, json};
-use dozer_types::types::{
-    Field, FieldType, Operation, Record, Schema, SchemaIdentifier, SourceDefinition,
-};
+use dozer_types::types::{Field, FieldType, Operation, Record, Schema, SourceDefinition};
 use serde::{Deserialize, Serialize};
 
 use dozer_types::types::FieldDefinition;
@@ -87,12 +85,8 @@ pub async fn get_block_traces(
     Ok(results)
 }
 
-fn get_schema_id() -> SchemaIdentifier {
-    SchemaIdentifier { id: 1, version: 1 }
-}
 pub fn get_trace_schema() -> Schema {
     Schema {
-        identifier: Some(get_schema_id()),
         fields: vec![
             FieldDefinition {
                 name: "type_field".to_string(),
@@ -151,7 +145,6 @@ pub fn map_trace_to_ops(trace: &Trace) -> Vec<Operation> {
     let mut ops = vec![];
     let op = Operation::Insert {
         new: Record {
-            schema_id: Some(get_schema_id()),
             values: vec![
                 Field::String(trace.type_field.clone()),
                 Field::String(format!("{:?}", trace.from)),

--- a/dozer-ingestion/src/connectors/ethereum/trace/tests.rs
+++ b/dozer-ingestion/src/connectors/ethereum/trace/tests.rs
@@ -55,7 +55,6 @@ async fn test_trace_iterator() {
         info!("Initializing with WSS: {}", https_url);
 
         let connector = EthTraceConnector::new(
-            1,
             EthTraceConfig {
                 https_url,
                 from_block: 1000000,
@@ -73,7 +72,7 @@ async fn test_trace_iterator() {
     });
 
     if let Some(IngestionMessage {
-        kind: IngestionMessageKind::OperationEvent(op),
+        kind: IngestionMessageKind::OperationEvent { op, .. },
         ..
     }) = iterator.next_timeout(Duration::from_millis(1000))
     {

--- a/dozer-ingestion/src/connectors/grpc/adapter/mod.rs
+++ b/dozer-ingestion/src/connectors/grpc/adapter/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use dozer_types::grpc_types::ingest::{IngestArrowRequest, IngestRequest};
 
 use crate::{connectors::SourceSchema, errors::ConnectorError, ingestion::Ingestor};
@@ -8,7 +10,7 @@ mod arrow;
 
 pub use arrow::ArrowAdapter;
 pub use default::DefaultAdapter;
-pub trait IngestAdapter
+pub trait IngestAdapter: Debug
 where
     Self: Send + Sync + 'static + Sized,
 {
@@ -16,6 +18,7 @@ where
     fn get_schemas(&self) -> Vec<(String, SourceSchema)>;
     fn handle_message(
         &self,
+        table_index: usize,
         msg: GrpcIngestMessage,
         ingestor: &'static Ingestor,
     ) -> Result<(), ConnectorError>;
@@ -51,9 +54,10 @@ where
 
     pub fn handle_message(
         &self,
+        table_index: usize,
         msg: GrpcIngestMessage,
         ingestor: &'static Ingestor,
     ) -> Result<(), ConnectorError> {
-        self.adapter.handle_message(msg, ingestor)
+        self.adapter.handle_message(table_index, msg, ingestor)
     }
 }

--- a/dozer-ingestion/src/connectors/grpc/tests.rs
+++ b/dozer-ingestion/src/connectors/grpc/tests.rs
@@ -120,7 +120,7 @@ async fn ingest_grpc_default() {
     let msg = iterator.next().unwrap();
     assert_eq!(msg.identifier.seq_in_tx, 1, "seq_no should be 1");
 
-    if let IngestionMessageKind::OperationEvent(op) = msg.kind {
+    if let IngestionMessageKind::OperationEvent { op, .. } = msg.kind {
         if let Operation::Insert { new: record } = op {
             assert_eq!(record.values[0].as_int(), Some(1675));
             assert_eq!(record.values[1].as_string(), Some("dario"));
@@ -154,7 +154,7 @@ async fn test_serialize_arrow_schema() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn ingest_grpc_arrow() {
     let schema_str = serde_json::to_string(
-        &DozerSchema::empty()
+        &DozerSchema::default()
             .field(
                 FieldDefinition::new(
                     "id".to_string(),
@@ -254,7 +254,7 @@ async fn ingest_grpc_arrow() {
     let msg = iterator.next().unwrap();
     assert_eq!(msg.identifier.seq_in_tx, 1, "seq_no should be 1");
 
-    if let IngestionMessageKind::OperationEvent(op) = msg.kind {
+    if let IngestionMessageKind::OperationEvent { op, .. } = msg.kind {
         if let Operation::Insert { new: record } = op {
             assert_eq!(record.values[0].as_int(), Some(1675));
             assert_eq!(record.values[1].as_string(), Some("dario"));

--- a/dozer-ingestion/src/connectors/kafka/debezium/mapper.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/mapper.rs
@@ -311,7 +311,6 @@ mod tests {
         let value = Value::from(v);
 
         let schema = Schema {
-            identifier: None,
             fields: vec![
                 FieldDefinition {
                     name: "id".to_string(),
@@ -401,7 +400,6 @@ mod tests {
         let value = Value::from(v);
 
         let schema = Schema {
-            identifier: None,
             fields: vec![
                 FieldDefinition {
                     name: "id".to_string(),

--- a/dozer-ingestion/src/connectors/kafka/debezium/schema.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/schema.rs
@@ -5,7 +5,7 @@ use crate::connectors::kafka::debezium::stream_consumer::DebeziumSchemaStruct;
 
 use crate::errors::KafkaSchemaError;
 use crate::errors::KafkaSchemaError::{SchemaDefinitionNotFound, TypeNotSupported};
-use dozer_types::types::{FieldDefinition, FieldType, Schema, SchemaIdentifier, SourceDefinition};
+use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 
 // Reference: https://debezium.io/documentation/reference/0.9/connectors/postgresql.html
 pub fn map_type(schema: &DebeziumSchemaStruct) -> Result<FieldType, KafkaSchemaError> {
@@ -85,7 +85,6 @@ pub fn map_schema(
 
                 Ok((
                     Schema {
-                        identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
                         fields: defined_fields?,
                         primary_index: pk_keys_indexes,
                     },
@@ -105,9 +104,7 @@ mod tests {
     use crate::errors::KafkaSchemaError::SchemaDefinitionNotFound;
     use crate::errors::KafkaSchemaError::TypeNotSupported;
     use dozer_types::serde_json::Value;
-    use dozer_types::types::{
-        FieldDefinition, FieldType, Schema, SchemaIdentifier, SourceDefinition,
-    };
+    use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 
     #[test]
     fn test_it_fails_when_schema_empty() {
@@ -194,7 +191,6 @@ mod tests {
 
         let (schema, _) = map_schema(&schema, &key_schema).unwrap();
         let expected_schema = Schema {
-            identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
             fields: vec![
                 FieldDefinition {
                     name: "id".to_string(),
@@ -246,7 +242,6 @@ mod tests {
 
         let (schema, _) = map_schema(&schema, &key_schema).unwrap();
         let expected_schema = Schema {
-            identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
             fields: vec![],
             primary_index: vec![],
         };

--- a/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
@@ -8,7 +8,7 @@ use crate::errors::KafkaSchemaError::TypeNotSupported;
 use crate::errors::{ConnectorError, KafkaError, KafkaSchemaError};
 use dozer_types::serde_json;
 use dozer_types::serde_json::Value;
-use dozer_types::types::{FieldDefinition, FieldType, Schema, SchemaIdentifier, SourceDefinition};
+use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 use schema_registry_converter::async_impl::schema_registry::SrSettings;
 use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
 use std::collections::HashMap;
@@ -125,7 +125,6 @@ impl SchemaRegistry {
                         .collect();
 
                     let schema = Schema {
-                        identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
                         fields: defined_fields?,
                         primary_index: pk_keys_indexes,
                     };

--- a/dozer-ingestion/src/connectors/kafka/debezium/stream_consumer.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/stream_consumer.rs
@@ -9,7 +9,7 @@ use dozer_types::ingestion_types::IngestionMessage;
 use dozer_types::serde::{Deserialize, Serialize};
 use dozer_types::serde_json;
 use dozer_types::serde_json::Value;
-use dozer_types::types::{Operation, Record, SchemaIdentifier};
+use dozer_types::types::{Operation, Record};
 use rdkafka::consumer::BaseConsumer;
 
 use crate::connectors::TableInfo;
@@ -130,14 +130,13 @@ impl StreamConsumer for DebeziumStreamConsumer {
                             .handle_message(IngestionMessage::new_op(
                                 0,
                                 0,
+                                0,
                                 Operation::Update {
                                     old: Record {
-                                        schema_id: Some(SchemaIdentifier { id: 1, version: 1 }),
                                         values: old,
                                         lifetime: None,
                                     },
                                     new: Record {
-                                        schema_id: Some(SchemaIdentifier { id: 1, version: 1 }),
                                         values: new,
                                         lifetime: None,
                                     },
@@ -155,9 +154,9 @@ impl StreamConsumer for DebeziumStreamConsumer {
                             .handle_message(IngestionMessage::new_op(
                                 0,
                                 0,
+                                0,
                                 Operation::Delete {
                                     old: Record {
-                                        schema_id: Some(SchemaIdentifier { id: 1, version: 1 }),
                                         values: old,
                                         lifetime: None,
                                     },
@@ -175,9 +174,9 @@ impl StreamConsumer for DebeziumStreamConsumer {
                             .handle_message(IngestionMessage::new_op(
                                 0,
                                 0,
+                                0,
                                 Operation::Insert {
                                     new: Record {
-                                        schema_id: Some(SchemaIdentifier { id: 1, version: 1 }),
                                         values: new,
                                         lifetime: None,
                                     },

--- a/dozer-ingestion/src/connectors/kafka/no_schema_registry_basic.rs
+++ b/dozer-ingestion/src/connectors/kafka/no_schema_registry_basic.rs
@@ -4,14 +4,13 @@ use crate::connectors::{CdcType, SourceSchema};
 
 use crate::errors::ConnectorError;
 
-use dozer_types::types::{FieldDefinition, FieldType, Schema, SchemaIdentifier, SourceDefinition};
+use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 
 pub struct NoSchemaRegistryBasic {}
 
 impl NoSchemaRegistryBasic {
-    pub fn get_single_schema(id: u32) -> SourceSchema {
+    pub fn get_single_schema() -> SourceSchema {
         let schema = Schema {
-            identifier: Some(SchemaIdentifier { id, version: 1 }),
             fields: vec![
                 FieldDefinition {
                     name: "key".to_string(),
@@ -35,8 +34,8 @@ impl NoSchemaRegistryBasic {
     pub fn get_schema(table_names: Option<&[String]>) -> Result<Vec<SourceSchema>, ConnectorError> {
         let mut schemas = vec![];
         if let Some(tables) = table_names {
-            for (id, _table_name) in tables.iter().enumerate() {
-                let schema = Self::get_single_schema(id as u32);
+            for _ in 0..tables.len() {
+                let schema = Self::get_single_schema();
                 schemas.push(schema);
             }
         }

--- a/dozer-ingestion/src/connectors/kafka/schema_registry_basic.rs
+++ b/dozer-ingestion/src/connectors/kafka/schema_registry_basic.rs
@@ -5,7 +5,7 @@ use crate::connectors::{CdcType, SourceSchema};
 
 use crate::errors::{ConnectorError, KafkaError};
 
-use dozer_types::types::{FieldDefinition, Schema, SchemaIdentifier, SourceDefinition};
+use dozer_types::types::{FieldDefinition, Schema, SourceDefinition};
 
 use crate::connectors::kafka::debezium::schema_registry::SchemaRegistry;
 use schema_registry_converter::async_impl::schema_registry::SrSettings;
@@ -15,7 +15,6 @@ pub struct SchemaRegistryBasic {}
 
 impl SchemaRegistryBasic {
     pub async fn get_single_schema(
-        id: u32,
         table_name: &str,
         schema_registry_url: &str,
     ) -> Result<(SourceSchema, HashMap<String, DebeziumSchemaStruct>), ConnectorError> {
@@ -56,7 +55,6 @@ impl SchemaRegistryBasic {
             .collect();
 
         let schema = Schema {
-            identifier: Some(SchemaIdentifier { id, version: 1 }),
             fields: defined_fields?,
             primary_index: pk_keys_indexes,
         };
@@ -73,9 +71,8 @@ impl SchemaRegistryBasic {
     ) -> Result<Vec<SourceSchema>, ConnectorError> {
         let mut schemas = vec![];
         if let Some(tables) = table_names {
-            for (index, table_name) in tables.iter().enumerate() {
-                let (schema, _) =
-                    Self::get_single_schema(index as u32, table_name, &schema_registry_url).await?;
+            for table_name in tables.iter() {
+                let (schema, _) = Self::get_single_schema(table_name, &schema_registry_url).await?;
                 schemas.push(schema);
             }
         }

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -181,23 +181,21 @@ pub fn get_connector(connection: Connection) -> Result<Box<dyn Connector>, Conne
         }
         #[cfg(feature = "ethereum")]
         ConnectionConfig::Ethereum(eth_config) => match eth_config.provider.unwrap() {
-            dozer_types::ingestion_types::EthProviderConfig::Log(log_config) => Ok(Box::new(
-                EthLogConnector::new(2, log_config, connection.name),
-            )),
+            dozer_types::ingestion_types::EthProviderConfig::Log(log_config) => {
+                Ok(Box::new(EthLogConnector::new(log_config, connection.name)))
+            }
             dozer_types::ingestion_types::EthProviderConfig::Trace(trace_config) => Ok(Box::new(
-                EthTraceConnector::new(2, trace_config, connection.name),
+                EthTraceConnector::new(trace_config, connection.name),
             )),
         },
         #[cfg(not(feature = "ethereum"))]
         ConnectionConfig::Ethereum(_) => Err(ConnectorError::EthereumFeatureNotEnabled),
         ConnectionConfig::Grpc(grpc_config) => match grpc_config.adapter.as_str() {
             "arrow" => Ok(Box::new(GrpcConnector::<ArrowAdapter>::new(
-                3,
                 connection.name,
                 grpc_config,
             )?)),
             "default" => Ok(Box::new(GrpcConnector::<DefaultAdapter>::new(
-                3,
                 connection.name,
                 grpc_config,
             )?)),
@@ -219,13 +217,13 @@ pub fn get_connector(connection: Connection) -> Result<Box<dyn Connector>, Conne
         #[cfg(not(feature = "kafka"))]
         ConnectionConfig::Kafka(_) => Err(ConnectorError::KafkaFeatureNotEnabled),
         ConnectionConfig::S3Storage(object_store_config) => {
-            Ok(Box::new(ObjectStoreConnector::new(5, object_store_config)))
+            Ok(Box::new(ObjectStoreConnector::new(object_store_config)))
         }
         ConnectionConfig::LocalStorage(object_store_config) => {
-            Ok(Box::new(ObjectStoreConnector::new(5, object_store_config)))
+            Ok(Box::new(ObjectStoreConnector::new(object_store_config)))
         }
         ConnectionConfig::DeltaLake(delta_lake_config) => {
-            Ok(Box::new(DeltaLakeConnector::new(6, delta_lake_config)))
+            Ok(Box::new(DeltaLakeConnector::new(delta_lake_config)))
         }
     }
 }

--- a/dozer-ingestion/src/connectors/object_store/csv/csv_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/csv/csv_table.rs
@@ -52,7 +52,7 @@ impl<T: DozerObjectStore + Send> CsvTable<T> {
 
     async fn read(
         &self,
-        id: u32,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
@@ -145,7 +145,7 @@ impl<T: DozerObjectStore + Send> CsvTable<T> {
                         .unwrap();
 
                     let result = connectors::object_store::table_reader::TableReader::<T>::read(
-                        id,
+                        table_index,
                         ctx.clone(),
                         file_path,
                         listing_options.clone(),
@@ -171,7 +171,7 @@ impl<T: DozerObjectStore + Send> CsvTable<T> {
 impl<T: DozerObjectStore + Send> TableWatcher for CsvTable<T> {
     async fn snapshot(
         &self,
-        id: usize,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<JoinHandle<(usize, HashMap<object_store::path::Path, DateTime<Utc>>)>, ConnectorError>
@@ -261,7 +261,7 @@ impl<T: DozerObjectStore + Send> TableWatcher for CsvTable<T> {
                     .unwrap();
 
                 let result = connectors::object_store::table_reader::TableReader::<T>::read(
-                    id as u32,
+                    table_index,
                     ctx.clone(),
                     file_path,
                     listing_options.clone(),
@@ -273,7 +273,7 @@ impl<T: DozerObjectStore + Send> TableWatcher for CsvTable<T> {
                     sender.send(Err(e)).await.unwrap();
                 }
             }
-            (id, update_state)
+            (table_index, update_state)
         });
 
         Ok(h)
@@ -281,11 +281,11 @@ impl<T: DozerObjectStore + Send> TableWatcher for CsvTable<T> {
 
     async fn ingest(
         &self,
-        id: usize,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
-        self.read(id as u32, table, sender).await?;
+        self.read(table_index, table, sender).await?;
         Ok(())
     }
 }

--- a/dozer-ingestion/src/connectors/object_store/parquet/parquet_table.rs
+++ b/dozer-ingestion/src/connectors/object_store/parquet/parquet_table.rs
@@ -50,7 +50,7 @@ impl<T: DozerObjectStore + Send> ParquetTable<T> {
 
     async fn read(
         &self,
-        id: u32,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
@@ -143,7 +143,7 @@ impl<T: DozerObjectStore + Send> ParquetTable<T> {
                         .unwrap();
 
                     let result = connectors::object_store::table_reader::TableReader::<T>::read(
-                        id,
+                        table_index,
                         ctx.clone(),
                         file_path,
                         listing_options.clone(),
@@ -169,7 +169,7 @@ impl<T: DozerObjectStore + Send> ParquetTable<T> {
 impl<T: DozerObjectStore + Send> TableWatcher for ParquetTable<T> {
     async fn snapshot(
         &self,
-        id: usize,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<JoinHandle<(usize, HashMap<object_store::path::Path, DateTime<Utc>>)>, ConnectorError>
@@ -259,7 +259,7 @@ impl<T: DozerObjectStore + Send> TableWatcher for ParquetTable<T> {
                     .unwrap();
 
                 let result = connectors::object_store::table_reader::TableReader::<T>::read(
-                    id as u32,
+                    table_index,
                     ctx.clone(),
                     file_path,
                     listing_options.clone(),
@@ -271,7 +271,7 @@ impl<T: DozerObjectStore + Send> TableWatcher for ParquetTable<T> {
                     sender.send(Err(e)).await.unwrap();
                 }
             }
-            (id, update_state)
+            (table_index, update_state)
         });
 
         Ok(h)
@@ -279,11 +279,11 @@ impl<T: DozerObjectStore + Send> TableWatcher for ParquetTable<T> {
 
     async fn ingest(
         &self,
-        id: usize,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
-        self.read(id as u32, table, sender).await?;
+        self.read(table_index, table, sender).await?;
         Ok(())
     }
 }

--- a/dozer-ingestion/src/connectors/object_store/table_watcher.rs
+++ b/dozer-ingestion/src/connectors/object_store/table_watcher.rs
@@ -38,24 +38,24 @@ impl PartialEq for FileInfo {
 pub trait TableWatcher {
     async fn watch(
         &self,
-        id: usize,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
-        self.ingest(id, table, sender.clone()).await?;
+        self.ingest(table_index, table, sender.clone()).await?;
         Ok(())
     }
 
     async fn snapshot(
         &self,
-        id: usize,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<JoinHandle<(usize, HashMap<object_store::path::Path, DateTime<Utc>>)>, ConnectorError>;
 
     async fn ingest(
         &self,
-        id: usize,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError>;

--- a/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
+++ b/dozer-ingestion/src/connectors/object_store/tests/local_storage_tests.rs
@@ -24,7 +24,7 @@ macro_rules! test_type_conversion {
 async fn test_get_schema_of_parquet() {
     let local_storage = get_local_storage_config("parquet");
 
-    let connector = ObjectStoreConnector::new(1, local_storage);
+    let connector = ObjectStoreConnector::new(local_storage);
     let (_, schemas) = connector.list_all_schemas().await.unwrap();
     let schema = schemas.get(0).unwrap();
 
@@ -46,7 +46,7 @@ async fn test_get_schema_of_parquet() {
 async fn test_get_schema_of_csv() {
     let local_storage = get_local_storage_config("csv");
 
-    let connector = ObjectStoreConnector::new(1, local_storage);
+    let connector = ObjectStoreConnector::new(local_storage);
     let (_, schemas) = connector.list_all_schemas().await.unwrap();
     let schema = schemas.get(0).unwrap();
 
@@ -66,7 +66,7 @@ async fn test_get_schema_of_csv() {
 async fn test_read_parquet_file() {
     let local_storage = get_local_storage_config("parquet");
 
-    let connector = ObjectStoreConnector::new(1, local_storage);
+    let connector = ObjectStoreConnector::new(local_storage);
 
     let config = IngestionConfig::default();
     let (ingestor, mut iterator) = Ingestor::initialize_channel(config);
@@ -95,7 +95,11 @@ async fn test_read_parquet_file() {
         let row = iterator.next();
         if let Some(IngestionMessage {
             identifier: OpIdentifier { seq_in_tx, .. },
-            kind: IngestionMessageKind::OperationEvent(Operation::Insert { new }),
+            kind:
+                IngestionMessageKind::OperationEvent {
+                    op: Operation::Insert { new },
+                    ..
+                },
         }) = row
         {
             let values = new.values;
@@ -136,7 +140,7 @@ async fn test_read_parquet_file() {
 async fn test_csv_read() {
     let local_storage = get_local_storage_config("csv");
 
-    let connector = ObjectStoreConnector::new(1, local_storage);
+    let connector = ObjectStoreConnector::new(local_storage);
 
     let config = IngestionConfig::default();
     let (ingestor, mut iterator) = Ingestor::initialize_channel(config);
@@ -167,7 +171,11 @@ async fn test_csv_read() {
         let row = iterator.next();
         if let Some(IngestionMessage {
             identifier: OpIdentifier { seq_in_tx, .. },
-            kind: IngestionMessageKind::OperationEvent(Operation::Insert { new }),
+            kind:
+                IngestionMessageKind::OperationEvent {
+                    op: Operation::Insert { new },
+                    ..
+                },
         }) = row
         {
             let values = new.values;
@@ -228,7 +236,7 @@ async fn test_missing_directory() {
     local_storage.details = Some(LocalDetails {
         path: "not_existing_path".to_string(),
     });
-    let connector = ObjectStoreConnector::new(1, local_storage);
+    let connector = ObjectStoreConnector::new(local_storage);
 
     let tables = connector
         .list_columns(connector.list_tables().await.unwrap())

--- a/dozer-ingestion/src/connectors/object_store/watcher.rs
+++ b/dozer-ingestion/src/connectors/object_store/watcher.rs
@@ -50,7 +50,7 @@ impl PartialEq for FileInfo {
 pub trait Watcher<T> {
     async fn watch(
         &self,
-        id: u32,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError>;
@@ -60,7 +60,7 @@ pub trait Watcher<T> {
 impl<T: DozerObjectStore> Watcher<T> for TableReader<T> {
     async fn watch(
         &self,
-        id: u32,
+        table_index: usize,
         table: &TableInfo,
         sender: Sender<Result<Option<IngestionMessageKind>, ObjectStoreConnectorError>>,
     ) -> Result<(), ConnectorError> {
@@ -148,7 +148,7 @@ impl<T: DozerObjectStore> Watcher<T> for TableReader<T> {
                         .unwrap();
 
                     let result = Self::read(
-                        id,
+                        table_index,
                         ctx.clone(),
                         file_path,
                         listing_options.clone(),

--- a/dozer-ingestion/src/connectors/postgres/connection/validator.rs
+++ b/dozer-ingestion/src/connectors/postgres/connection/validator.rs
@@ -364,10 +364,13 @@ mod tests {
             match result {
                 Ok(_) => panic!("Validation should fail"),
                 Err(e) => {
-                    assert!(matches!(e, PostgresConnectorError::TableError(_)));
+                    assert!(matches!(e, PostgresConnectorError::TablesNotFound(_)));
 
-                    if let PostgresConnectorError::TableError(msg) = e {
-                        assert_eq!(msg, vec!["public.not_existing".to_string()]);
+                    if let PostgresConnectorError::TablesNotFound(msg) = e {
+                        assert_eq!(
+                            msg,
+                            vec![("public".to_string(), "not_existing".to_string())]
+                        );
                     } else {
                         panic!("Unexpected error occurred");
                     }

--- a/dozer-ingestion/src/connectors/postgres/connector.rs
+++ b/dozer-ingestion/src/connectors/postgres/connector.rs
@@ -11,7 +11,7 @@ use rand::distributions::Alphanumeric;
 use rand::Rng;
 use tonic::async_trait;
 
-use crate::connectors::postgres::schema::helper::SchemaHelper;
+use crate::connectors::postgres::schema::helper::{SchemaHelper, DEFAULT_SCHEMA_NAME};
 use crate::errors::ConnectorError::PostgresConnectorError;
 use crate::errors::PostgresConnectorError::{CreatePublicationError, DropPublicationError};
 use tokio_postgres::config::ReplicationMode;
@@ -232,7 +232,10 @@ impl PostgresConnector {
                     .map(|table_identifier| {
                         format!(
                             "{}.{}",
-                            table_identifier.schema.as_deref().unwrap_or("public"),
+                            table_identifier
+                                .schema
+                                .as_deref()
+                                .unwrap_or(DEFAULT_SCHEMA_NAME),
                             table_identifier.name
                         )
                     })

--- a/dozer-ingestion/src/errors.rs
+++ b/dozer-ingestion/src/errors.rs
@@ -146,8 +146,8 @@ pub enum PostgresConnectorError {
     #[error("WAL level should be 'logical'")]
     WALLevelIsNotCorrect(),
 
-    #[error("Cannot find table: {:?}", .0.join(", "))]
-    TableError(Vec<String>),
+    #[error("Cannot find tables {0:?}")]
+    TablesNotFound(Vec<(String, String)>),
 
     #[error("Cannot find column {0} in {1}")]
     ColumnNotFound(String, String),
@@ -226,6 +226,20 @@ pub enum PostgresConnectorError {
 
     #[error("Failed to load native certs: {0}")]
     LoadNativeCerts(#[source] std::io::Error),
+
+    #[error("Non utf8 column name in table {table_index} column {column_index}")]
+    NonUtf8ColumnName {
+        table_index: usize,
+        column_index: usize,
+    },
+
+    #[error("Column type changed in table {table_index} column {column_name} from {old_type} to {new_type}")]
+    ColumnTypeChanged {
+        table_index: usize,
+        column_name: String,
+        old_type: postgres_types::Type,
+        new_type: postgres_types::Type,
+    },
 }
 
 #[derive(Error, Debug)]

--- a/dozer-ingestion/src/ingestion/ingestor.rs
+++ b/dozer-ingestion/src/ingestion/ingestor.rs
@@ -91,19 +91,19 @@ mod tests {
 
         // Expected seq no - 2
         let operation = Operation::Insert {
-            new: Record::new(None, vec![]),
+            new: Record::new(vec![]),
         };
 
         // Expected seq no - 3
         let operation2 = Operation::Insert {
-            new: Record::new(None, vec![]),
+            new: Record::new(vec![]),
         };
 
         ingestor
-            .handle_message(IngestionMessage::new_op(1, 2, operation.clone()))
+            .handle_message(IngestionMessage::new_op(1, 2, 0, operation.clone()))
             .unwrap();
         ingestor
-            .handle_message(IngestionMessage::new_op(1, 3, operation2.clone()))
+            .handle_message(IngestionMessage::new_op(1, 3, 0, operation2.clone()))
             .unwrap();
         ingestor
             .handle_message(IngestionMessage::new_snapshotting_done(1, 4))
@@ -111,9 +111,12 @@ mod tests {
 
         let expected_op_event_message = vec![operation, operation2].into_iter();
 
-        for x in expected_op_event_message {
+        for op in expected_op_event_message {
             let msg = rx.recv().unwrap();
-            assert_eq!(IngestionMessageKind::OperationEvent(x), msg.kind);
+            assert_eq!(
+                IngestionMessageKind::OperationEvent { table_index: 0, op },
+                msg.kind
+            );
         }
     }
 }

--- a/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/object_store/local_storage.rs
@@ -97,7 +97,7 @@ fn create_connector(
             name: table_name,
         }],
     };
-    let connector = ObjectStoreConnector::new(0, local_storage);
+    let connector = ObjectStoreConnector::new(local_storage);
 
     (temp_dir, connector)
 }

--- a/dozer-sql/src/pipeline/aggregation/processor.rs
+++ b/dozer-sql/src/pipeline/aggregation/processor.rs
@@ -109,7 +109,6 @@ impl AggregationProcessor {
             having_eval_schema: Schema {
                 fields: having_eval_schema_fields,
                 primary_index: vec![],
-                identifier: None,
             },
         })
     }
@@ -503,7 +502,7 @@ impl AggregationProcessor {
             output.push(exp.evaluate(original, aggregation_schema)?);
         }
         original.values.drain(original_len..);
-        let mut output_record = Record::new(None, output);
+        let mut output_record = Record::new(output);
 
         output_record.set_lifetime(original.get_lifetime());
 

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_count_tests.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_count_tests.rs
@@ -29,8 +29,8 @@ fn test_count_star() {
     output!(processor, insert_field(ITALY, FIELD_100_FLOAT));
     let out = output!(processor, insert_field(ITALY, FIELD_100_FLOAT));
     let exp = vec![Operation::Update {
-        old: Record::new(None, vec![FIELD_1_INT.clone()]),
-        new: Record::new(None, vec![FIELD_2_INT.clone()]),
+        old: Record::new(vec![FIELD_1_INT.clone()]),
+        new: Record::new(vec![FIELD_2_INT.clone()]),
     }];
     assert_eq!(out, exp);
 }

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_null.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_null.rs
@@ -29,19 +29,16 @@ fn test_sum_aggregation_null() {
         SUM = 100.0
     */
     let inp = Operation::Insert {
-        new: Record::new(
-            None,
-            vec![
-                Field::Int(0),
-                Field::Null,
-                FIELD_100_INT.clone(),
-                FIELD_100_INT.clone(),
-            ],
-        ),
+        new: Record::new(vec![
+            Field::Int(0),
+            Field::Null,
+            FIELD_100_INT.clone(),
+            FIELD_100_INT.clone(),
+        ]),
     };
     let out = output!(processor, inp);
     let exp = vec![Operation::Insert {
-        new: Record::new(None, vec![Field::Null, FIELD_100_INT.clone()]),
+        new: Record::new(vec![Field::Null, FIELD_100_INT.clone()]),
     }];
     assert_eq!(out, exp);
 }

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_test_planner.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_test_planner.rs
@@ -8,7 +8,7 @@ use dozer_types::types::{
 #[test]
 fn test_planner_with_aggregator() {
     let sql = "SELECT CONCAT(city,'/',country), CONCAT('Total: ', CAST(SUM(adults_count + children_count) AS STRING), ' people') as headcounts GROUP BY CONCAT(city,'/',country)";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "household_name".to_string(),
@@ -89,31 +89,25 @@ fn test_planner_with_aggregator() {
 
     let _r = processor
         .aggregate(Operation::Insert {
-            new: Record::new(
-                None,
-                vec![
-                    Field::String("John Smith".to_string()),
-                    Field::String("Johor".to_string()),
-                    Field::String("Malaysia".to_string()),
-                    Field::Int(2),
-                    Field::Int(1),
-                ],
-            ),
+            new: Record::new(vec![
+                Field::String("John Smith".to_string()),
+                Field::String("Johor".to_string()),
+                Field::String("Malaysia".to_string()),
+                Field::Int(2),
+                Field::Int(1),
+            ]),
         })
         .unwrap();
 
     let _r = processor
         .aggregate(Operation::Insert {
-            new: Record::new(
-                None,
-                vec![
-                    Field::String("Todd Enton".to_string()),
-                    Field::String("Johor".to_string()),
-                    Field::String("Malaysia".to_string()),
-                    Field::Int(2),
-                    Field::Int(2),
-                ],
-            ),
+            new: Record::new(vec![
+                Field::String("Todd Enton".to_string()),
+                Field::String("Johor".to_string()),
+                Field::String("Malaysia".to_string()),
+                Field::Int(2),
+                Field::Int(2),
+            ]),
         })
         .unwrap();
 }

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_tests_utils.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_tests_utils.rs
@@ -43,7 +43,7 @@ pub(crate) fn init_processor(
 }
 
 pub(crate) fn init_input_schema(field_type: FieldType, aggregator_name: &str) -> Schema {
-    Schema::empty()
+    Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("ID"),
@@ -84,7 +84,7 @@ pub(crate) fn init_input_schema(field_type: FieldType, aggregator_name: &str) ->
 }
 
 pub(crate) fn init_val_input_schema(field_type: FieldType, aggregator_name: &str) -> Schema {
-    Schema::empty()
+    Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("ID"),
@@ -126,29 +126,23 @@ pub(crate) fn init_val_input_schema(field_type: FieldType, aggregator_name: &str
 
 pub(crate) fn insert_field(country: &str, insert_field: &Field) -> Operation {
     Operation::Insert {
-        new: Record::new(
-            None,
-            vec![
-                Field::Int(0),
-                Field::String(country.to_string()),
-                insert_field.clone(),
-                insert_field.clone(),
-            ],
-        ),
+        new: Record::new(vec![
+            Field::Int(0),
+            Field::String(country.to_string()),
+            insert_field.clone(),
+            insert_field.clone(),
+        ]),
     }
 }
 
 pub(crate) fn delete_field(country: &str, deleted_field: &Field) -> Operation {
     Operation::Delete {
-        old: Record::new(
-            None,
-            vec![
-                Field::Int(0),
-                Field::String(country.to_string()),
-                deleted_field.clone(),
-                deleted_field.clone(),
-            ],
-        ),
+        old: Record::new(vec![
+            Field::Int(0),
+            Field::String(country.to_string()),
+            deleted_field.clone(),
+            deleted_field.clone(),
+        ]),
     }
 }
 
@@ -159,61 +153,55 @@ pub(crate) fn update_field(
     new: &Field,
 ) -> Operation {
     Operation::Update {
-        old: Record::new(
-            None,
-            vec![
-                Field::Int(0),
-                Field::String(old_country.to_string()),
-                old.clone(),
-                old.clone(),
-            ],
-        ),
-        new: Record::new(
-            None,
-            vec![
-                Field::Int(0),
-                Field::String(new_country.to_string()),
-                new.clone(),
-                new.clone(),
-            ],
-        ),
+        old: Record::new(vec![
+            Field::Int(0),
+            Field::String(old_country.to_string()),
+            old.clone(),
+            old.clone(),
+        ]),
+        new: Record::new(vec![
+            Field::Int(0),
+            Field::String(new_country.to_string()),
+            new.clone(),
+            new.clone(),
+        ]),
     }
 }
 
 pub(crate) fn insert_val_exp(inserted_field: &Field) -> Operation {
     Operation::Insert {
-        new: Record::new(None, vec![inserted_field.clone()]),
+        new: Record::new(vec![inserted_field.clone()]),
     }
 }
 
 pub(crate) fn delete_val_exp(deleted_field: &Field) -> Operation {
     Operation::Delete {
-        old: Record::new(None, vec![deleted_field.clone()]),
+        old: Record::new(vec![deleted_field.clone()]),
     }
 }
 
 pub(crate) fn update_val_exp(old: &Field, new: &Field) -> Operation {
     Operation::Update {
-        old: Record::new(None, vec![old.clone()]),
-        new: Record::new(None, vec![new.clone()]),
+        old: Record::new(vec![old.clone()]),
+        new: Record::new(vec![new.clone()]),
     }
 }
 
 pub(crate) fn insert_exp(country: &str, inserted_field: &Field) -> Operation {
     Operation::Insert {
-        new: Record::new(
-            None,
-            vec![Field::String(country.to_string()), inserted_field.clone()],
-        ),
+        new: Record::new(vec![
+            Field::String(country.to_string()),
+            inserted_field.clone(),
+        ]),
     }
 }
 
 pub(crate) fn delete_exp(country: &str, deleted_field: &Field) -> Operation {
     Operation::Delete {
-        old: Record::new(
-            None,
-            vec![Field::String(country.to_string()), deleted_field.clone()],
-        ),
+        old: Record::new(vec![
+            Field::String(country.to_string()),
+            deleted_field.clone(),
+        ]),
     }
 }
 
@@ -224,14 +212,8 @@ pub(crate) fn update_exp(
     new: &Field,
 ) -> Operation {
     Operation::Update {
-        old: Record::new(
-            None,
-            vec![Field::String(old_country.to_string()), old.clone()],
-        ),
-        new: Record::new(
-            None,
-            vec![Field::String(new_country.to_string()), new.clone()],
-        ),
+        old: Record::new(vec![Field::String(old_country.to_string()), old.clone()]),
+        new: Record::new(vec![Field::String(new_country.to_string()), new.clone()]),
     }
 }
 

--- a/dozer-sql/src/pipeline/expression/tests/case.rs
+++ b/dozer-sql/src/pipeline/expression/tests/case.rs
@@ -11,7 +11,7 @@ fn test_case() {
                     ELSE 'The age is under 11' \
                 END AS age_text \
             FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("first_name"),
@@ -46,7 +46,7 @@ fn test_case_else() {
                     ELSE 'The age is under 11' \
                 END AS age_text \
             FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("first_name"),
@@ -80,7 +80,7 @@ fn test_case_no_else() {
                     WHEN age = 11 THEN 'The age is 11' \
                 END AS age_text \
             FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("first_name"),

--- a/dozer-sql/src/pipeline/expression/tests/cast.rs
+++ b/dozer-sql/src/pipeline/expression/tests/cast.rs
@@ -16,7 +16,7 @@ use num_traits::FromPrimitive;
 fn test_uint() {
     let f = run_fct(
         "SELECT CAST(field AS UINT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -33,7 +33,7 @@ fn test_uint() {
 
     let f = run_fct(
         "SELECT CAST(field AS UINT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -50,7 +50,7 @@ fn test_uint() {
 
     let f = run_fct(
         "SELECT CAST(field AS UINT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -70,7 +70,7 @@ fn test_uint() {
 fn test_u128() {
     let f = run_fct(
         "SELECT CAST(field AS U128) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -87,7 +87,7 @@ fn test_u128() {
 
     let f = run_fct(
         "SELECT CAST(field AS U128) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -104,7 +104,7 @@ fn test_u128() {
 
     let f = run_fct(
         "SELECT CAST(field AS U128) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -124,7 +124,7 @@ fn test_u128() {
 fn test_int() {
     let f = run_fct(
         "SELECT CAST(field AS INT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -141,7 +141,7 @@ fn test_int() {
 
     let f = run_fct(
         "SELECT CAST(field AS INT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -158,7 +158,7 @@ fn test_int() {
 
     let f = run_fct(
         "SELECT CAST(field AS INT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -178,7 +178,7 @@ fn test_int() {
 fn test_i128() {
     let f = run_fct(
         "SELECT CAST(field AS I128) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -195,7 +195,7 @@ fn test_i128() {
 
     let f = run_fct(
         "SELECT CAST(field AS I128) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -212,7 +212,7 @@ fn test_i128() {
 
     let f = run_fct(
         "SELECT CAST(field AS I128) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -232,7 +232,7 @@ fn test_i128() {
 fn test_float() {
     let f = run_fct(
         "SELECT CAST(field AS FLOAT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -252,7 +252,7 @@ fn test_float() {
 
     let f = run_fct(
         "SELECT CAST(field AS FLOAT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -269,7 +269,7 @@ fn test_float() {
 
     let f = run_fct(
         "SELECT CAST(field AS FLOAT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -286,7 +286,7 @@ fn test_float() {
 
     let f = run_fct(
         "SELECT CAST(field AS FLOAT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -303,7 +303,7 @@ fn test_float() {
 
     let f = run_fct(
         "SELECT CAST(field AS FLOAT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -323,7 +323,7 @@ fn test_float() {
 fn test_boolean() {
     let f = run_fct(
         "SELECT CAST(field AS BOOLEAN) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -340,7 +340,7 @@ fn test_boolean() {
 
     let f = run_fct(
         "SELECT CAST(field AS BOOLEAN) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -357,7 +357,7 @@ fn test_boolean() {
 
     let f = run_fct(
         "SELECT CAST(field AS BOOLEAN) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -374,7 +374,7 @@ fn test_boolean() {
 
     let f = run_fct(
         "SELECT CAST(field AS BOOLEAN) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -391,7 +391,7 @@ fn test_boolean() {
 
     let f = run_fct(
         "SELECT CAST(field AS BOOLEAN) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -408,7 +408,7 @@ fn test_boolean() {
 
     let f = run_fct(
         "SELECT CAST(field AS BOOLEAN) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -428,7 +428,7 @@ fn test_boolean() {
 fn test_string() {
     // let f = run_scalar_fct(
     //     "SELECT CAST(field AS STRING) FROM users",
-    //     Schema::empty()
+    //     Schema::default()
     //         .field(
     //             FieldDefinition::new(String::from("field"), FieldType::Binary, false),
     //             false,
@@ -440,7 +440,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -457,7 +457,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -474,7 +474,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -491,7 +491,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -508,7 +508,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -525,7 +525,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -542,7 +542,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -559,7 +559,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -578,7 +578,7 @@ fn test_string() {
 
     let f = run_fct(
         "SELECT CAST(field AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -598,7 +598,7 @@ fn test_string() {
 fn test_text() {
     // let f = run_scalar_fct(
     //     "SELECT CAST(field AS STRING) FROM users",
-    //     Schema::empty()
+    //     Schema::default()
     //         .field(
     //             FieldDefinition::new(String::from("field"), FieldType::Binary, false),
     //             false,
@@ -610,7 +610,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -627,7 +627,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -644,7 +644,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -661,7 +661,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -678,7 +678,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -695,7 +695,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -712,7 +712,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -729,7 +729,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -748,7 +748,7 @@ fn test_text() {
 
     let f = run_fct(
         "SELECT CAST(field AS TEXT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -779,85 +779,85 @@ fn test_decimal() {
     let uint1 = Box::new(Literal(Field::UInt(1_u64)));
     let uint2 = Box::new(Literal(Field::UInt(2_u64)));
 
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
     // left: Int, right: Decimal
     assert_eq!(
-        evaluate_add(&Schema::empty(), &int1, dec1.as_ref(), &row)
+        evaluate_add(&Schema::default(), &int1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_sub(&Schema::empty(), &int1, dec1.as_ref(), &row)
+        evaluate_sub(&Schema::default(), &int1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
     assert_eq!(
-        evaluate_mul(&Schema::empty(), &int2, dec1.as_ref(), &row)
+        evaluate_mul(&Schema::default(), &int2, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_div(&Schema::empty(), &int1, dec2.as_ref(), &row)
+        evaluate_div(&Schema::default(), &int1, dec2.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_f64(0.5).unwrap())
     );
     assert_eq!(
-        evaluate_mod(&Schema::empty(), &int1, dec1.as_ref(), &row)
+        evaluate_mod(&Schema::default(), &int1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
 
     // left: UInt, right: Decimal
     assert_eq!(
-        evaluate_add(&Schema::empty(), &uint1, dec1.as_ref(), &row)
+        evaluate_add(&Schema::default(), &uint1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_sub(&Schema::empty(), &uint1, dec1.as_ref(), &row)
+        evaluate_sub(&Schema::default(), &uint1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
     assert_eq!(
-        evaluate_mul(&Schema::empty(), &uint2, dec1.as_ref(), &row)
+        evaluate_mul(&Schema::default(), &uint2, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_div(&Schema::empty(), &uint1, dec2.as_ref(), &row)
+        evaluate_div(&Schema::default(), &uint1, dec2.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_f64(0.5).unwrap())
     );
     assert_eq!(
-        evaluate_mod(&Schema::empty(), &uint1, dec1.as_ref(), &row)
+        evaluate_mod(&Schema::default(), &uint1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
 
     // left: Float, right: Decimal
     assert_eq!(
-        evaluate_add(&Schema::empty(), &float1, dec1.as_ref(), &row)
+        evaluate_add(&Schema::default(), &float1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_sub(&Schema::empty(), &float1, dec1.as_ref(), &row)
+        evaluate_sub(&Schema::default(), &float1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
     assert_eq!(
-        evaluate_mul(&Schema::empty(), &float2, dec1.as_ref(), &row)
+        evaluate_mul(&Schema::default(), &float2, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_div(&Schema::empty(), &float1, dec2.as_ref(), &row)
+        evaluate_div(&Schema::default(), &float1, dec2.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_f64(0.5).unwrap())
     );
     assert_eq!(
-        evaluate_mod(&Schema::empty(), &float1, dec1.as_ref(), &row)
+        evaluate_mod(&Schema::default(), &float1, dec1.as_ref(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );

--- a/dozer-sql/src/pipeline/expression/tests/comparison.rs
+++ b/dozer-sql/src/pipeline/expression/tests/comparison.rs
@@ -18,7 +18,7 @@ use proptest::prelude::*;
 fn test_comparison() {
     proptest!(ProptestConfig::with_cases(1000), move |(
         u_num1: u64, u_num2: u64, i_num1: i64, i_num2: i64, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Literal(Field::UInt(u_num1));
         let uint2 = Literal(Field::UInt(u_num2));
@@ -426,13 +426,13 @@ fn test_eq(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     match result {
         None => {
             assert!(matches!(
-                evaluate_eq(&Schema::empty(), exp1, exp2, row),
+                evaluate_eq(&Schema::default(), exp1, exp2, row),
                 Ok(Field::Boolean(true))
             ));
         }
         Some(_val) => {
             assert!(matches!(
-                evaluate_eq(&Schema::empty(), exp1, exp2, row),
+                evaluate_eq(&Schema::default(), exp1, exp2, row),
                 Ok(_val)
             ));
         }
@@ -443,13 +443,13 @@ fn test_ne(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     match result {
         None => {
             assert!(matches!(
-                evaluate_ne(&Schema::empty(), exp1, exp2, row),
+                evaluate_ne(&Schema::default(), exp1, exp2, row),
                 Ok(Field::Boolean(true))
             ));
         }
         Some(_val) => {
             assert!(matches!(
-                evaluate_ne(&Schema::empty(), exp1, exp2, row),
+                evaluate_ne(&Schema::default(), exp1, exp2, row),
                 Ok(_val)
             ));
         }
@@ -460,13 +460,13 @@ fn test_gt(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     match result {
         None => {
             assert!(matches!(
-                evaluate_gt(&Schema::empty(), exp1, exp2, row),
+                evaluate_gt(&Schema::default(), exp1, exp2, row),
                 Ok(Field::Boolean(true))
             ));
         }
         Some(_val) => {
             assert!(matches!(
-                evaluate_gt(&Schema::empty(), exp1, exp2, row),
+                evaluate_gt(&Schema::default(), exp1, exp2, row),
                 Ok(_val)
             ));
         }
@@ -477,13 +477,13 @@ fn test_lt(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     match result {
         None => {
             assert!(matches!(
-                evaluate_lt(&Schema::empty(), exp1, exp2, row),
+                evaluate_lt(&Schema::default(), exp1, exp2, row),
                 Ok(Field::Boolean(true))
             ));
         }
         Some(_val) => {
             assert!(matches!(
-                evaluate_lt(&Schema::empty(), exp1, exp2, row),
+                evaluate_lt(&Schema::default(), exp1, exp2, row),
                 Ok(_val)
             ));
         }
@@ -494,13 +494,13 @@ fn test_gte(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<F
     match result {
         None => {
             assert!(matches!(
-                evaluate_gte(&Schema::empty(), exp1, exp2, row),
+                evaluate_gte(&Schema::default(), exp1, exp2, row),
                 Ok(Field::Boolean(true))
             ));
         }
         Some(_val) => {
             assert!(matches!(
-                evaluate_gte(&Schema::empty(), exp1, exp2, row),
+                evaluate_gte(&Schema::default(), exp1, exp2, row),
                 Ok(_val)
             ));
         }
@@ -511,13 +511,13 @@ fn test_lte(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<F
     match result {
         None => {
             assert!(matches!(
-                evaluate_lte(&Schema::empty(), exp1, exp2, row),
+                evaluate_lte(&Schema::default(), exp1, exp2, row),
                 Ok(Field::Boolean(true))
             ));
         }
         Some(_val) => {
             assert!(matches!(
-                evaluate_lte(&Schema::empty(), exp1, exp2, row),
+                evaluate_lte(&Schema::default(), exp1, exp2, row),
                 Ok(_val)
             ));
         }
@@ -527,7 +527,7 @@ fn test_lte(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<F
 #[test]
 fn test_comparison_logical_int() {
     let record = vec![Field::Int(124)];
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("id"),
@@ -596,7 +596,7 @@ fn test_comparison_logical_int() {
 fn test_comparison_logical_timestamp() {
     let f = run_fct(
         "SELECT time = '2020-01-01T00:00:00Z' FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("time"),
@@ -615,7 +615,7 @@ fn test_comparison_logical_timestamp() {
 
     let f = run_fct(
         "SELECT time < '2020-01-01T00:00:01Z' FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("time"),
@@ -637,7 +637,7 @@ fn test_comparison_logical_timestamp() {
 fn test_comparison_logical_date() {
     let f = run_fct(
         "SELECT date = '2020-01-01' FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("date"),
@@ -656,7 +656,7 @@ fn test_comparison_logical_date() {
 
     let f = run_fct(
         "SELECT date != '2020-01-01' FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("date"),
@@ -675,7 +675,7 @@ fn test_comparison_logical_date() {
 
     let f = run_fct(
         "SELECT date > '2020-01-01' FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("date"),

--- a/dozer-sql/src/pipeline/expression/tests/conditional.rs
+++ b/dozer-sql/src/pipeline/expression/tests/conditional.rs
@@ -32,7 +32,7 @@ fn test_coalesce() {
         // UInt
         let typ = FieldType::UInt;
         let f = Field::UInt(u_num1);
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), uint1.clone()];
         test_validate_coalesce(&args, typ);
@@ -53,7 +53,7 @@ fn test_coalesce() {
         // Int
         let typ = FieldType::Int;
         let f = Field::Int(i_num1);
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), int1.clone()];
         test_validate_coalesce(&args, typ);
@@ -74,7 +74,7 @@ fn test_coalesce() {
         // Float
         let typ = FieldType::Float;
         let f = Field::Float(OrderedFloat(f_num1));
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), float1.clone()];
         test_validate_coalesce(&args, typ);
@@ -95,7 +95,7 @@ fn test_coalesce() {
         // Decimal
         let typ = FieldType::Decimal;
         let f = Field::Decimal(d_num1.0);
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), dec1.clone()];
         test_validate_coalesce(&args, typ);
@@ -116,7 +116,7 @@ fn test_coalesce() {
         // String
         let typ = FieldType::String;
         let f = Field::String(s_val1.clone());
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), str1.clone()];
         test_validate_coalesce(&args, typ);
@@ -137,7 +137,7 @@ fn test_coalesce() {
         // String
         let typ = FieldType::String;
         let f = Field::String(s_val1);
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), str1.clone()];
         test_validate_coalesce(&args, typ);
@@ -158,7 +158,7 @@ fn test_coalesce() {
         // Timestamp
         let typ = FieldType::Timestamp;
         let f = Field::Timestamp(dt_val1.0);
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), t1.clone()];
         test_validate_coalesce(&args, typ);
@@ -179,7 +179,7 @@ fn test_coalesce() {
         // Date
         let typ = FieldType::Date;
         let f = Field::Date(dt_val1.0.date_naive());
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone(), dt1.clone()];
         test_validate_coalesce(&args, typ);
@@ -200,7 +200,7 @@ fn test_coalesce() {
         // Null
         let typ = FieldType::Date;
         let f = Field::Null;
-        let row = Record::new(None, vec![f.clone()]);
+        let row = Record::new(vec![f.clone()]);
 
         let args = vec![null.clone()];
         test_validate_coalesce(&args, typ);
@@ -213,7 +213,7 @@ fn test_coalesce() {
 }
 
 fn test_validate_coalesce(args: &[Expression], typ: FieldType) {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(String::from("field"), typ, false, SourceDefinition::Dynamic),
             false,
@@ -225,7 +225,7 @@ fn test_validate_coalesce(args: &[Expression], typ: FieldType) {
 }
 
 fn test_evaluate_coalesce(args: &[Expression], row: &Record, typ: FieldType, _result: Field) {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(String::from("field"), typ, false, SourceDefinition::Dynamic),
             false,
@@ -240,7 +240,7 @@ fn test_evaluate_coalesce(args: &[Expression], row: &Record, typ: FieldType, _re
 fn test_coalesce_logic() {
     let f = run_fct(
         "SELECT COALESCE(field, 2) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -257,7 +257,7 @@ fn test_coalesce_logic() {
 
     let f = run_fct(
         "SELECT COALESCE(field, CAST(2 AS FLOAT)) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -274,7 +274,7 @@ fn test_coalesce_logic() {
 
     let f = run_fct(
         "SELECT COALESCE(field, 'X') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -291,7 +291,7 @@ fn test_coalesce_logic() {
 
     let f = run_fct(
         "SELECT COALESCE(field, 'X') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),
@@ -311,7 +311,7 @@ fn test_coalesce_logic() {
 fn test_coalesce_logic_null() {
     let f = run_fct(
         "SELECT COALESCE(field) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("field"),

--- a/dozer-sql/src/pipeline/expression/tests/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/tests/datetime.rs
@@ -23,7 +23,7 @@ fn test_time() {
 }
 
 fn test_date_parts(datetime: ArbitraryDateTime) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
     let date_parts = vec![
         (
@@ -48,7 +48,7 @@ fn test_date_parts(datetime: ArbitraryDateTime) {
     let v = Expression::Literal(Field::Date(datetime.0.date_naive()));
 
     for (part, value) in date_parts {
-        let result = evaluate_date_part(&Schema::empty(), &part, &v, &row).unwrap();
+        let result = evaluate_date_part(&Schema::default(), &part, &v, &row).unwrap();
         assert_eq!(result, Field::Int(value));
     }
 }
@@ -83,7 +83,7 @@ fn test_extract_date() {
         for i in inputs.clone() {
             let f = run_fct(
                 &format!("select extract({part} from date) from users"),
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("date"),
@@ -107,7 +107,7 @@ fn test_extract_date() {
 fn test_timestamp_diff() {
     let f = run_fct(
         "SELECT ts1 - ts2 FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts1"),
@@ -151,7 +151,7 @@ fn test_duration() {
 }
 
 fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
     let v = Expression::Literal(Field::Date(dt1.0.date_naive()));
     let dur1 = Expression::Literal(Field::Duration(DozerDuration(
@@ -164,7 +164,7 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
     )));
 
     // Duration + Duration = Duration
-    let result = evaluate_add(&Schema::empty(), &dur1, &dur2, &row);
+    let result = evaluate_add(&Schema::default(), &dur1, &dur2, &row);
     let sum = std::time::Duration::from_nanos(d1).checked_add(std::time::Duration::from_nanos(d2));
     if result.is_ok() && sum.is_some() {
         assert_eq!(
@@ -173,7 +173,7 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         );
     }
     // Duration - Duration = Duration
-    let result = evaluate_sub(&Schema::empty(), &dur1, &dur2, &row);
+    let result = evaluate_sub(&Schema::default(), &dur1, &dur2, &row);
     let diff = std::time::Duration::from_nanos(d1).checked_sub(std::time::Duration::from_nanos(d2));
     if result.is_ok() && diff.is_some() {
         assert_eq!(
@@ -182,33 +182,33 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         );
     }
     // Duration * Duration = Error
-    let result = evaluate_mul(&Schema::empty(), &dur1, &dur2, &row);
+    let result = evaluate_mul(&Schema::default(), &dur1, &dur2, &row);
     assert!(result.is_err());
     // Duration / Duration = Error
-    let result = evaluate_div(&Schema::empty(), &dur1, &dur2, &row);
+    let result = evaluate_div(&Schema::default(), &dur1, &dur2, &row);
     assert!(result.is_err());
     // Duration % Duration = Error
-    let result = evaluate_mod(&Schema::empty(), &dur1, &dur2, &row);
+    let result = evaluate_mod(&Schema::default(), &dur1, &dur2, &row);
     assert!(result.is_err());
 
     // Duration + Timestamp = Error
-    let result = evaluate_add(&Schema::empty(), &dur1, &v, &row);
+    let result = evaluate_add(&Schema::default(), &dur1, &v, &row);
     assert!(result.is_err());
     // Duration - Timestamp = Error
-    let result = evaluate_sub(&Schema::empty(), &dur1, &v, &row);
+    let result = evaluate_sub(&Schema::default(), &dur1, &v, &row);
     assert!(result.is_err());
     // Duration * Timestamp = Error
-    let result = evaluate_mul(&Schema::empty(), &dur1, &v, &row);
+    let result = evaluate_mul(&Schema::default(), &dur1, &v, &row);
     assert!(result.is_err());
     // Duration / Timestamp = Error
-    let result = evaluate_div(&Schema::empty(), &dur1, &v, &row);
+    let result = evaluate_div(&Schema::default(), &dur1, &v, &row);
     assert!(result.is_err());
     // Duration % Timestamp = Error
-    let result = evaluate_mod(&Schema::empty(), &dur1, &v, &row);
+    let result = evaluate_mod(&Schema::default(), &dur1, &v, &row);
     assert!(result.is_err());
 
     // Timestamp + Duration = Timestamp
-    let result = evaluate_add(&Schema::empty(), &v, &dur1, &row);
+    let result = evaluate_add(&Schema::default(), &v, &dur1, &row);
     let sum = dt1
         .0
         .checked_add_signed(chrono::Duration::nanoseconds(d1 as i64));
@@ -216,7 +216,7 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         assert_eq!(result.unwrap(), Field::Timestamp(sum.unwrap()));
     }
     // Timestamp - Duration = Timestamp
-    let result = evaluate_sub(&Schema::empty(), &v, &dur2, &row);
+    let result = evaluate_sub(&Schema::default(), &v, &dur2, &row);
     let diff = dt1
         .0
         .checked_sub_signed(chrono::Duration::nanoseconds(d2 as i64));
@@ -224,13 +224,13 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         assert_eq!(result.unwrap(), Field::Timestamp(diff.unwrap()));
     }
     // Timestamp * Duration = Error
-    let result = evaluate_mul(&Schema::empty(), &v, &dur1, &row);
+    let result = evaluate_mul(&Schema::default(), &v, &dur1, &row);
     assert!(result.is_err());
     // Timestamp / Duration = Error
-    let result = evaluate_div(&Schema::empty(), &v, &dur1, &row);
+    let result = evaluate_div(&Schema::default(), &v, &dur1, &row);
     assert!(result.is_err());
     // Timestamp % Duration = Error
-    let result = evaluate_mod(&Schema::empty(), &v, &dur1, &row);
+    let result = evaluate_mod(&Schema::default(), &v, &dur1, &row);
     assert!(result.is_err());
 }
 
@@ -238,7 +238,7 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
 fn test_interval() {
     let f = run_fct(
         "SELECT ts1 - INTERVAL '1' SECOND FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts1"),
@@ -260,7 +260,7 @@ fn test_interval() {
 
     let f = run_fct(
         "SELECT ts1 + INTERVAL '1' SECOND FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts1"),
@@ -282,7 +282,7 @@ fn test_interval() {
 
     let f = run_fct(
         "SELECT INTERVAL '1' SECOND + ts1 FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts1"),
@@ -307,7 +307,7 @@ fn test_interval() {
 fn test_now() {
     let f = run_fct(
         "SELECT NOW() FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts1"),

--- a/dozer-sql/src/pipeline/expression/tests/distance.rs
+++ b/dozer-sql/src/pipeline/expression/tests/distance.rs
@@ -18,7 +18,7 @@ use proptest::prelude::*;
 #[test]
 fn test_geo() {
     proptest!(ProptestConfig::with_cases(1000), move |(x1: f64, x2: f64, y1: f64, y2: f64)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
         let from = Field::Point(DozerPoint::from((x1, y1)));
         let to = Field::Point(DozerPoint::from((x2, y2)));
         let null = Field::Null;
@@ -49,7 +49,7 @@ fn test_distance(
     result: Option<Result<Field, PipelineError>>,
 ) {
     let args = &vec![Literal(from.clone()), Literal(to.clone())];
-    if validate_distance(args, &Schema::empty()).is_ok() {
+    if validate_distance(args, &Schema::default()).is_ok() {
         match result {
             None => {
                 let from_f = from.to_owned();
@@ -64,13 +64,13 @@ fn test_distance(
                     // Some(Algorithm::Vincenty) => f.0.vincenty_distance(&t.0).unwrap(),
                 };
                 assert!(matches!(
-                    evaluate_distance(&Schema::empty(), args, row),
+                    evaluate_distance(&Schema::default(), args, row),
                     Ok(Field::Float(_dist)),
                 ))
             }
             Some(_val) => {
                 assert!(matches!(
-                    evaluate_distance(&Schema::empty(), args, row),
+                    evaluate_distance(&Schema::default(), args, row),
                     _val,
                 ))
             }
@@ -80,7 +80,7 @@ fn test_distance(
 
 #[test]
 fn test_validate_distance() {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("from"),
@@ -176,7 +176,7 @@ fn test_distance_logical() {
         ("VINCENTY", 1113.0264975564357),
     ];
 
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("from"),
@@ -220,7 +220,7 @@ fn test_distance_logical() {
 fn test_distance_with_nullable_parameter() {
     let f = run_fct(
         "SELECT DISTANCE(from, to) FROM LOCATION",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("from"),

--- a/dozer-sql/src/pipeline/expression/tests/execution.rs
+++ b/dozer-sql/src/pipeline/expression/tests/execution.rs
@@ -16,7 +16,7 @@ use dozer_types::types::{
 fn test_column_execution() {
     use dozer_types::ordered_float::OrderedFloat;
 
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "int_field".to_string(),
@@ -46,14 +46,11 @@ fn test_column_execution() {
         )
         .clone();
 
-    let record = Record::new(
-        None,
-        vec![
-            Field::Int(1337),
-            Field::String("test".to_string()),
-            Field::Float(OrderedFloat(10.10)),
-        ],
-    );
+    let record = Record::new(vec![
+        Field::Int(1337),
+        Field::String("test".to_string()),
+        Field::Float(OrderedFloat(10.10)),
+    ]);
 
     // Column
     let e = Expression::Column { index: 0 };
@@ -122,7 +119,7 @@ fn test_column_execution() {
 
 #[test]
 fn test_alias() {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("fn"),
@@ -158,7 +155,7 @@ fn test_alias() {
 
     assert_eq!(
         r,
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("alias1"),
@@ -183,7 +180,7 @@ fn test_alias() {
 
 #[test]
 fn test_wildcard() {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("fn"),
@@ -219,7 +216,7 @@ fn test_wildcard() {
 
     assert_eq!(
         r,
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -244,7 +241,7 @@ fn test_wildcard() {
 
 #[test]
 fn test_timestamp_difference() {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("a"),
@@ -265,13 +262,10 @@ fn test_timestamp_difference() {
         )
         .clone();
 
-    let record = Record::new(
-        None,
-        vec![
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:12:10Z").unwrap()),
-        ],
-    );
+    let record = Record::new(vec![
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:12:10Z").unwrap()),
+    ]);
 
     let result = evaluate_sub(
         &schema,

--- a/dozer-sql/src/pipeline/expression/tests/expression_builder_test.rs
+++ b/dozer-sql/src/pipeline/expression/tests/expression_builder_test.rs
@@ -11,7 +11,7 @@ use sqlparser::ast::SelectItem;
 #[test]
 fn test_simple_function() {
     let sql = "SELECT CONCAT(a, b) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),
@@ -60,7 +60,7 @@ fn test_simple_function() {
 #[test]
 fn test_simple_aggr_function() {
     let sql = "SELECT SUM(field0) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "field0".to_string(),
@@ -94,7 +94,7 @@ fn test_simple_aggr_function() {
 #[test]
 fn test_2_nested_aggr_function() {
     let sql = "SELECT SUM(ROUND(field1, 2)) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "field0".to_string(),
@@ -143,7 +143,7 @@ fn test_2_nested_aggr_function() {
 #[test]
 fn test_3_nested_aggr_function() {
     let sql = "SELECT ROUND(SUM(ROUND(field1, 2))) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "field0".to_string(),
@@ -198,7 +198,7 @@ fn test_3_nested_aggr_function() {
 #[test]
 fn test_3_nested_aggr_function_dup() {
     let sql = "SELECT CONCAT(SUM(ROUND(field1, 2)), SUM(ROUND(field1, 2))) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "field0".to_string(),
@@ -256,7 +256,7 @@ fn test_3_nested_aggr_function_dup() {
 #[test]
 fn test_3_nested_aggr_function_and_sum() {
     let sql = "SELECT ROUND(SUM(ROUND(field1, 2))) + SUM(field0) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "field0".to_string(),
@@ -321,7 +321,7 @@ fn test_3_nested_aggr_function_and_sum() {
 #[test]
 fn test_3_nested_aggr_function_and_sum_3() {
     let sql = "SELECT (ROUND(SUM(ROUND(field1, 2))) + SUM(field0)) + field0 FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "field0".to_string(),
@@ -392,7 +392,7 @@ fn test_3_nested_aggr_function_and_sum_3() {
 #[should_panic]
 fn test_wrong_nested_aggregations() {
     let sql = "SELECT SUM(SUM(field0)) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "field0".to_string(),
@@ -414,7 +414,7 @@ fn test_wrong_nested_aggregations() {
 #[test]
 fn test_name_resolution() {
     let sql = "SELECT CONCAT(table0.a, connection1.table0.b, a) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),
@@ -470,7 +470,7 @@ fn test_name_resolution() {
 #[test]
 fn test_alias_resolution() {
     let sql = "SELECT CONCAT(alias.a, a) FROM t0";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),

--- a/dozer-sql/src/pipeline/expression/tests/in_list.rs
+++ b/dozer-sql/src/pipeline/expression/tests/in_list.rs
@@ -5,19 +5,19 @@ use dozer_types::types::{Field, FieldDefinition, FieldType, Schema, SourceDefini
 fn test_in_list() {
     let f = run_fct(
         "SELECT 42 IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)",
-        Schema::empty(),
+        Schema::default(),
         vec![],
     );
     assert_eq!(f, Field::Boolean(false));
 
     let f = run_fct(
         "SELECT 42 IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 42)",
-        Schema::empty(),
+        Schema::default(),
         vec![],
     );
     assert_eq!(f, Field::Boolean(true));
 
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("age"),
@@ -47,19 +47,19 @@ fn test_in_list() {
 fn test_not_in_list() {
     let f = run_fct(
         "SELECT 42 NOT IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)",
-        Schema::empty(),
+        Schema::default(),
         vec![],
     );
     assert_eq!(f, Field::Boolean(true));
 
     let f = run_fct(
         "SELECT 42 NOT IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 42)",
-        Schema::empty(),
+        Schema::default(),
         vec![],
     );
     assert_eq!(f, Field::Boolean(false));
 
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("age"),

--- a/dozer-sql/src/pipeline/expression/tests/json_functions.rs
+++ b/dozer-sql/src/pipeline/expression/tests/json_functions.rs
@@ -25,7 +25,7 @@ fn test_json_value() {
 
     let f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.info.address.town') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -62,7 +62,7 @@ fn test_json_value_null() {
 
     let f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.info.address.tags') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -99,7 +99,7 @@ fn test_json_query() {
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.info.address') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -152,7 +152,7 @@ fn test_json_query_null() {
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.type') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -188,7 +188,7 @@ fn test_json_query_len_one_array() {
 
     let f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.info.tags') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -229,7 +229,7 @@ fn test_json_query_array() {
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.info.tags') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -276,7 +276,7 @@ fn test_json_query_default_path() {
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -304,7 +304,7 @@ fn test_json_query_all() {
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo, '$..*') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -352,7 +352,7 @@ fn test_json_query_iter() {
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo, '$[*].digit') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -376,7 +376,7 @@ fn test_json_query_iter() {
 fn test_json_cast() {
     let f = run_fct(
         "SELECT CAST(uint AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("uint"),
@@ -394,7 +394,7 @@ fn test_json_cast() {
 
     let f = run_fct(
         "SELECT CAST(u128 AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("u128"),
@@ -412,7 +412,7 @@ fn test_json_cast() {
 
     let f = run_fct(
         "SELECT CAST(int AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("int"),
@@ -430,7 +430,7 @@ fn test_json_cast() {
 
     let f = run_fct(
         "SELECT CAST(i128 AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("i128"),
@@ -448,7 +448,7 @@ fn test_json_cast() {
 
     let f = run_fct(
         "SELECT CAST(float AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("float"),
@@ -466,7 +466,7 @@ fn test_json_cast() {
 
     let f = run_fct(
         "SELECT CAST(str AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("str"),
@@ -484,7 +484,7 @@ fn test_json_cast() {
 
     let f = run_fct(
         "SELECT CAST(str AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("str"),
@@ -502,7 +502,7 @@ fn test_json_cast() {
 
     let f = run_fct(
         "SELECT CAST(bool AS JSON) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("bool"),
@@ -531,7 +531,7 @@ fn test_json_value_cast() {
 
     let f = run_fct(
         "SELECT JSON_VALUE(jsonInfo, '$[0].digit') FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -549,7 +549,7 @@ fn test_json_value_cast() {
 
     let f = run_fct(
         "SELECT CAST(JSON_VALUE(jsonInfo, '$[0].digit') AS UINT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -567,7 +567,7 @@ fn test_json_value_cast() {
 
     let f = run_fct(
         "SELECT CAST(JSON_VALUE(jsonInfo, '$[0].digit') AS INT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -585,7 +585,7 @@ fn test_json_value_cast() {
 
     let f = run_fct(
         "SELECT CAST(JSON_VALUE(jsonInfo, '$[0].digit') AS FLOAT) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -603,7 +603,7 @@ fn test_json_value_cast() {
 
     let f = run_fct(
         "SELECT CAST(JSON_VALUE(jsonInfo, '$[0].digit') AS STRING) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),
@@ -629,7 +629,7 @@ fn test_json_value_cast() {
 
     let f = run_fct(
         "SELECT CAST(JSON_VALUE(jsonInfo, '$[0].bool') AS BOOLEAN) FROM users",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("jsonInfo"),

--- a/dozer-sql/src/pipeline/expression/tests/logical.rs
+++ b/dozer-sql/src/pipeline/expression/tests/logical.rs
@@ -51,12 +51,12 @@ fn test_logical() {
 }
 
 fn _test_bool_bool_and(bool1: bool, bool2: bool) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let l = Box::new(Literal(Field::Boolean(bool1)));
     let r = Box::new(Literal(Field::Boolean(bool2)));
     assert!(
         matches!(
-            evaluate_and(&Schema::empty(), &l, &r, &row)
+            evaluate_and(&Schema::default(), &l, &r, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Boolean(_ans)
         )
@@ -64,65 +64,68 @@ fn _test_bool_bool_and(bool1: bool, bool2: bool) {
 }
 
 fn _test_bool_null_and(f1: Field, f2: Field) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let l = Box::new(Literal(f1));
     let r = Box::new(Literal(f2));
     assert!(matches!(
-        evaluate_and(&Schema::empty(), &l, &r, &row)
+        evaluate_and(&Schema::default(), &l, &r, &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Boolean(false)
     ));
 }
 
 fn _test_bool_bool_or(bool1: bool, bool2: bool) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let l = Box::new(Literal(Field::Boolean(bool1)));
     let r = Box::new(Literal(Field::Boolean(bool2)));
     assert!(matches!(
-        evaluate_or(&Schema::empty(), &l, &r, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+        evaluate_or(&Schema::default(), &l, &r, &row)
+            .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Boolean(_ans)
     ));
 }
 
 fn _test_bool_null_or(_bool: bool) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let l = Box::new(Literal(Field::Boolean(_bool)));
     let r = Box::new(Literal(Field::Null));
     assert!(matches!(
-        evaluate_or(&Schema::empty(), &l, &r, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+        evaluate_or(&Schema::default(), &l, &r, &row)
+            .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Boolean(_bool)
     ));
 }
 
 fn _test_null_bool_or(_bool: bool) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let l = Box::new(Literal(Field::Null));
     let r = Box::new(Literal(Field::Boolean(_bool)));
     assert!(matches!(
-        evaluate_or(&Schema::empty(), &l, &r, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+        evaluate_or(&Schema::default(), &l, &r, &row)
+            .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Boolean(_bool)
     ));
 }
 
 fn _test_bool_not(bool: bool) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let v = Box::new(Literal(Field::Boolean(bool)));
     assert!(matches!(
-        evaluate_not(&Schema::empty(), &v, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+        evaluate_not(&Schema::default(), &v, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Boolean(_ans)
     ));
 }
 
 fn _test_bool_non_bool_and(f1: Field, f2: Field) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let l = Box::new(Literal(f1));
     let r = Box::new(Literal(f2));
-    assert!(evaluate_and(&Schema::empty(), &l, &r, &row).is_err());
+    assert!(evaluate_and(&Schema::default(), &l, &r, &row).is_err());
 }
 
 fn _test_bool_non_bool_or(f1: Field, f2: Field) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
     let l = Box::new(Literal(f1));
     let r = Box::new(Literal(f2));
-    assert!(evaluate_or(&Schema::empty(), &l, &r, &row).is_err());
+    assert!(evaluate_or(&Schema::default(), &l, &r, &row).is_err());
 }

--- a/dozer-sql/src/pipeline/expression/tests/mathematical.rs
+++ b/dozer-sql/src/pipeline/expression/tests/mathematical.rs
@@ -18,7 +18,7 @@ use std::num::Wrapping;
 #[test]
 fn test_uint_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Box::new(Literal(Field::UInt(u_num1)));
         let uint2 = Box::new(Literal(Field::UInt(u_num2)));
@@ -38,31 +38,31 @@ fn test_uint_math() {
         //// left: UInt, right: UInt
         assert_eq!(
             // UInt + UInt = UInt
-            evaluate_add(&Schema::empty(), &uint1, &uint2, &row)
+            evaluate_add(&Schema::default(), &uint1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num1) + Wrapping(u_num2)).0)
         );
         assert_eq!(
             // UInt - UInt = UInt
-            evaluate_sub(&Schema::empty(), &uint1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &uint1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num1) - Wrapping(u_num2)).0)
         );
         assert_eq!(
             // UInt * UInt = UInt
-            evaluate_mul(&Schema::empty(), &uint2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &uint2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num2) * Wrapping(u_num1)).0)
         );
         assert_eq!(
             // UInt / UInt = Float
-            evaluate_div(&Schema::empty(), &uint2, &uint1, &row)
+            evaluate_div(&Schema::default(), &uint2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // UInt % UInt = UInt
-            evaluate_mod(&Schema::empty(), &uint1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &uint1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num1) % Wrapping(u_num2)).0)
         );
@@ -70,31 +70,31 @@ fn test_uint_math() {
         //// left: UInt, right: U128
         assert_eq!(
             // UInt + U128 = U128
-            evaluate_add(&Schema::empty(), &uint1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &uint1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num1 as u128) + Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // UInt - U128 = U128
-            evaluate_sub(&Schema::empty(), &uint1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &uint1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num1 as u128) - Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // UInt * U128 = U128
-            evaluate_mul(&Schema::empty(), &uint2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &uint2, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num2 as u128) * Wrapping(u128_num1)).0)
         );
         assert_eq!(
             // UInt / U128 = Float
-            evaluate_div(&Schema::empty(), &uint2, &u128_1, &row)
+            evaluate_div(&Schema::default(), &uint2, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_u128(u128_num1).unwrap()))
         );
         assert_eq!(
             // UInt % U128 = U128
-            evaluate_mod(&Schema::empty(), &uint1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &uint1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num1 as u128) % Wrapping(u128_num2)).0)
         );
@@ -102,31 +102,31 @@ fn test_uint_math() {
         //// left: UInt, right: Int
         assert_eq!(
             // UInt + Int = Int
-            evaluate_add(&Schema::empty(), &uint1, &int2, &row)
+            evaluate_add(&Schema::default(), &uint1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num1 as i64) + Wrapping(i_num2)).0)
         );
         assert_eq!(
             // UInt - Int = Int
-            evaluate_sub(&Schema::empty(), &uint1, &int2, &row)
+            evaluate_sub(&Schema::default(), &uint1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num1 as i64) - Wrapping(i_num2)).0)
         );
         assert_eq!(
             // UInt * Int = Int
-            evaluate_mul(&Schema::empty(), &uint2, &int1, &row)
+            evaluate_mul(&Schema::default(), &uint2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num2 as i64) * Wrapping(i_num1)).0)
         );
         assert_eq!(
             // UInt / Int = Float
-            evaluate_div(&Schema::empty(), &uint2, &int1, &row)
+            evaluate_div(&Schema::default(), &uint2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // UInt % Int = Int
-            evaluate_mod(&Schema::empty(), &uint1, &int2, &row)
+            evaluate_mod(&Schema::default(), &uint1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num1 as i64) % Wrapping(i_num2)).0)
         );
@@ -134,31 +134,31 @@ fn test_uint_math() {
         //// left: UInt, right: I128
         assert_eq!(
             // UInt + I128 = I128
-            evaluate_add(&Schema::empty(), &uint1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &uint1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num1 as i128) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // UInt - I128 = I128
-            evaluate_sub(&Schema::empty(), &uint1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &uint1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num1 as i128) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // UInt * I128 = I128
-            evaluate_mul(&Schema::empty(), &uint2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &uint2, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num2 as i128) * Wrapping(i128_num1)).0)
         );
         assert_eq!(
             // UInt / I128 = Float
-            evaluate_div(&Schema::empty(), &uint2, &i128_1, &row)
+            evaluate_div(&Schema::default(), &uint2, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
         );
         assert_eq!(
             // UInt % I128 = I128
-            evaluate_mod(&Schema::empty(), &uint1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &uint1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num1 as i128) % Wrapping(i128_num2)).0)
         );
@@ -166,26 +166,26 @@ fn test_uint_math() {
         //// left: UInt, right: Float
         assert_eq!(
             // UInt + Float = Float
-            evaluate_add(&Schema::empty(), &uint1, &float2, &row)
+            evaluate_add(&Schema::default(), &uint1, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() + f_num2))
         );
         assert_eq!(
             // UInt - Float = Float
-            evaluate_sub(&Schema::empty(), &uint1, &float2, &row)
+            evaluate_sub(&Schema::default(), &uint1, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() - f_num2))
         );
         assert_eq!(
             // UInt * Float = Float
-            evaluate_mul(&Schema::empty(), &uint2, &float1, &row)
+            evaluate_mul(&Schema::default(), &uint2, &float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() * f_num1))
         );
         if *float1 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // UInt / Float = Float
-                evaluate_div(&Schema::empty(), &uint2, &float1, &row)
+                evaluate_div(&Schema::default(), &uint2, &float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f_num1))
             );
@@ -193,7 +193,7 @@ fn test_uint_math() {
         if *float2 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // UInt % Float = Float
-                evaluate_mod(&Schema::empty(), &uint1, &float2, &row)
+                evaluate_mod(&Schema::default(), &uint1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() % f_num2))
             );
@@ -202,18 +202,18 @@ fn test_uint_math() {
         //// left: UInt, right: Decimal
         assert_eq!(
             // UInt + Decimal = Decimal
-            evaluate_add(&Schema::empty(), &uint1, &dec2, &row)
+            evaluate_add(&Schema::default(), &uint1, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_u64(u_num1).unwrap() + d_num2.0)
         );
         assert_eq!(
             // UInt - Decimal = Decimal
-            evaluate_sub(&Schema::empty(), &uint1, &dec2, &row)
+            evaluate_sub(&Schema::default(), &uint1, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_u64(u_num1).unwrap() - d_num2.0)
         );
         // UInt * Decimal = Decimal
-        let res = evaluate_mul(&Schema::empty(), &uint2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &uint2, &dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_u64(u_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -226,7 +226,7 @@ fn test_uint_math() {
             ));
         }
         // UInt / Decimal = Decimal
-        let res = evaluate_div(&Schema::empty(), &uint2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &uint2, &dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -246,7 +246,7 @@ fn test_uint_math() {
             ));
         }
         // UInt % Decimal = Decimal
-        let res = evaluate_mod(&Schema::empty(), &uint2, &dec1, &row);
+        let res = evaluate_mod(&Schema::default(), &uint2, &dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -269,31 +269,31 @@ fn test_uint_math() {
         //// left: UInt, right: Null
         assert_eq!(
             // UInt + Null = Null
-            evaluate_add(&Schema::empty(), &uint1, &null, &row)
+            evaluate_add(&Schema::default(), &uint1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt - Null = Null
-            evaluate_sub(&Schema::empty(), &uint1, &null, &row)
+            evaluate_sub(&Schema::default(), &uint1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt * Null = Null
-            evaluate_mul(&Schema::empty(), &uint2, &null, &row)
+            evaluate_mul(&Schema::default(), &uint2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt / Null = Null
-            evaluate_div(&Schema::empty(), &uint2, &null, &row)
+            evaluate_div(&Schema::default(), &uint2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt % Null = Null
-            evaluate_mod(&Schema::empty(), &uint1, &null, &row)
+            evaluate_mod(&Schema::default(), &uint1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -303,7 +303,7 @@ fn test_uint_math() {
 #[test]
 fn test_u128_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Box::new(Literal(Field::UInt(u_num1)));
         let uint2 = Box::new(Literal(Field::UInt(u_num2)));
@@ -323,31 +323,31 @@ fn test_u128_math() {
         //// left: U128, right: UInt
         assert_eq!(
             // U128 + UInt = U128
-            evaluate_add(&Schema::empty(), &u128_1, &uint2, &row)
+            evaluate_add(&Schema::default(), &u128_1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) + Wrapping(u_num2 as u128)).0)
         );
         assert_eq!(
             // U128 - UInt = U128
-            evaluate_sub(&Schema::empty(), &u128_1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &u128_1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) - Wrapping(u_num2 as u128)).0)
         );
         assert_eq!(
             // U128 * UInt = U128
-            evaluate_mul(&Schema::empty(), &u128_2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &u128_2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num2) * Wrapping(u_num1 as u128)).0)
         );
         assert_eq!(
             // U128 / UInt = Float
-            evaluate_div(&Schema::empty(), &u128_2, &uint1, &row)
+            evaluate_div(&Schema::default(), &u128_2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // U128 % UInt = U128
-            evaluate_mod(&Schema::empty(), &u128_1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &u128_1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) % Wrapping(u_num2 as u128)).0)
         );
@@ -355,31 +355,31 @@ fn test_u128_math() {
         //// left: U128, right: U128
         assert_eq!(
             // U128 + U128 = U128
-            evaluate_add(&Schema::empty(), &u128_1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &u128_1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) + Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // U128 - U128 = U128
-            evaluate_sub(&Schema::empty(), &u128_1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &u128_1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) - Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // U128 * U128 = U128
-            evaluate_mul(&Schema::empty(), &u128_2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &u128_2, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num2) * Wrapping(u128_num1)).0)
         );
         assert_eq!(
             // U128 / U128 = Float
-            evaluate_div(&Schema::empty(), &u128_2, &u128_1, &row)
+            evaluate_div(&Schema::default(), &u128_2, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_u128(u128_num1).unwrap()))
         );
         assert_eq!(
             // U128 % U128 = U128
-            evaluate_mod(&Schema::empty(), &u128_1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &u128_1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) % Wrapping(u128_num2)).0)
         );
@@ -387,31 +387,31 @@ fn test_u128_math() {
         //// left: U128, right: Int
         assert_eq!(
             // U128 + Int = I128
-            evaluate_add(&Schema::empty(), &u128_1, &int2, &row)
+            evaluate_add(&Schema::default(), &u128_1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) + Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // U128 - Int = I128
-            evaluate_sub(&Schema::empty(), &u128_1, &int2, &row)
+            evaluate_sub(&Schema::default(), &u128_1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) - Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // U128 * Int = I128
-            evaluate_mul(&Schema::empty(), &u128_2, &int1, &row)
+            evaluate_mul(&Schema::default(), &u128_2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num2 as i128) * Wrapping(i_num1 as i128)).0)
         );
         assert_eq!(
             // U128 / Int = Float
-            evaluate_div(&Schema::empty(), &u128_2, &int1, &row)
+            evaluate_div(&Schema::default(), &u128_2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // U128 % Int = I128
-            evaluate_mod(&Schema::empty(), &u128_1, &int2, &row)
+            evaluate_mod(&Schema::default(), &u128_1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) % Wrapping(i_num2 as i128)).0)
         );
@@ -419,103 +419,103 @@ fn test_u128_math() {
         //// left: U128, right: I128
         assert_eq!(
             // U128 + I128 = I128
-            evaluate_add(&Schema::empty(), &u128_1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &u128_1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // U128 - I128 = I128
-            evaluate_sub(&Schema::empty(), &u128_1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &u128_1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // U128 * I128 = I128
-            evaluate_mul(&Schema::empty(), &u128_2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &u128_2, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num2 as i128) * Wrapping(i128_num1)).0)
         );
         assert_eq!(
             // U128 / I128 = Float
-            evaluate_div(&Schema::empty(), &u128_2, &i128_1, &row)
+            evaluate_div(&Schema::default(), &u128_2, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
         );
         assert_eq!(
             // U128 % I128 = I128
-            evaluate_mod(&Schema::empty(), &u128_1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &u128_1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) % Wrapping(i128_num2)).0)
         );
 
         //// left: U128, right: Float
-        let res = evaluate_add(&Schema::empty(), &u128_1, &float2, &row);
+        let res = evaluate_add(&Schema::default(), &u128_1, &float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 + Float = Float
-                evaluate_add(&Schema::empty(), &u128_1, &float2, &row)
+                evaluate_add(&Schema::default(), &u128_1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num1).unwrap() + f_num2))
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &u128_1, &float2, &row);
+        let res = evaluate_sub(&Schema::default(), &u128_1, &float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 - Float = Float
-                evaluate_sub(&Schema::empty(), &u128_1, &float2, &row)
+                evaluate_sub(&Schema::default(), &u128_1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num1).unwrap() - f_num2))
             );
         }
-        let res = evaluate_mul(&Schema::empty(), &u128_2, &float1, &row);
+        let res = evaluate_mul(&Schema::default(), &u128_2, &float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 * Float = Float
-                evaluate_mul(&Schema::empty(), &u128_2, &float1, &row)
+                evaluate_mul(&Schema::default(), &u128_2, &float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() * f_num1))
             );
         }
-        let res = evaluate_div(&Schema::empty(), &u128_2, &float1, &row);
+        let res = evaluate_div(&Schema::default(), &u128_2, &float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 / Float = Float
-                evaluate_div(&Schema::empty(), &u128_2, &float1, &row)
+                evaluate_div(&Schema::default(), &u128_2, &float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f_num1))
             );
         }
-        let res = evaluate_mod(&Schema::empty(), &u128_1, &float2, &row);
+        let res = evaluate_mod(&Schema::default(), &u128_1, &float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 % Float = Float
-                evaluate_mod(&Schema::empty(), &u128_1, &float2, &row)
+                evaluate_mod(&Schema::default(), &u128_1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num1).unwrap() % f_num2))
             );
         }
 
         //// left: U128, right: Decimal
-        let res = evaluate_add(&Schema::empty(), &u128_1, &dec2, &row);
+        let res = evaluate_add(&Schema::default(), &u128_1, &dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 + Decimal = Decimal
-                evaluate_add(&Schema::empty(), &u128_1, &dec2, &row)
+                evaluate_add(&Schema::default(), &u128_1, &dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_u128(u128_num1).unwrap() + d_num2.0)
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &u128_1, &dec2, &row);
+        let res = evaluate_sub(&Schema::default(), &u128_1, &dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 - Decimal = Decimal
-                evaluate_sub(&Schema::empty(), &u128_1, &dec2, &row)
+                evaluate_sub(&Schema::default(), &u128_1, &dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_u128(u128_num1).unwrap() - d_num2.0)
             );
         }
         // U128 * Decimal = Decimal
-        let res = evaluate_mul(&Schema::empty(), &u128_2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &u128_2, &dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_u128(u128_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -530,7 +530,7 @@ fn test_u128_math() {
             }
         }
         // U128 / Decimal = Decimal
-        let res = evaluate_div(&Schema::empty(), &u128_2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &u128_2, &dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -554,7 +554,7 @@ fn test_u128_math() {
             }
         }
         // U128 % Decimal = Decimal
-        let res = evaluate_mod(&Schema::empty(), &u128_1, &dec1, &row);
+        let res = evaluate_mod(&Schema::default(), &u128_1, &dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -581,31 +581,31 @@ fn test_u128_math() {
         //// left: U128, right: Null
         assert_eq!(
             // U128 + Null = Null
-            evaluate_add(&Schema::empty(), &u128_1, &null, &row)
+            evaluate_add(&Schema::default(), &u128_1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 - Null = Null
-            evaluate_sub(&Schema::empty(), &u128_1, &null, &row)
+            evaluate_sub(&Schema::default(), &u128_1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 * Null = Null
-            evaluate_mul(&Schema::empty(), &u128_2, &null, &row)
+            evaluate_mul(&Schema::default(), &u128_2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 / Null = Null
-            evaluate_div(&Schema::empty(), &u128_2, &null, &row)
+            evaluate_div(&Schema::default(), &u128_2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 % Null = Null
-            evaluate_mod(&Schema::empty(), &u128_1, &null, &row)
+            evaluate_mod(&Schema::default(), &u128_1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -615,7 +615,7 @@ fn test_u128_math() {
 #[test]
 fn test_int_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Box::new(Literal(Field::UInt(u_num1)));
         let uint2 = Box::new(Literal(Field::UInt(u_num2)));
@@ -635,31 +635,31 @@ fn test_int_math() {
         //// left: Int, right: UInt
         assert_eq!(
             // Int + UInt = Int
-            evaluate_add(&Schema::empty(), &int1, &uint2, &row)
+            evaluate_add(&Schema::default(), &int1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) + Wrapping(u_num2 as i64)).0)
         );
         assert_eq!(
             // Int - UInt = Int
-            evaluate_sub(&Schema::empty(), &int1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &int1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) - Wrapping(u_num2 as i64)).0)
         );
         assert_eq!(
             // Int * UInt = Int
-            evaluate_mul(&Schema::empty(), &int2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &int2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num2) * Wrapping(u_num1 as i64)).0)
         );
         assert_eq!(
             // Int / UInt = Float
-            evaluate_div(&Schema::empty(), &int2, &uint1, &row)
+            evaluate_div(&Schema::default(), &int2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // Int % UInt = Int
-            evaluate_mod(&Schema::empty(), &int1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &int1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) % Wrapping(u_num2 as i64)).0)
         );
@@ -667,33 +667,33 @@ fn test_int_math() {
         //// left: Int, right: U128
         assert_eq!(
             // Int + U128 = I128
-            evaluate_add(&Schema::empty(), &int1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &int1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) + Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // Int - U128 = I128
-            evaluate_sub(&Schema::empty(), &int1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &int1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) - Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // Int * U128 = I128
-            evaluate_mul(&Schema::empty(), &int2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &int2, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num2 as i128) * Wrapping(u128_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::empty(), &int2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &int2, &u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Int / U128 = Float
-                evaluate_div(&Schema::empty(), &int2, &u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+                evaluate_div(&Schema::default(), &int2, &u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i_num2 as i128).unwrap() / f64::from_i128(u128_num1 as i128).unwrap()))
             );
         }
         assert_eq!(
             // Int % U128 = I128
-            evaluate_mod(&Schema::empty(), &int1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &int1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) % Wrapping(u128_num2 as i128)).0)
         );
@@ -701,31 +701,31 @@ fn test_int_math() {
         //// left: Int, right: Int
         assert_eq!(
             // Int + Int = Int
-            evaluate_add(&Schema::empty(), &int1, &int2, &row)
+            evaluate_add(&Schema::default(), &int1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) + Wrapping(i_num2)).0)
         );
         assert_eq!(
             // Int - Int = Int
-            evaluate_sub(&Schema::empty(), &int1, &int2, &row)
+            evaluate_sub(&Schema::default(), &int1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) - Wrapping(i_num2)).0)
         );
         assert_eq!(
             // Int * Int = Int
-            evaluate_mul(&Schema::empty(), &int2, &int1, &row)
+            evaluate_mul(&Schema::default(), &int2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num2) * Wrapping(i_num1)).0)
         );
         assert_eq!(
             // Int / Int = Float
-            evaluate_div(&Schema::empty(), &int2, &int1, &row)
+            evaluate_div(&Schema::default(), &int2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // Int % Int = Int
-            evaluate_mod(&Schema::empty(), &int1, &int2, &row)
+            evaluate_mod(&Schema::default(), &int1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) % Wrapping(i_num2)).0)
         );
@@ -733,34 +733,34 @@ fn test_int_math() {
         //// left: Int, right: I128
         assert_eq!(
             // Int + I128 = I128
-            evaluate_add(&Schema::empty(), &int1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &int1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // Int - I128 = I128
-            evaluate_sub(&Schema::empty(), &int1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &int1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // Int * I128 = I128
-            evaluate_mul(&Schema::empty(), &int2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &int2, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num2 as i128) * Wrapping(i128_num1)).0)
         );
-        let res = evaluate_div(&Schema::empty(), &int2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &int2, &i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Int / I128 = Float
-                evaluate_div(&Schema::empty(), &int2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &int2, &i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
             );
         }
         assert_eq!(
             // Int % I128 = I128
-            evaluate_mod(&Schema::empty(), &int1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &int1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) % Wrapping(i128_num2)).0)
         );
@@ -768,26 +768,26 @@ fn test_int_math() {
         //// left: Int, right: Float
         assert_eq!(
             // Int + Float = Float
-            evaluate_add(&Schema::empty(), &int1, &float2, &row)
+            evaluate_add(&Schema::default(), &int1, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() + f_num2))
         );
         assert_eq!(
             // Int - Float = Float
-            evaluate_sub(&Schema::empty(), &int1, &float2, &row)
+            evaluate_sub(&Schema::default(), &int1, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() - f_num2))
         );
         assert_eq!(
             // Int * Float = Float
-            evaluate_mul(&Schema::empty(), &int2, &float1, &row)
+            evaluate_mul(&Schema::default(), &int2, &float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() * f_num1))
         );
         if *float1 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Int / Float = Float
-                evaluate_div(&Schema::empty(), &int2, &float1, &row)
+                evaluate_div(&Schema::default(), &int2, &float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f_num1))
             );
@@ -795,7 +795,7 @@ fn test_int_math() {
         if *float2 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Int % Float = Float
-                evaluate_mod(&Schema::empty(), &int1, &float2, &row)
+                evaluate_mod(&Schema::default(), &int1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() % f_num2))
             );
@@ -804,18 +804,18 @@ fn test_int_math() {
         //// left: Int, right: Decimal
         assert_eq!(
             // Int + Decimal = Decimal
-            evaluate_add(&Schema::empty(), &int1, &dec2, &row)
+            evaluate_add(&Schema::default(), &int1, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_i64(i_num1).unwrap() + d_num2.0)
         );
         assert_eq!(
             // Int - Decimal = Decimal
-            evaluate_sub(&Schema::empty(), &int1, &dec2, &row)
+            evaluate_sub(&Schema::default(), &int1, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_i64(i_num1).unwrap() - d_num2.0)
         );
         // Int * Decimal = Decimal
-        let res = evaluate_mul(&Schema::empty(), &int2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &int2, &dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_i64(i_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -828,7 +828,7 @@ fn test_int_math() {
             ));
         }
         // Int / Decimal = Decimal
-        let res = evaluate_div(&Schema::empty(), &int2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &int2, &dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -848,7 +848,7 @@ fn test_int_math() {
             ));
         }
         // Int % Decimal = Decimal
-        let res = evaluate_mod(&Schema::empty(), &int1, &dec2, &row);
+        let res = evaluate_mod(&Schema::default(), &int1, &dec2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -871,31 +871,31 @@ fn test_int_math() {
         //// left: Int, right: Null
         assert_eq!(
             // Int + Null = Null
-            evaluate_add(&Schema::empty(), &int1, &null, &row)
+            evaluate_add(&Schema::default(), &int1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int - Null = Null
-            evaluate_sub(&Schema::empty(), &int1, &null, &row)
+            evaluate_sub(&Schema::default(), &int1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int * Null = Null
-            evaluate_mul(&Schema::empty(), &int2, &null, &row)
+            evaluate_mul(&Schema::default(), &int2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int / Null = Null
-            evaluate_div(&Schema::empty(), &int2, &null, &row)
+            evaluate_div(&Schema::default(), &int2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int % Null = Null
-            evaluate_mod(&Schema::empty(), &int1, &null, &row)
+            evaluate_mod(&Schema::default(), &int1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -905,7 +905,7 @@ fn test_int_math() {
 #[test]
 fn test_i128_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Box::new(Literal(Field::UInt(u_num1)));
         let uint2 = Box::new(Literal(Field::UInt(u_num2)));
@@ -925,34 +925,34 @@ fn test_i128_math() {
         //// left: I128, right: UInt
         assert_eq!(
             // I128 + UInt = I128
-            evaluate_add(&Schema::empty(), &i128_1, &uint2, &row)
+            evaluate_add(&Schema::default(), &i128_1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(u_num2 as i128)).0)
         );
         assert_eq!(
             // I128 - UInt = I128
-            evaluate_sub(&Schema::empty(), &i128_1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &i128_1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(u_num2 as i128)).0)
         );
         assert_eq!(
             // I128 * UInt = I128
-            evaluate_mul(&Schema::empty(), &i128_2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &i128_2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(u_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::empty(), &i128_2, &uint1, &row);
+        let res = evaluate_div(&Schema::default(), &i128_2, &uint1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / UInt = Float
-                evaluate_div(&Schema::empty(), &i128_2, &uint1, &row)
+                evaluate_div(&Schema::default(), &i128_2, &uint1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
             );
         }
         assert_eq!(
             // I128 % UInt = I128
-            evaluate_mod(&Schema::empty(), &i128_1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &i128_1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(u_num2 as i128)).0)
         );
@@ -960,33 +960,33 @@ fn test_i128_math() {
         //// left: I128, right: U128
         assert_eq!(
             // I128 + U128 = I128
-            evaluate_add(&Schema::empty(), &i128_1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &i128_1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // I128 - U128 = I128
-            evaluate_sub(&Schema::empty(), &i128_1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &i128_1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // I128 * U128 = I128
-            evaluate_mul(&Schema::empty(), &i128_2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &i128_2, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(u128_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::empty(), &i128_2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &i128_2, &u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / U128 = Float
-                evaluate_div(&Schema::empty(), &i128_2, &u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+                evaluate_div(&Schema::default(), &i128_2, &u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_i128(u128_num1 as i128).unwrap()))
             );
         }
         assert_eq!(
             // I128 % U128 = I128
-            evaluate_mod(&Schema::empty(), &i128_1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &i128_1, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(u128_num2 as i128)).0)
         );
@@ -994,34 +994,34 @@ fn test_i128_math() {
         //// left: I128, right: Int
         assert_eq!(
             // I128 + Int = I128
-            evaluate_add(&Schema::empty(), &i128_1, &int2, &row)
+            evaluate_add(&Schema::default(), &i128_1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // I128 - Int = I128
-            evaluate_sub(&Schema::empty(), &i128_1, &int2, &row)
+            evaluate_sub(&Schema::default(), &i128_1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // I128 * Int = I128
-            evaluate_mul(&Schema::empty(), &i128_2, &int1, &row)
+            evaluate_mul(&Schema::default(), &i128_2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(i_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::empty(), &i128_2, &int1, &row);
+        let res = evaluate_div(&Schema::default(), &i128_2, &int1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / Int = Float
-                evaluate_div(&Schema::empty(), &i128_2, &int1, &row)
+                evaluate_div(&Schema::default(), &i128_2, &int1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
             );
         }
         assert_eq!(
             // I128 % Int = I128
-            evaluate_mod(&Schema::empty(), &i128_1, &int2, &row)
+            evaluate_mod(&Schema::default(), &i128_1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(i_num2 as i128)).0)
         );
@@ -1029,106 +1029,106 @@ fn test_i128_math() {
         //// left: I128, right: I128
         assert_eq!(
             // I128 + I128 = I128
-            evaluate_add(&Schema::empty(), &i128_1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &i128_1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // I128 - I128 = I128
-            evaluate_sub(&Schema::empty(), &i128_1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &i128_1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // I128 * I128 = I128
-            evaluate_mul(&Schema::empty(), &i128_2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &i128_2, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(i128_num1)).0)
         );
-        let res = evaluate_div(&Schema::empty(), &i128_2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &i128_2, &i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / I128 = Float
-                evaluate_div(&Schema::empty(), &i128_2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &i128_2, &i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
             );
         }
         assert_eq!(
             // I128 % I128 = I128
-            evaluate_mod(&Schema::empty(), &i128_1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &i128_1, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(i128_num2)).0)
         );
 
         //// left: I128, right: Float
-        let res = evaluate_add(&Schema::empty(), &i128_1, &float2, &row);
+        let res = evaluate_add(&Schema::default(), &i128_1, &float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 + Float = Float
-                evaluate_add(&Schema::empty(), &i128_1, &float2, &row)
+                evaluate_add(&Schema::default(), &i128_1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num1).unwrap() + f_num2))
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &i128_1, &float2, &row);
+        let res = evaluate_sub(&Schema::default(), &i128_1, &float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 - Float = Float
-                evaluate_sub(&Schema::empty(), &i128_1, &float2, &row)
+                evaluate_sub(&Schema::default(), &i128_1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num1).unwrap() - f_num2))
             );
         }
-        let res = evaluate_mul(&Schema::empty(), &i128_2, &float1, &row);
+        let res = evaluate_mul(&Schema::default(), &i128_2, &float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 * Float = Float
-                evaluate_mul(&Schema::empty(), &i128_2, &float1, &row)
+                evaluate_mul(&Schema::default(), &i128_2, &float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() * f_num1))
             );
         }
-        let res = evaluate_div(&Schema::empty(), &i128_2, &float1, &row);
+        let res = evaluate_div(&Schema::default(), &i128_2, &float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / Float = Float
-                evaluate_div(&Schema::empty(), &i128_2, &float1, &row)
+                evaluate_div(&Schema::default(), &i128_2, &float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f_num1))
             );
         }
-        let res = evaluate_mod(&Schema::empty(), &i128_1, &float2, &row);
+        let res = evaluate_mod(&Schema::default(), &i128_1, &float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 % Float = Float
-                evaluate_mod(&Schema::empty(), &i128_1, &float2, &row)
+                evaluate_mod(&Schema::default(), &i128_1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num1).unwrap() % f_num2))
             );
         }
 
         //// left: I128, right: Decimal
-        let res = evaluate_add(&Schema::empty(), &i128_1, &dec2, &row);
+        let res = evaluate_add(&Schema::default(), &i128_1, &dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 + Decimal = Decimal
-                evaluate_add(&Schema::empty(), &i128_1, &dec2, &row)
+                evaluate_add(&Schema::default(), &i128_1, &dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_i128(i128_num1).unwrap() + d_num2.0)
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &i128_1, &dec2, &row);
+        let res = evaluate_sub(&Schema::default(), &i128_1, &dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 - Decimal = Decimal
-                evaluate_sub(&Schema::empty(), &i128_1, &dec2, &row)
+                evaluate_sub(&Schema::default(), &i128_1, &dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_i128(i128_num1).unwrap() - d_num2.0)
             );
         }
         // I128 * Decimal = Decimal
-        let res = evaluate_mul(&Schema::empty(), &i128_2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &i128_2, &dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_i128(i128_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -1143,7 +1143,7 @@ fn test_i128_math() {
             }
         }
         // I128 / Decimal = Decimal
-        let res = evaluate_div(&Schema::empty(), &i128_2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &i128_2, &dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1167,7 +1167,7 @@ fn test_i128_math() {
             }
         }
         // I128 % Decimal = Decimal
-        let res = evaluate_mod(&Schema::empty(), &i128_1, &dec2, &row);
+        let res = evaluate_mod(&Schema::default(), &i128_1, &dec2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1194,31 +1194,31 @@ fn test_i128_math() {
         //// left: I128, right: Null
         assert_eq!(
             // I128 + Null = Null
-            evaluate_add(&Schema::empty(), &i128_1, &null, &row)
+            evaluate_add(&Schema::default(), &i128_1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 - Null = Null
-            evaluate_sub(&Schema::empty(), &i128_1, &null, &row)
+            evaluate_sub(&Schema::default(), &i128_1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 * Null = Null
-            evaluate_mul(&Schema::empty(), &i128_2, &null, &row)
+            evaluate_mul(&Schema::default(), &i128_2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 / Null = Null
-            evaluate_div(&Schema::empty(), &i128_2, &null, &row)
+            evaluate_div(&Schema::default(), &i128_2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 % Null = Null
-            evaluate_mod(&Schema::empty(), &i128_1, &null, &row)
+            evaluate_mod(&Schema::default(), &i128_1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -1228,7 +1228,7 @@ fn test_i128_math() {
 #[test]
 fn test_float_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Box::new(Literal(Field::UInt(u_num1)));
         let uint2 = Box::new(Literal(Field::UInt(u_num2)));
@@ -1248,77 +1248,77 @@ fn test_float_math() {
         //// left: Float, right: UInt
         assert_eq!(
             // Float + UInt = Float
-            evaluate_add(&Schema::empty(), &float1, &uint2, &row)
+            evaluate_add(&Schema::default(), &float1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_u64(u_num2).unwrap()))
         );
         assert_eq!(
             // Float - UInt = Float
-            evaluate_sub(&Schema::empty(), &float1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &float1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_u64(u_num2).unwrap()))
         );
         assert_eq!(
             // Float * UInt = Float
-            evaluate_mul(&Schema::empty(), &float2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &float2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // Float / UInt = Float
-            evaluate_div(&Schema::empty(), &float2, &uint1, &row)
+            evaluate_div(&Schema::default(), &float2, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // Float % UInt = Float
-            evaluate_mod(&Schema::empty(), &float1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &float1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_u64(u_num2).unwrap()))
         );
 
         //// left: Float, right: U128
-        let res = evaluate_add(&Schema::empty(), &float1, &u128_2, &row);
+        let res = evaluate_add(&Schema::default(), &float1, &u128_2, &row);
         if res.is_ok() {
            assert_eq!(
                 // Float + U128 = Float
-                evaluate_add(&Schema::empty(), &float1, &u128_2, &row)
+                evaluate_add(&Schema::default(), &float1, &u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_u128(u128_num2).unwrap()))
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &float1, &u128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &float1, &u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float - U128 = Float
-                evaluate_sub(&Schema::empty(), &float1, &u128_2, &row)
+                evaluate_sub(&Schema::default(), &float1, &u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_u128(u128_num2).unwrap()))
             );
         }
-        let res = evaluate_mul(&Schema::empty(), &float2, &u128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &float2, &u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float * U128 = Float
-                evaluate_mul(&Schema::empty(), &float2, &u128_1, &row)
+                evaluate_mul(&Schema::default(), &float2, &u128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_u128(u128_num1).unwrap()))
             );
         }
-        let res = evaluate_div(&Schema::empty(), &float2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &float2, &u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float / U128 = Float
-                evaluate_div(&Schema::empty(), &float2, &u128_1, &row)
+                evaluate_div(&Schema::default(), &float2, &u128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_u128(u128_num1).unwrap()))
             );
         }
-        let res = evaluate_mod(&Schema::empty(), &float1, &u128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &float1, &u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float % U128 = Float
-                evaluate_mod(&Schema::empty(), &float1, &u128_2, &row)
+                evaluate_mod(&Schema::default(), &float1, &u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_u128(u128_num2).unwrap()))
             );
@@ -1327,77 +1327,77 @@ fn test_float_math() {
         //// left: Float, right: Int
         assert_eq!(
             // Float + Int = Float
-            evaluate_add(&Schema::empty(), &float1, &int2, &row)
+            evaluate_add(&Schema::default(), &float1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_i64(i_num2).unwrap()))
         );
         assert_eq!(
             // Float - Int = Float
-            evaluate_sub(&Schema::empty(), &float1, &int2, &row)
+            evaluate_sub(&Schema::default(), &float1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_i64(i_num2).unwrap()))
         );
         assert_eq!(
             // Float * Int = Float
-            evaluate_mul(&Schema::empty(), &float2, &int1, &row)
+            evaluate_mul(&Schema::default(), &float2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // Float / Int = Float
-            evaluate_div(&Schema::empty(), &float2, &int1, &row)
+            evaluate_div(&Schema::default(), &float2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // Float % Int = Float
-            evaluate_mod(&Schema::empty(), &float1, &int2, &row)
+            evaluate_mod(&Schema::default(), &float1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_i64(i_num2).unwrap()))
         );
 
         //// left: Float, right: I128
-        let res = evaluate_add(&Schema::empty(), &float1, &i128_2, &row);
+        let res = evaluate_add(&Schema::default(), &float1, &i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float + I128 = Float
-                evaluate_add(&Schema::empty(), &float1, &i128_2, &row)
+                evaluate_add(&Schema::default(), &float1, &i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_i128(i128_num2).unwrap()))
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &float1, &i128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &float1, &i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float - I128 = Float
-                evaluate_sub(&Schema::empty(), &float1, &i128_2, &row)
+                evaluate_sub(&Schema::default(), &float1, &i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_i128(i128_num2).unwrap()))
             );
         }
-        let res = evaluate_mul(&Schema::empty(), &float2, &i128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &float2, &i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float * I128 = Float
-                evaluate_mul(&Schema::empty(), &float2, &i128_1, &row)
+                evaluate_mul(&Schema::default(), &float2, &i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_i128(i128_num1).unwrap()))
             );
         }
-        let res = evaluate_div(&Schema::empty(), &float2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &float2, &i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float / I128 = Float
-                evaluate_div(&Schema::empty(), &float2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &float2, &i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_i128(i128_num1).unwrap()))
             );
         }
-        let res = evaluate_mod(&Schema::empty(), &float1, &i128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &float1, &i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float % I128 = Float
-                evaluate_mod(&Schema::empty(), &float1, &i128_2, &row)
+                evaluate_mod(&Schema::default(), &float1, &i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_i128(i128_num2).unwrap()))
             );
@@ -1406,26 +1406,26 @@ fn test_float_math() {
         //// left: Float, right: Float
         assert_eq!(
             // Float + Float = Float
-            evaluate_add(&Schema::empty(), &float1, &float2, &row)
+            evaluate_add(&Schema::default(), &float1, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1 + f_num2))
         );
         assert_eq!(
             // Float - Float = Float
-            evaluate_sub(&Schema::empty(), &float1, &float2, &row)
+            evaluate_sub(&Schema::default(), &float1, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1 - f_num2))
         );
         assert_eq!(
             // Float * Float = Float
-            evaluate_mul(&Schema::empty(), &float2, &float1, &row)
+            evaluate_mul(&Schema::default(), &float2, &float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2 * f_num1))
         );
         if *float1 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Float / Float = Float
-                evaluate_div(&Schema::empty(), &float2, &float1, &row)
+                evaluate_div(&Schema::default(), &float2, &float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2 / f_num1))
             );
@@ -1433,7 +1433,7 @@ fn test_float_math() {
         if *float2 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Float % Float = Float
-                evaluate_mod(&Schema::empty(), &float1, &float2, &row)
+                evaluate_mod(&Schema::default(), &float1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1 % f_num2))
             );
@@ -1445,18 +1445,18 @@ fn test_float_math() {
         if d_val1.is_some() && d_val2.is_some() {
             assert_eq!(
                 // Float + Decimal = Decimal
-                evaluate_add(&Schema::empty(), &float1, &dec2, &row)
+                evaluate_add(&Schema::default(), &float1, &dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_val1.unwrap() + d_num2.0)
             );
             assert_eq!(
                 // Float - Decimal = Decimal
-                evaluate_sub(&Schema::empty(), &float1, &dec2, &row)
+                evaluate_sub(&Schema::default(), &float1, &dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_val1.unwrap() - d_num2.0)
             );
             // Float * Decimal = Decimal
-            let res = evaluate_mul(&Schema::empty(), &float2, &dec1, &row);
+            let res = evaluate_mul(&Schema::default(), &float2, &dec1, &row);
             if res.is_ok() {
                  assert_eq!(
                     res.unwrap(), Field::Decimal(d_val2.unwrap().checked_mul(d_num1.0).unwrap())
@@ -1469,7 +1469,7 @@ fn test_float_math() {
                 ));
             }
             // Float / Decimal = Decimal
-            let res = evaluate_div(&Schema::empty(), &float2, &dec1, &row);
+            let res = evaluate_div(&Schema::default(), &float2, &dec1, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1489,7 +1489,7 @@ fn test_float_math() {
                 ));
             }
             // Float % Decimal = Decimal
-            let res = evaluate_mod(&Schema::empty(), &float1, &dec2, &row);
+            let res = evaluate_mod(&Schema::default(), &float1, &dec2, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1513,31 +1513,31 @@ fn test_float_math() {
         //// left: Float, right: Null
         assert_eq!(
             // Float + Null = Null
-            evaluate_add(&Schema::empty(), &float1, &null, &row)
+            evaluate_add(&Schema::default(), &float1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float - Null = Null
-            evaluate_sub(&Schema::empty(), &float1, &null, &row)
+            evaluate_sub(&Schema::default(), &float1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float * Null = Null
-            evaluate_mul(&Schema::empty(), &float2, &null, &row)
+            evaluate_mul(&Schema::default(), &float2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float / Null = Null
-            evaluate_div(&Schema::empty(), &float2, &null, &row)
+            evaluate_div(&Schema::default(), &float2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float % Null = Null
-            evaluate_mod(&Schema::empty(), &float1, &null, &row)
+            evaluate_mod(&Schema::default(), &float1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -1547,7 +1547,7 @@ fn test_float_math() {
 #[test]
 fn test_decimal_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Box::new(Literal(Field::UInt(u_num1)));
         let uint2 = Box::new(Literal(Field::UInt(u_num2)));
@@ -1567,18 +1567,18 @@ fn test_decimal_math() {
         //// left: Decimal, right: UInt
         assert_eq!(
             // Decimal + UInt = Decimal
-            evaluate_add(&Schema::empty(), &dec1, &uint2, &row)
+            evaluate_add(&Schema::default(), &dec1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 + Decimal::from(u_num2))
         );
         assert_eq!(
             // Decimal - UInt = Decimal
-            evaluate_sub(&Schema::empty(), &dec1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &dec1, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 - Decimal::from(u_num2))
         );
         // Decimal * UInt = Decimal
-        let res = evaluate_mul(&Schema::empty(), &dec2, &uint1, &row);
+        let res = evaluate_mul(&Schema::default(), &dec2, &uint1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(d_num2.0 * Decimal::from(u_num1))
@@ -1591,7 +1591,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal / UInt = Decimal
-        let res = evaluate_div(&Schema::empty(), &dec2, &uint1, &row);
+        let res = evaluate_div(&Schema::default(), &dec2, &uint1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1611,7 +1611,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal % UInt = Decimal
-        let res = evaluate_mod(&Schema::empty(), &dec1, &uint2, &row);
+        let res = evaluate_mod(&Schema::default(), &dec1, &uint2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1632,26 +1632,26 @@ fn test_decimal_math() {
         }
 
         //// left: Decimal, right: U128
-        let res = evaluate_add(&Schema::empty(), &dec1, &u128_2, &row);
+        let res = evaluate_add(&Schema::default(), &dec1, &u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal + U128 = Decimal
-                evaluate_add(&Schema::empty(), &dec1, &u128_2, &row)
+                evaluate_add(&Schema::default(), &dec1, &u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 + Decimal::from_u128(u128_num2).unwrap())
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &dec1, &u128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &dec1, &u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal - U128 = Decimal
-                evaluate_sub(&Schema::empty(), &dec1, &u128_2, &row)
+                evaluate_sub(&Schema::default(), &dec1, &u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 - Decimal::from_u128(u128_num2).unwrap())
             );
         }
         // Decimal * U128 = Decimal
-        let res = evaluate_mul(&Schema::empty(), &dec2, &u128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &dec2, &u128_1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(d_num2.0 * Decimal::from_u128(u128_num1).unwrap())
@@ -1666,7 +1666,7 @@ fn test_decimal_math() {
             }
         }
         // Decimal / U128 = Decimal
-        let res = evaluate_div(&Schema::empty(), &dec2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &dec2, &u128_1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1690,7 +1690,7 @@ fn test_decimal_math() {
             }
         }
         // Decimal % U128 = Decimal
-        let res = evaluate_mod(&Schema::empty(), &dec1, &u128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &dec1, &u128_2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1717,80 +1717,80 @@ fn test_decimal_math() {
         //// left: Decimal, right: Int
         assert_eq!(
             // Decimal + Int = Decimal
-            evaluate_add(&Schema::empty(), &dec1, &int2, &row)
+            evaluate_add(&Schema::default(), &dec1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 + Decimal::from(i_num2))
         );
         assert_eq!(
             // Decimal - Int = Decimal
-            evaluate_sub(&Schema::empty(), &dec1, &int2, &row)
+            evaluate_sub(&Schema::default(), &dec1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 - Decimal::from(i_num2))
         );
-        let res = evaluate_mul(&Schema::empty(), &dec2, &int1, &row);
+        let res = evaluate_mul(&Schema::default(), &dec2, &int1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal * Int = Decimal
-                evaluate_mul(&Schema::empty(), &dec2, &int1, &row)
+                evaluate_mul(&Schema::default(), &dec2, &int1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num2.0 * Decimal::from(i_num1))
             );
         }
         assert_eq!(
             // Decimal / Int = Decimal
-            evaluate_div(&Schema::empty(), &dec2, &int1, &row)
+            evaluate_div(&Schema::default(), &dec2, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num2.0 / Decimal::from(i_num1))
         );
         assert_eq!(
             // Decimal % Int = Decimal
-            evaluate_mod(&Schema::empty(), &dec1, &int2, &row)
+            evaluate_mod(&Schema::default(), &dec1, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 % Decimal::from(i_num2))
         );
 
         //// left: Decimal, right: I128
-        let res = evaluate_add(&Schema::empty(), &dec1, &i128_2, &row);
+        let res = evaluate_add(&Schema::default(), &dec1, &i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal + I128 = Decimal
-                evaluate_add(&Schema::empty(), &dec1, &i128_2, &row)
+                evaluate_add(&Schema::default(), &dec1, &i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 + Decimal::from_i128(i128_num2).unwrap())
             );
         }
-        let res = evaluate_sub(&Schema::empty(), &dec1, &i128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &dec1, &i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal - I128 = Decimal
-                evaluate_sub(&Schema::empty(), &dec1, &i128_2, &row)
+                evaluate_sub(&Schema::default(), &dec1, &i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 - Decimal::from_i128(i128_num2).unwrap())
             );
         }
-        let res = evaluate_mul(&Schema::empty(), &dec2, &i128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &dec2, &i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal * I128 = Decimal
-                evaluate_mul(&Schema::empty(), &dec2, &i128_1, &row)
+                evaluate_mul(&Schema::default(), &dec2, &i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num2.0 * Decimal::from_i128(i128_num1).unwrap())
             );
         }
-        let res = evaluate_div(&Schema::empty(), &dec2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &dec2, &i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal / I128 = Decimal
-                evaluate_div(&Schema::empty(), &dec2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &dec2, &i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num2.0 / Decimal::from_i128(i128_num1).unwrap())
             );
         }
-        let res = evaluate_mod(&Schema::empty(), &dec1, &i128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &dec1, &i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal % I128 = Decimal
-                evaluate_mod(&Schema::empty(), &dec1, &i128_2, &row)
+                evaluate_mod(&Schema::default(), &dec1, &i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 % Decimal::from_i128(i128_num2).unwrap())
             );
@@ -1802,18 +1802,18 @@ fn test_decimal_math() {
         if d_val1.is_some() && d_val2.is_some() && d_val1.unwrap() != Decimal::new(0, 0) && d_val2.unwrap() != Decimal::new(0, 0) {
             assert_eq!(
                 // Decimal + Float = Decimal
-                evaluate_add(&Schema::empty(), &dec1, &float2, &row)
+                evaluate_add(&Schema::default(), &dec1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 + d_val2.unwrap())
             );
             assert_eq!(
                 // Decimal - Float = Decimal
-                evaluate_sub(&Schema::empty(), &dec1, &float2, &row)
+                evaluate_sub(&Schema::default(), &dec1, &float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 - d_val2.unwrap())
             );
             // Decimal * Float = Decimal
-            let res = evaluate_mul(&Schema::empty(), &dec2, &float1, &row);
+            let res = evaluate_mul(&Schema::default(), &dec2, &float1, &row);
             if res.is_ok() {
                  assert_eq!(
                     res.unwrap(), Field::Decimal(d_num2.0 * d_val1.unwrap())
@@ -1826,7 +1826,7 @@ fn test_decimal_math() {
                 ));
             }
             // Decimal / Float = Decimal
-            let res = evaluate_div(&Schema::empty(), &dec2, &float1, &row);
+            let res = evaluate_div(&Schema::default(), &dec2, &float1, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1846,7 +1846,7 @@ fn test_decimal_math() {
                 ));
             }
             // Decimal % Float = Decimal
-            let res = evaluate_mod(&Schema::empty(), &dec1, &float2, &row);
+            let res = evaluate_mod(&Schema::default(), &dec1, &float2, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1871,18 +1871,18 @@ fn test_decimal_math() {
         //// left: Decimal, right: Decimal
         assert_eq!(
             // Decimal + Decimal = Decimal
-            evaluate_add(&Schema::empty(), &dec1, &dec2, &row)
+            evaluate_add(&Schema::default(), &dec1, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 + d_num2.0)
         );
         assert_eq!(
             // Decimal - Decimal = Decimal
-            evaluate_sub(&Schema::empty(), &dec1, &dec2, &row)
+            evaluate_sub(&Schema::default(), &dec1, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 - d_num2.0)
         );
         // Decimal * Decimal = Decimal
-        let res = evaluate_mul(&Schema::empty(), &dec2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &dec2, &dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(d_num2.0 * d_num1.0)
@@ -1895,7 +1895,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal / Decimal = Decimal
-        let res = evaluate_div(&Schema::empty(), &dec2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &dec2, &dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1915,7 +1915,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal % Decimal = Decimal
-        let res = evaluate_mod(&Schema::empty(), &dec1, &dec2, &row);
+        let res = evaluate_mod(&Schema::default(), &dec1, &dec2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1938,31 +1938,31 @@ fn test_decimal_math() {
         //// left: Decimal, right: Null
         assert_eq!(
             // Decimal + Null = Null
-            evaluate_add(&Schema::empty(), &dec1, &null, &row)
+            evaluate_add(&Schema::default(), &dec1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal - Null = Null
-            evaluate_sub(&Schema::empty(), &dec1, &null, &row)
+            evaluate_sub(&Schema::default(), &dec1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal * Null = Null
-            evaluate_mul(&Schema::empty(), &dec2, &null, &row)
+            evaluate_mul(&Schema::default(), &dec2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Null = Null
-            evaluate_div(&Schema::empty(), &dec2, &null, &row)
+            evaluate_div(&Schema::default(), &dec2, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Null = Null
-            evaluate_mod(&Schema::empty(), &dec1, &null, &row)
+            evaluate_mod(&Schema::default(), &dec1, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -1972,7 +1972,7 @@ fn test_decimal_math() {
 #[test]
 fn test_null_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let uint1 = Box::new(Literal(Field::UInt(u_num1)));
         let uint2 = Box::new(Literal(Field::UInt(u_num2)));
@@ -1992,31 +1992,31 @@ fn test_null_math() {
         //// left: Null, right: UInt
         assert_eq!(
             // Null + UInt = Null
-            evaluate_add(&Schema::empty(), &null, &uint2, &row)
+            evaluate_add(&Schema::default(), &null, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - UInt = Null
-            evaluate_sub(&Schema::empty(), &null, &uint2, &row)
+            evaluate_sub(&Schema::default(), &null, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * UInt = Null
-            evaluate_mul(&Schema::empty(), &null, &uint1, &row)
+            evaluate_mul(&Schema::default(), &null, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / UInt = Null
-            evaluate_div(&Schema::empty(), &null, &uint1, &row)
+            evaluate_div(&Schema::default(), &null, &uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % UInt = Null
-            evaluate_mod(&Schema::empty(), &null, &uint2, &row)
+            evaluate_mod(&Schema::default(), &null, &uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2024,31 +2024,31 @@ fn test_null_math() {
         //// left: Null, right: U128
         assert_eq!(
             // Null + U128 = Null
-            evaluate_add(&Schema::empty(), &null, &u128_2, &row)
+            evaluate_add(&Schema::default(), &null, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - U128 = Null
-            evaluate_sub(&Schema::empty(), &null, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &null, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * U128 = Null
-            evaluate_mul(&Schema::empty(), &null, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &null, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / U128 = Null
-            evaluate_div(&Schema::empty(), &null, &u128_1, &row)
+            evaluate_div(&Schema::default(), &null, &u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % U128 = Null
-            evaluate_mod(&Schema::empty(), &null, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &null, &u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2056,31 +2056,31 @@ fn test_null_math() {
         //// left: Null, right: Int
         assert_eq!(
             // Null + Int = Null
-            evaluate_add(&Schema::empty(), &null, &int2, &row)
+            evaluate_add(&Schema::default(), &null, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Int = Null
-            evaluate_sub(&Schema::empty(), &null, &int2, &row)
+            evaluate_sub(&Schema::default(), &null, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Int = Null
-            evaluate_mul(&Schema::empty(), &null, &int1, &row)
+            evaluate_mul(&Schema::default(), &null, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Int = Null
-            evaluate_div(&Schema::empty(), &null, &int1, &row)
+            evaluate_div(&Schema::default(), &null, &int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Int = Null
-            evaluate_mod(&Schema::empty(), &null, &int2, &row)
+            evaluate_mod(&Schema::default(), &null, &int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2088,31 +2088,31 @@ fn test_null_math() {
         //// left: Null, right: I128
         assert_eq!(
             // Null + I128 = Null
-            evaluate_add(&Schema::empty(), &null, &i128_2, &row)
+            evaluate_add(&Schema::default(), &null, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - I128 = Null
-            evaluate_sub(&Schema::empty(), &null, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &null, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * I128 = Null
-            evaluate_mul(&Schema::empty(), &null, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &null, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / I128 = Null
-            evaluate_div(&Schema::empty(), &null, &i128_1, &row)
+            evaluate_div(&Schema::default(), &null, &i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % I128 = Null
-            evaluate_mod(&Schema::empty(), &null, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &null, &i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2120,31 +2120,31 @@ fn test_null_math() {
         //// left: Null, right: Float
         assert_eq!(
             // Null + Float = Null
-            evaluate_add(&Schema::empty(), &null, &float2, &row)
+            evaluate_add(&Schema::default(), &null, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Float = Null
-            evaluate_sub(&Schema::empty(), &null, &float2, &row)
+            evaluate_sub(&Schema::default(), &null, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Float = Null
-            evaluate_mul(&Schema::empty(), &null, &float1, &row)
+            evaluate_mul(&Schema::default(), &null, &float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Float = Null
-            evaluate_div(&Schema::empty(), &null, &float1, &row)
+            evaluate_div(&Schema::default(), &null, &float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Float = Null
-            evaluate_mod(&Schema::empty(), &null, &float2, &row)
+            evaluate_mod(&Schema::default(), &null, &float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2152,31 +2152,31 @@ fn test_null_math() {
         //// left: Null, right: Decimal
         assert_eq!(
             // Null + Decimal = Null
-            evaluate_add(&Schema::empty(), &null, &dec2, &row)
+            evaluate_add(&Schema::default(), &null, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Decimal = Null
-            evaluate_sub(&Schema::empty(), &null, &dec2, &row)
+            evaluate_sub(&Schema::default(), &null, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Decimal = Null
-            evaluate_mul(&Schema::empty(), &null, &dec1, &row)
+            evaluate_mul(&Schema::default(), &null, &dec1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Decimal = Null
-            evaluate_div(&Schema::empty(), &null, &dec1, &row)
+            evaluate_div(&Schema::default(), &null, &dec1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Decimal = Null
-            evaluate_mod(&Schema::empty(), &null, &dec2, &row)
+            evaluate_mod(&Schema::default(), &null, &dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2184,31 +2184,31 @@ fn test_null_math() {
         //// left: Null, right: Null
         assert_eq!(
             // Null + Null = Null
-            evaluate_add(&Schema::empty(), &null, &null, &row)
+            evaluate_add(&Schema::default(), &null, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Null = Null
-            evaluate_sub(&Schema::empty(), &null, &null, &row)
+            evaluate_sub(&Schema::default(), &null, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Null = Null
-            evaluate_mul(&Schema::empty(), &null, &null, &row)
+            evaluate_mul(&Schema::default(), &null, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Null = Null
-            evaluate_div(&Schema::empty(), &null, &null, &row)
+            evaluate_div(&Schema::default(), &null, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Null = Null
-            evaluate_mod(&Schema::empty(), &null, &null, &row)
+            evaluate_mod(&Schema::default(), &null, &null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );

--- a/dozer-sql/src/pipeline/expression/tests/number.rs
+++ b/dozer-sql/src/pipeline/expression/tests/number.rs
@@ -9,20 +9,20 @@ use std::ops::Neg;
 #[test]
 fn test_abs() {
     proptest!(ProptestConfig::with_cases(1000), |(i_num in 0i64..100000000i64, f_num in 0f64..100000000f64)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let v = Box::new(Literal(Field::Int(i_num.neg())));
         assert_eq!(
-            evaluate_abs(&Schema::empty(), &v, &row)
+            evaluate_abs(&Schema::default(), &v, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int(i_num)
         );
 
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let v = Box::new(Literal(Field::Float(OrderedFloat(f_num.neg()))));
         assert_eq!(
-            evaluate_abs(&Schema::empty(), &v, &row)
+            evaluate_abs(&Schema::default(), &v, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num))
         );
@@ -32,12 +32,12 @@ fn test_abs() {
 #[test]
 fn test_round() {
     proptest!(ProptestConfig::with_cases(1000), |(i_num: i64, f_num: f64, i_pow: i32, f_pow: f32)| {
-        let row = Record::new(None, vec![]);
+        let row = Record::new(vec![]);
 
         let v = Box::new(Literal(Field::Int(i_num)));
         let d = &Box::new(Literal(Field::Int(0)));
         assert_eq!(
-            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+            evaluate_round(&Schema::default(), &v, Some(d), &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int(i_num)
         );
@@ -45,7 +45,7 @@ fn test_round() {
         let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
         let d = &Box::new(Literal(Field::Int(0)));
         assert_eq!(
-            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+            evaluate_round(&Schema::default(), &v, Some(d), &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num.round()))
         );
@@ -54,7 +54,7 @@ fn test_round() {
         let d = &Box::new(Literal(Field::Int(i_pow as i64)));
         let order = 10.0_f64.powi(i_pow);
         assert_eq!(
-            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+            evaluate_round(&Schema::default(), &v, Some(d), &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat((f_num * order).round() / order))
         );
@@ -63,7 +63,7 @@ fn test_round() {
         let d = &Box::new(Literal(Field::Float(OrderedFloat(f_pow as f64))));
         let order = 10.0_f64.powi(f_pow.round() as i32);
         assert_eq!(
-            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+            evaluate_round(&Schema::default(), &v, Some(d), &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat((f_num * order).round() / order))
         );
@@ -71,7 +71,7 @@ fn test_round() {
         let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
         let d = &Box::new(Literal(Field::String(f_pow.to_string())));
         assert_eq!(
-            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+            evaluate_round(&Schema::default(), &v, Some(d), &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num.round()))
         );
@@ -79,7 +79,7 @@ fn test_round() {
         let v = Box::new(Literal(Field::Null));
         let d = &Box::new(Literal(Field::String(i_pow.to_string())));
         assert_eq!(
-            evaluate_round(&Schema::empty(), &v, Some(d), &row)
+            evaluate_round(&Schema::default(), &v, Some(d), &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -91,7 +91,7 @@ fn test_abs_logic() {
     proptest!(ProptestConfig::with_cases(1000), |(i_num in 0i64..100000000i64)| {
         let f = run_fct(
             "SELECT ABS(c) FROM USERS",
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         String::from("c"),

--- a/dozer-sql/src/pipeline/expression/tests/point.rs
+++ b/dozer-sql/src/pipeline/expression/tests/point.rs
@@ -21,7 +21,7 @@ fn test_point() {
 }
 
 fn test_validate_point(x: i64, y: i64) {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("x"),
@@ -115,9 +115,9 @@ fn test_validate_point(x: i64, y: i64) {
 }
 
 fn test_evaluate_point(x: i64, y: i64) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("x"),
@@ -189,7 +189,7 @@ fn test_evaluate_point(x: i64, y: i64) {
 fn test_point_logical() {
     let f = run_fct(
         "SELECT POINT(x, y) FROM LOCATION",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("x"),
@@ -221,7 +221,7 @@ fn test_point_logical() {
 fn test_point_with_nullable_parameter() {
     let f = run_fct(
         "SELECT POINT(x, y) FROM LOCATION",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("x"),

--- a/dozer-sql/src/pipeline/expression/tests/string.rs
+++ b/dozer-sql/src/pipeline/expression/tests/string.rs
@@ -21,14 +21,14 @@ fn test_string() {
 }
 
 fn test_like(s_val: &str, c_val: char) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
     // Field::String
     let value = Box::new(Literal(Field::String(format!("Hello{}", s_val))));
     let pattern = Box::new(Literal(Field::String("Hello%".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(true)
     );
 
@@ -36,7 +36,7 @@ fn test_like(s_val: &str, c_val: char) {
     let pattern = Box::new(Literal(Field::String("Hello, _orld!".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(true)
     );
 
@@ -44,7 +44,7 @@ fn test_like(s_val: &str, c_val: char) {
     let pattern = Box::new(Literal(Field::String("Hello%".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(false)
     );
 
@@ -53,7 +53,7 @@ fn test_like(s_val: &str, c_val: char) {
     let pattern = Box::new(Literal(Field::String("Hello, _!".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(false)
     );
 
@@ -63,7 +63,7 @@ fn test_like(s_val: &str, c_val: char) {
     // let escape = Some(c_val);
     //
     // assert_eq!(
-    //     evaluate_like(&Schema::empty(), &value, &pattern, escape, &row).unwrap(),
+    //     evaluate_like(&Schema::default(), &value, &pattern, escape, &row).unwrap(),
     //     Field::Boolean(true)
     // );
 
@@ -72,7 +72,7 @@ fn test_like(s_val: &str, c_val: char) {
     let pattern = Box::new(Literal(Field::Text("Hello%".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(true)
     );
 
@@ -80,7 +80,7 @@ fn test_like(s_val: &str, c_val: char) {
     let pattern = Box::new(Literal(Field::Text("Hello, _orld!".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(true)
     );
 
@@ -88,7 +88,7 @@ fn test_like(s_val: &str, c_val: char) {
     let pattern = Box::new(Literal(Field::Text("Hello%".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(false)
     );
 
@@ -97,7 +97,7 @@ fn test_like(s_val: &str, c_val: char) {
     let pattern = Box::new(Literal(Field::Text("Hello, _!".to_owned())));
 
     assert_eq!(
-        evaluate_like(&Schema::empty(), &value, &pattern, None, &row).unwrap(),
+        evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
         Field::Boolean(false)
     );
 
@@ -107,51 +107,51 @@ fn test_like(s_val: &str, c_val: char) {
     // let escape = Some(c_val);
     //
     // assert_eq!(
-    //     evaluate_like(&Schema::empty(), &value, &pattern, escape, &row).unwrap(),
+    //     evaluate_like(&Schema::default(), &value, &pattern, escape, &row).unwrap(),
     //     Field::Boolean(true)
     // );
 }
 
 fn test_ucase(s_val: &str, c_val: char) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
     // Field::String
     let value = Box::new(Literal(Field::String(s_val.to_string())));
     assert_eq!(
-        evaluate_ucase(&Schema::empty(), &value, &row).unwrap(),
+        evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
         Field::String(s_val.to_uppercase())
     );
 
     let value = Box::new(Literal(Field::String(c_val.to_string())));
     assert_eq!(
-        evaluate_ucase(&Schema::empty(), &value, &row).unwrap(),
+        evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
         Field::String(c_val.to_uppercase().to_string())
     );
 
     // Field::Text
     let value = Box::new(Literal(Field::Text(s_val.to_string())));
     assert_eq!(
-        evaluate_ucase(&Schema::empty(), &value, &row).unwrap(),
+        evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
         Field::Text(s_val.to_uppercase())
     );
 
     let value = Box::new(Literal(Field::Text(c_val.to_string())));
     assert_eq!(
-        evaluate_ucase(&Schema::empty(), &value, &row).unwrap(),
+        evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
         Field::Text(c_val.to_uppercase().to_string())
     );
 }
 
 fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
     // Field::String
     let val1 = Literal(Field::String(s_val1.to_string()));
     let val2 = Literal(Field::String(s_val2.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::String(s_val1.to_string() + s_val2)
         );
     }
@@ -159,9 +159,9 @@ fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
     let val1 = Literal(Field::String(s_val2.to_string()));
     let val2 = Literal(Field::String(s_val1.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::String(s_val2.to_string() + s_val1)
         );
     }
@@ -169,9 +169,9 @@ fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
     let val1 = Literal(Field::String(s_val1.to_string()));
     let val2 = Literal(Field::String(c_val.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::String(s_val1.to_string() + c_val.to_string().as_str())
         );
     }
@@ -179,9 +179,9 @@ fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
     let val1 = Literal(Field::String(c_val.to_string()));
     let val2 = Literal(Field::String(s_val1.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::String(c_val.to_string() + s_val1)
         );
     }
@@ -190,9 +190,9 @@ fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
     let val1 = Literal(Field::Text(s_val1.to_string()));
     let val2 = Literal(Field::Text(s_val2.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::Text(s_val1.to_string() + s_val2)
         );
     }
@@ -200,9 +200,9 @@ fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
     let val1 = Literal(Field::Text(s_val2.to_string()));
     let val2 = Literal(Field::Text(s_val1.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::Text(s_val2.to_string() + s_val1)
         );
     }
@@ -210,9 +210,9 @@ fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
     let val1 = Literal(Field::Text(s_val1.to_string()));
     let val2 = Literal(Field::Text(c_val.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::Text(s_val1.to_string() + c_val.to_string().as_str())
         );
     }
@@ -220,29 +220,29 @@ fn test_concat(s_val1: &str, s_val2: &str, c_val: char) {
     let val1 = Literal(Field::Text(c_val.to_string()));
     let val2 = Literal(Field::Text(s_val1.to_string()));
 
-    if validate_concat(&[val1.clone(), val2.clone()], &Schema::empty()).is_ok() {
+    if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_concat(&Schema::empty(), &[val1, val2], &row).unwrap(),
+            evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
             Field::Text(c_val.to_string() + s_val1)
         );
     }
 }
 
 fn test_trim(s_val1: &str, c_val: char) {
-    let row = Record::new(None, vec![]);
+    let row = Record::new(vec![]);
 
     // Field::String
     let value = Literal(Field::String(s_val1.to_string()));
     let what = ' ';
 
-    if validate_trim(&value, &Schema::empty()).is_ok() {
+    if validate_trim(&value, &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_trim(&Schema::empty(), &value, &None, &None, &row).unwrap(),
+            evaluate_trim(&Schema::default(), &value, &None, &None, &row).unwrap(),
             Field::String(s_val1.trim_matches(what).to_string())
         );
         assert_eq!(
             evaluate_trim(
-                &Schema::empty(),
+                &Schema::default(),
                 &value,
                 &None,
                 &Some(TrimType::Trailing),
@@ -253,7 +253,7 @@ fn test_trim(s_val1: &str, c_val: char) {
         );
         assert_eq!(
             evaluate_trim(
-                &Schema::empty(),
+                &Schema::default(),
                 &value,
                 &None,
                 &Some(TrimType::Leading),
@@ -263,7 +263,14 @@ fn test_trim(s_val1: &str, c_val: char) {
             Field::String(s_val1.trim_start_matches(what).to_string())
         );
         assert_eq!(
-            evaluate_trim(&Schema::empty(), &value, &None, &Some(TrimType::Both), &row).unwrap(),
+            evaluate_trim(
+                &Schema::default(),
+                &value,
+                &None,
+                &Some(TrimType::Both),
+                &row
+            )
+            .unwrap(),
             Field::String(s_val1.trim_matches(what).to_string())
         );
     }
@@ -271,14 +278,14 @@ fn test_trim(s_val1: &str, c_val: char) {
     let value = Literal(Field::String(s_val1.to_string()));
     let what = Some(Box::new(Literal(Field::String(c_val.to_string()))));
 
-    if validate_trim(&value, &Schema::empty()).is_ok() {
+    if validate_trim(&value, &Schema::default()).is_ok() {
         assert_eq!(
-            evaluate_trim(&Schema::empty(), &value, &what, &None, &row).unwrap(),
+            evaluate_trim(&Schema::default(), &value, &what, &None, &row).unwrap(),
             Field::String(s_val1.trim_matches(c_val).to_string())
         );
         assert_eq!(
             evaluate_trim(
-                &Schema::empty(),
+                &Schema::default(),
                 &value,
                 &what,
                 &Some(TrimType::Trailing),
@@ -289,7 +296,7 @@ fn test_trim(s_val1: &str, c_val: char) {
         );
         assert_eq!(
             evaluate_trim(
-                &Schema::empty(),
+                &Schema::default(),
                 &value,
                 &what,
                 &Some(TrimType::Leading),
@@ -299,7 +306,14 @@ fn test_trim(s_val1: &str, c_val: char) {
             Field::String(s_val1.trim_start_matches(c_val).to_string())
         );
         assert_eq!(
-            evaluate_trim(&Schema::empty(), &value, &what, &Some(TrimType::Both), &row).unwrap(),
+            evaluate_trim(
+                &Schema::default(),
+                &value,
+                &what,
+                &Some(TrimType::Both),
+                &row
+            )
+            .unwrap(),
             Field::String(s_val1.trim_matches(c_val).to_string())
         );
     }
@@ -309,7 +323,7 @@ fn test_trim(s_val1: &str, c_val: char) {
 fn test_concat_string() {
     let f = run_fct(
         "SELECT CONCAT(fn, ln, fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -341,7 +355,7 @@ fn test_concat_string() {
 fn test_concat_text() {
     let f = run_fct(
         "SELECT CONCAT(fn, ln, fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -373,7 +387,7 @@ fn test_concat_text() {
 fn test_concat_text_empty() {
     let f = run_fct(
         "SELECT CONCAT() FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -406,7 +420,7 @@ fn test_concat_text_empty() {
 fn test_concat_wrong_schema() {
     let f = run_fct(
         "SELECT CONCAT(fn, ln) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -435,7 +449,7 @@ fn test_concat_wrong_schema() {
 fn test_ucase_string() {
     let f = run_fct(
         "SELECT UCASE(fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -455,7 +469,7 @@ fn test_ucase_string() {
 fn test_ucase_text() {
     let f = run_fct(
         "SELECT UCASE(fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -475,7 +489,7 @@ fn test_ucase_text() {
 fn test_length() {
     let f = run_fct(
         "SELECT LENGTH(fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -495,7 +509,7 @@ fn test_length() {
 fn test_trim_string() {
     let f = run_fct(
         "SELECT TRIM(fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -515,7 +529,7 @@ fn test_trim_string() {
 fn test_trim_null() {
     let f = run_fct(
         "SELECT TRIM(fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -535,7 +549,7 @@ fn test_trim_null() {
 fn test_trim_text() {
     let f = run_fct(
         "SELECT TRIM(fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -555,7 +569,7 @@ fn test_trim_text() {
 fn test_trim_value() {
     let f = run_fct(
         "SELECT TRIM('_' FROM fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -575,7 +589,7 @@ fn test_trim_value() {
 fn test_btrim_value() {
     let f = run_fct(
         "SELECT TRIM(BOTH '_' FROM fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -595,7 +609,7 @@ fn test_btrim_value() {
 fn test_ltrim_value() {
     let f = run_fct(
         "SELECT TRIM(LEADING '_' FROM fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -615,7 +629,7 @@ fn test_ltrim_value() {
 fn test_ttrim_value() {
     let f = run_fct(
         "SELECT TRIM(TRAILING '_' FROM fn) FROM USERS",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("fn"),
@@ -635,7 +649,7 @@ fn test_ttrim_value() {
 fn test_like_value() {
     let f = run_fct(
         "SELECT first_name FROM users WHERE first_name LIKE 'J%'",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("first_name"),
@@ -655,7 +669,7 @@ fn test_like_value() {
 fn test_not_like_value() {
     let f = run_fct(
         "SELECT first_name FROM users WHERE first_name NOT LIKE 'A%'",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("first_name"),
@@ -675,7 +689,7 @@ fn test_not_like_value() {
 fn test_like_escape() {
     let f = run_fct(
         "SELECT first_name FROM users WHERE first_name LIKE 'J$%'",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("first_name"),
@@ -695,7 +709,7 @@ fn test_like_escape() {
 fn test_to_char() {
     let f = run_fct(
         "SELECT TO_CHAR(ts, '%Y-%m-%d') FROM transactions",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts"),
@@ -714,7 +728,7 @@ fn test_to_char() {
 
     let f = run_fct(
         "SELECT TO_CHAR(ts, '%H:%M') FROM transactions",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts"),
@@ -733,7 +747,7 @@ fn test_to_char() {
 
     let f = run_fct(
         "SELECT TO_CHAR(ts, '%H:%M') FROM transactions",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts"),
@@ -750,7 +764,7 @@ fn test_to_char() {
 
     let f = run_fct(
         "SELECT TO_CHAR(ts, '%Y-%m-%d') FROM transactions",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts"),
@@ -767,7 +781,7 @@ fn test_to_char() {
 
     let f = run_fct(
         "SELECT TO_CHAR(ts, '%H:%M') FROM transactions",
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     String::from("ts"),

--- a/dozer-sql/src/pipeline/expression/tests/test_common.rs
+++ b/dozer-sql/src/pipeline/expression/tests/test_common.rs
@@ -47,7 +47,7 @@ pub(crate) fn run_fct(sql: &str, schema: Schema, input: Vec<Field>) -> Field {
     let mut fw = TestChannelForwarder { operations: vec![] };
 
     let op = Operation::Insert {
-        new: Record::new(None, input),
+        new: Record::new(input),
     };
 
     processor.process(DEFAULT_PORT_HANDLE, op, &mut fw).unwrap();

--- a/dozer-sql/src/pipeline/planner/projection.rs
+++ b/dozer-sql/src/pipeline/planner/projection.rs
@@ -210,7 +210,7 @@ impl CommonPlanner {
         Self {
             input_schema: input_schema.clone(),
             post_aggregation_schema: input_schema,
-            post_projection_schema: Schema::empty(),
+            post_projection_schema: Schema::default(),
             aggregation_output: Vec::new(),
             having: None,
             groupby: Vec::new(),

--- a/dozer-sql/src/pipeline/planner/tests/projection_tests.rs
+++ b/dozer-sql/src/pipeline/planner/tests/projection_tests.rs
@@ -12,7 +12,7 @@ use dozer_types::types::{Field, FieldDefinition, FieldType, Schema, SourceDefini
 fn test_basic_projection() {
     let sql =
         "SELECT ROUND(SUM(ROUND(a,2)),2), a as a2 FROM t0 GROUP BY b,a HAVING SUM(ROUND(a,2)) > SUM(b)";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),
@@ -80,7 +80,7 @@ fn test_basic_projection() {
 
     assert_eq!(
         projection_planner.post_projection_schema,
-        Schema::empty()
+        Schema::default()
             .field(
                 FieldDefinition::new(
                     "ROUND(SUM(ROUND(a,2)),2)".to_string(),

--- a/dozer-sql/src/pipeline/planner/tests/schema_tests.rs
+++ b/dozer-sql/src/pipeline/planner/tests/schema_tests.rs
@@ -5,7 +5,7 @@ use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 #[test]
 fn test_schema_index_partial_group_by() {
     let sql = "SELECT COUNT(a), b FROM t0 GROUP BY b, c";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),
@@ -58,7 +58,7 @@ fn test_schema_index_partial_group_by() {
 #[test]
 fn test_schema_index_full_group_by() {
     let sql = "SELECT COUNT(a), c, b  FROM t0 GROUP BY b, c";
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),

--- a/dozer-sql/src/pipeline/product/join/factory.rs
+++ b/dozer-sql/src/pipeline/product/join/factory.rs
@@ -177,8 +177,8 @@ impl ProcessorFactory<SchemaSQLContext> for JoinProcessorFactory {
             right_join_key_indexes,
             left_primary_key_indexes,
             right_primary_key_indexes,
-            Record::from_schema(&left_schema),
-            Record::from_schema(&right_schema),
+            Record::nulls_from_schema(&left_schema),
+            Record::nulls_from_schema(&right_schema),
         );
 
         Ok(Box::new(ProductProcessor::new(
@@ -189,7 +189,7 @@ impl ProcessorFactory<SchemaSQLContext> for JoinProcessorFactory {
 }
 
 fn append_schema(left_schema: &Schema, right_schema: &Schema) -> Schema {
-    let mut output_schema = Schema::empty();
+    let mut output_schema = Schema::default();
 
     let left_len = left_schema.fields.len();
 

--- a/dozer-sql/src/pipeline/product/join/operator.rs
+++ b/dozer-sql/src/pipeline/product/join/operator.rs
@@ -592,7 +592,7 @@ fn join_records(left_record: &Record, right_record: &Record) -> Record {
         right_record.values.as_slice(),
     ]
     .concat();
-    let mut output_record = Record::new(None, concat_values);
+    let mut output_record = Record::new(concat_values);
 
     if let Some(left_record_lifetime) = left_record.lifetime.clone() {
         if let Some(right_record_lifetime) = right_record.lifetime.clone() {

--- a/dozer-sql/src/pipeline/product/set/set_factory.rs
+++ b/dozer-sql/src/pipeline/product/set/set_factory.rs
@@ -54,22 +54,16 @@ impl ProcessorFactory<SchemaSQLContext> for SetProcessorFactory {
     ) -> Result<(Schema, SchemaSQLContext), BoxedError> {
         let output_columns = validate_set_operation_input_schemas(input_schemas)?;
 
-        let mut output_schema = Schema::empty();
-        output_schema.fields = output_columns;
-        output_schema.identifier = input_schemas
-            .get(&0)
-            .map_or(Err(SetError::InvalidInputSchemas), Ok)
-            .unwrap()
-            .to_owned()
-            .0
-            .identifier;
-        output_schema.primary_index = input_schemas
-            .get(&0)
-            .map_or(Err(SetError::InvalidInputSchemas), Ok)
-            .unwrap()
-            .to_owned()
-            .0
-            .primary_index;
+        let output_schema = Schema {
+            fields: output_columns,
+            primary_index: input_schemas
+                .get(&0)
+                .map_or(Err(SetError::InvalidInputSchemas), Ok)
+                .unwrap()
+                .to_owned()
+                .0
+                .primary_index,
+        };
 
         Ok((output_schema, SchemaSQLContext::default()))
     }

--- a/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/product/tests/pipeline_test.rs
@@ -55,7 +55,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                 name: "user".to_string(),
             };
             Ok((
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("id"),
@@ -110,7 +110,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                 name: "department".to_string(),
             };
             Ok((
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("did"),
@@ -138,7 +138,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                 name: "country".to_string(),
             };
             Ok((
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("cid"),
@@ -193,82 +193,67 @@ impl Source for TestSource {
         let operations = vec![
             (
                 Operation::Insert {
-                    new: Record::new(None, vec![Field::Int(0), Field::String("IT".to_string())]),
+                    new: Record::new(vec![Field::Int(0), Field::String("IT".to_string())]),
                 },
                 DEPARTMENT_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(None, vec![Field::Int(1), Field::String("HR".to_string())]),
+                    new: Record::new(vec![Field::Int(1), Field::String("HR".to_string())]),
                 },
                 DEPARTMENT_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::Int(10000),
-                            Field::String("Alice".to_string()),
-                            Field::Int(0),
-                            Field::String("UK".to_string()),
-                            Field::Float(OrderedFloat(1.1)),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::Int(10000),
+                        Field::String("Alice".to_string()),
+                        Field::Int(0),
+                        Field::String("UK".to_string()),
+                        Field::Float(OrderedFloat(1.1)),
+                    ]),
                 },
                 USER_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::Int(10001),
-                            Field::String("Bob".to_string()),
-                            Field::Int(0),
-                            Field::String("UK".to_string()),
-                            Field::Float(OrderedFloat(1.1)),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::Int(10001),
+                        Field::String("Bob".to_string()),
+                        Field::Int(0),
+                        Field::String("UK".to_string()),
+                        Field::Float(OrderedFloat(1.1)),
+                    ]),
                 },
                 USER_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String("UK".to_string()),
-                            Field::String("United Kingdom".to_string()),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::String("UK".to_string()),
+                        Field::String("United Kingdom".to_string()),
+                    ]),
                 },
                 COUNTRY_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::String("SG".to_string()),
-                            Field::String("Singapore".to_string()),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::String("SG".to_string()),
+                        Field::String("Singapore".to_string()),
+                    ]),
                 },
                 COUNTRY_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::Int(10002),
-                            Field::String("Craig".to_string()),
-                            Field::Int(1),
-                            Field::String("SG".to_string()),
-                            Field::Float(OrderedFloat(1.1)),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::Int(10002),
+                        Field::String("Craig".to_string()),
+                        Field::Int(1),
+                        Field::String("SG".to_string()),
+                        Field::Float(OrderedFloat(1.1)),
+                    ]),
                 },
                 USER_PORT,
             ),
@@ -283,31 +268,25 @@ impl Source for TestSource {
             // ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::Int(10003),
-                            Field::String("Dan".to_string()),
-                            Field::Int(0),
-                            Field::String("UK".to_string()),
-                            Field::Float(OrderedFloat(1.1)),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::Int(10003),
+                        Field::String("Dan".to_string()),
+                        Field::Int(0),
+                        Field::String("UK".to_string()),
+                        Field::Float(OrderedFloat(1.1)),
+                    ]),
                 },
                 USER_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::Int(10004),
-                            Field::String("Eve".to_string()),
-                            Field::Int(1),
-                            Field::String("SG".to_string()),
-                            Field::Float(OrderedFloat(1.1)),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::Int(10004),
+                        Field::String("Eve".to_string()),
+                        Field::Int(1),
+                        Field::String("SG".to_string()),
+                        Field::Float(OrderedFloat(1.1)),
+                    ]),
                 },
                 USER_PORT,
             ),
@@ -327,23 +306,20 @@ impl Source for TestSource {
             // ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::Int(10005),
-                            Field::String("Frank".to_string()),
-                            Field::Int(1),
-                            Field::String("SG".to_string()),
-                            Field::Float(OrderedFloat(1.5)),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::Int(10005),
+                        Field::String("Frank".to_string()),
+                        Field::Int(1),
+                        Field::String("SG".to_string()),
+                        Field::Float(OrderedFloat(1.5)),
+                    ]),
                 },
                 USER_PORT,
             ),
             (
                 Operation::Update {
-                    old: Record::new(None, vec![Field::Int(0), Field::String("IT".to_string())]),
-                    new: Record::new(None, vec![Field::Int(0), Field::String("RD".to_string())]),
+                    old: Record::new(vec![Field::Int(0), Field::String("IT".to_string())]),
+                    new: Record::new(vec![Field::Int(0), Field::String("RD".to_string())]),
                 },
                 DEPARTMENT_PORT,
             ),
@@ -379,7 +355,7 @@ impl Source for TestSource {
             //         )
             //     }
             // }
-            fw.send(IngestionMessage::new_op(index as u64, 0, op), port)
+            fw.send(IngestionMessage::new_op(index as u64, 0, 0, op), port)
                 .unwrap();
         }
 

--- a/dozer-sql/src/pipeline/projection/processor.rs
+++ b/dozer-sql/src/pipeline/projection/processor.rs
@@ -29,7 +29,7 @@ impl ProjectionProcessor {
             results.push(expr.evaluate(record, &self.input_schema)?);
         }
 
-        let mut output_record = Record::new(None, results);
+        let mut output_record = Record::new(results);
         output_record.set_lifetime(record.lifetime.to_owned());
 
         Ok(Operation::Delete { old: output_record })
@@ -42,7 +42,7 @@ impl ProjectionProcessor {
             results.push(expr.evaluate(record, &self.input_schema)?);
         }
 
-        let mut output_record = Record::new(None, results);
+        let mut output_record = Record::new(results);
         output_record.set_lifetime(record.lifetime.to_owned());
         Ok(Operation::Insert { new: output_record })
     }
@@ -56,9 +56,9 @@ impl ProjectionProcessor {
             new_results.push(expr.evaluate(new, &self.input_schema)?);
         }
 
-        let mut old_output_record = Record::new(None, old_results);
+        let mut old_output_record = Record::new(old_results);
         old_output_record.set_lifetime(old.lifetime.to_owned());
-        let mut new_output_record = Record::new(None, new_results);
+        let mut new_output_record = Record::new(new_results);
         new_output_record.set_lifetime(new.lifetime.to_owned());
         Ok(Operation::Update {
             old: old_output_record,

--- a/dozer-sql/src/pipeline/table_operator/tests/operator_test.rs
+++ b/dozer-sql/src/pipeline/table_operator/tests/operator_test.rs
@@ -15,7 +15,7 @@ use crate::pipeline::{
 
 #[test]
 fn test_lifetime() {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 "id".to_string(),
@@ -40,13 +40,10 @@ fn test_lifetime() {
         )
         .to_owned();
 
-    let record = Record::new(
-        None,
-        vec![
-            Field::Int(0),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-        ],
-    );
+    let record = Record::new(vec![
+        Field::Int(0),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+    ]);
 
     let table_operator = LifetimeTableOperator::new(
         None,
@@ -71,13 +68,10 @@ fn test_lifetime() {
     assert_eq!(result.len(), 1);
     let lifetime_record = result.get(0).unwrap();
 
-    let mut expected_record = Record::new(
-        None,
-        vec![
-            Field::Int(0),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-        ],
-    );
+    let mut expected_record = Record::new(vec![
+        Field::Int(0),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+    ]);
 
     expected_record.set_lifetime(Some(Lifetime {
         reference: Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),

--- a/dozer-sql/src/pipeline/table_operator/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/table_operator/tests/pipeline_test.rs
@@ -123,7 +123,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                 name: "taxi_trips".to_string(),
             };
             Ok((
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("taxi_id"),
@@ -160,7 +160,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                 name: "zones".to_string(),
             };
             Ok((
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("location_id"),
@@ -215,140 +215,119 @@ impl Source for TestSource {
         let operations = vec![
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1001),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:00:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(1),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1001),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:00:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(1),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1002),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:01:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(2),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1002),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:01:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(2),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1003),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:02:10", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(3),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1003),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:02:10", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(3),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1004),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:03:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(2),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1004),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:03:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(2),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1005),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:05:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(1),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1005),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:05:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(1),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1006),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:06:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(2),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1006),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:06:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(2),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![Field::UInt(1), Field::String("Newark Airport".to_string())],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1),
+                        Field::String("Newark Airport".to_string()),
+                    ]),
                 },
                 ZONES_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![Field::UInt(2), Field::String("Jamaica Bay".to_string())],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(2),
+                        Field::String("Jamaica Bay".to_string()),
+                    ]),
                 },
                 ZONES_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(3),
-                            Field::String("Allerton/Pelham Gardens".to_string()),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(3),
+                        Field::String("Allerton/Pelham Gardens".to_string()),
+                    ]),
                 },
                 ZONES_PORT,
             ),
         ];
 
         for (index, (op, port)) in operations.into_iter().enumerate() {
-            fw.send(IngestionMessage::new_op(index as u64, 0, op), port)
+            fw.send(IngestionMessage::new_op(index as u64, 0, 0, op), port)
                 .unwrap();
             //thread::sleep(Duration::from_millis(500));
         }

--- a/dozer-sql/src/pipeline/tests/builder_test.rs
+++ b/dozer-sql/src/pipeline/tests/builder_test.rs
@@ -47,7 +47,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
         _port: &PortHandle,
     ) -> Result<(Schema, SchemaSQLContext), BoxedError> {
         Ok((
-            Schema::empty()
+            Schema::default()
                 .field(
                     FieldDefinition::new(
                         String::from("CustomerID"),
@@ -106,15 +106,13 @@ impl Source for TestSource {
                 IngestionMessage::new_op(
                     n,
                     0,
+                    0,
                     Operation::Insert {
-                        new: Record::new(
-                            None,
-                            vec![
-                                Field::Int(0),
-                                Field::String("Italy".to_string()),
-                                Field::Float(OrderedFloat(5.5)),
-                            ],
-                        ),
+                        new: Record::new(vec![
+                            Field::Int(0),
+                            Field::String("Italy".to_string()),
+                            Field::Float(OrderedFloat(5.5)),
+                        ]),
                     },
                 ),
                 DEFAULT_PORT_HANDLE,

--- a/dozer-sql/src/pipeline/window/tests/operator_test.rs
+++ b/dozer-sql/src/pipeline/window/tests/operator_test.rs
@@ -7,13 +7,10 @@ use crate::pipeline::window::operator::WindowType;
 
 #[test]
 fn test_hop() {
-    let record = Record::new(
-        None,
-        vec![
-            Field::Int(0),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-        ],
-    );
+    let record = Record::new(vec![
+        Field::Int(0),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+    ]);
 
     let window = WindowType::Hop {
         column_index: 1,
@@ -24,42 +21,33 @@ fn test_hop() {
     assert_eq!(result.len(), 5);
     let window_record = result.get(0).unwrap();
 
-    let expected_record = Record::new(
-        None,
-        vec![
-            Field::Int(0),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:09:00Z").unwrap()),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:14:00Z").unwrap()),
-        ],
-    );
+    let expected_record = Record::new(vec![
+        Field::Int(0),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:09:00Z").unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:14:00Z").unwrap()),
+    ]);
 
     assert_eq!(*window_record, expected_record);
 
     let window_record = result.get(1).unwrap();
 
-    let expected_record = Record::new(
-        None,
-        vec![
-            Field::Int(0),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:10:00Z").unwrap()),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:15:00Z").unwrap()),
-        ],
-    );
+    let expected_record = Record::new(vec![
+        Field::Int(0),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:10:00Z").unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:15:00Z").unwrap()),
+    ]);
 
     assert_eq!(*window_record, expected_record);
 }
 
 #[test]
 fn test_tumble() {
-    let record = Record::new(
-        None,
-        vec![
-            Field::Int(0),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-        ],
-    );
+    let record = Record::new(vec![
+        Field::Int(0),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+    ]);
 
     let window = WindowType::Tumble {
         column_index: 1,
@@ -70,22 +58,19 @@ fn test_tumble() {
     assert_eq!(result.len(), 1);
     let window_record = result.get(0).unwrap();
 
-    let expected_record = Record::new(
-        None,
-        vec![
-            Field::Int(0),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:10:00Z").unwrap()),
-            Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:15:00Z").unwrap()),
-        ],
-    );
+    let expected_record = Record::new(vec![
+        Field::Int(0),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:13:00Z").unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:10:00Z").unwrap()),
+        Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:15:00Z").unwrap()),
+    ]);
 
     assert_eq!(*window_record, expected_record);
 }
 
 #[test]
 fn test_window_schema() {
-    let schema = Schema::empty()
+    let schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("id"),
@@ -113,7 +98,7 @@ fn test_window_schema() {
 
     let result = window.get_output_schema(&schema).unwrap();
 
-    let mut expected_schema = Schema::empty()
+    let mut expected_schema = Schema::default()
         .field(
             FieldDefinition::new(
                 String::from("id"),

--- a/dozer-sql/src/pipeline/window/tests/pipeline_test.rs
+++ b/dozer-sql/src/pipeline/window/tests/pipeline_test.rs
@@ -123,7 +123,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                 name: "taxi_trips".to_string(),
             };
             Ok((
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("taxi_id"),
@@ -160,7 +160,7 @@ impl SourceFactory<SchemaSQLContext> for TestSourceFactory {
                 name: "zones".to_string(),
             };
             Ok((
-                Schema::empty()
+                Schema::default()
                     .field(
                         FieldDefinition::new(
                             String::from("location_id"),
@@ -215,103 +215,85 @@ impl Source for TestSource {
         let operations = vec![
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1001),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:00:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(1),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1001),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:00:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(1),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1002),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:01:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(2),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1002),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:01:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(2),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1003),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:02:10", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(3),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1003),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:02:10", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(3),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1004),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:03:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(2),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1004),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:03:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(2),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1005),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:05:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(1),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1005),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:05:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(1),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
             (
                 Operation::Insert {
-                    new: Record::new(
-                        None,
-                        vec![
-                            Field::UInt(1006),
-                            Field::Timestamp(
-                                Utc.datetime_from_str("2023-02-01 22:06:00", DATE_FORMAT)
-                                    .unwrap()
-                                    .into(),
-                            ),
-                            Field::UInt(2),
-                        ],
-                    ),
+                    new: Record::new(vec![
+                        Field::UInt(1006),
+                        Field::Timestamp(
+                            Utc.datetime_from_str("2023-02-01 22:06:00", DATE_FORMAT)
+                                .unwrap()
+                                .into(),
+                        ),
+                        Field::UInt(2),
+                    ]),
                 },
                 TRIPS_PORT,
             ),
@@ -348,7 +330,7 @@ impl Source for TestSource {
         ];
 
         for (index, (op, port)) in operations.into_iter().enumerate() {
-            fw.send(IngestionMessage::new_op(index as u64, 0, op), port)
+            fw.send(IngestionMessage::new_op(index as u64, 0, 0, op), port)
                 .unwrap();
         }
 

--- a/dozer-tests/src/cache_tests/film/schema.rs
+++ b/dozer-tests/src/cache_tests/film/schema.rs
@@ -1,7 +1,7 @@
 use dozer_types::{
     chrono::{DateTime, FixedOffset},
     serde::{self, Deserialize, Serialize},
-    types::{FieldDefinition, FieldType, Schema, SchemaIdentifier, SourceDefinition},
+    types::{FieldDefinition, FieldType, Schema, SourceDefinition},
 };
 use mongodb::bson::doc;
 
@@ -24,8 +24,7 @@ pub struct Film {
 }
 
 pub fn film_schema() -> Schema {
-    let mut schema = Schema::empty();
-    schema.identifier = Some(SchemaIdentifier { id: 0, version: 0 });
+    let mut schema = Schema::default();
     schema
         .field(
             FieldDefinition::new(

--- a/dozer-tests/src/cache_tests/mod.rs
+++ b/dozer-tests/src/cache_tests/mod.rs
@@ -34,5 +34,5 @@ pub fn string_record_to_record(record: &StringRecord, schema: &Schema) -> Record
         })
         .collect();
 
-    Record::new(schema.identifier, values)
+    Record::new(values)
 }

--- a/dozer-tests/src/sql_tests/helper/mapper.rs
+++ b/dozer-tests/src/sql_tests/helper/mapper.rs
@@ -200,7 +200,6 @@ fn get_record_from_json(data: String, schema: &Schema) -> Record {
     let root: Value = serde_json::from_str(&data).unwrap();
     let mut record = Record {
         values: vec![],
-        schema_id: None,
         lifetime: None,
     };
 

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -123,7 +123,7 @@ impl Source for TestSource {
         while let Ok(Some((schema_name, op))) = self.receiver.recv() {
             idx += 1;
             let port = self.name_to_port.get(&schema_name).expect("port not found");
-            fw.send(IngestionMessage::new_op(idx, 0, op), *port)
+            fw.send(IngestionMessage::new_op(idx, 0, 0, op), *port)
                 .unwrap();
         }
         thread::sleep(Duration::from_millis(200));
@@ -311,7 +311,7 @@ impl TestPipeline {
         // dag.print_dot();
 
         Ok(TestPipeline {
-            schema: Schema::empty(),
+            schema: Schema::default(),
             dag,
             used_schemas,
 

--- a/dozer-tests/src/sql_tests/helper/schema.rs
+++ b/dozer-tests/src/sql_tests/helper/schema.rs
@@ -40,7 +40,6 @@ pub fn get_schema(columns: &[rusqlite::Column]) -> Schema {
         .collect();
 
     Schema {
-        identifier: None,
         fields,
         primary_index,
     }

--- a/dozer-tracing/src/helper.rs
+++ b/dozer-tracing/src/helper.rs
@@ -1,6 +1,6 @@
 use dozer_types::chrono::{DateTime, Utc};
 use dozer_types::types::{Field, Record};
-use dozer_types::types::{FieldDefinition, FieldType, Schema, SchemaIdentifier, SourceDefinition};
+use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 use opentelemetry::sdk::export::trace::SpanData;
 
 pub(crate) fn map_span_data(span_data: SpanData) -> (Record, Vec<Record>) {
@@ -9,7 +9,6 @@ pub(crate) fn map_span_data(span_data: SpanData) -> (Record, Vec<Record>) {
 
     let span_id = u64::from_be_bytes(span_data.span_context.span_id().to_bytes());
     let span_record = Record {
-        schema_id: Some(SchemaIdentifier { id: 1, version: 1 }),
         values: vec![
             Field::UInt(span_id),
             Field::Binary(span_data.span_context.trace_id().to_bytes().to_vec()),
@@ -25,7 +24,6 @@ pub(crate) fn map_span_data(span_data: SpanData) -> (Record, Vec<Record>) {
     for evt in span_data.events {
         let ts: DateTime<Utc> = evt.timestamp.into();
         let record = Record {
-            schema_id: Some(SchemaIdentifier { id: 2, version: 1 }),
             values: vec![
                 Field::UInt(span_id),
                 Field::Text(evt.name.to_string()),
@@ -80,7 +78,6 @@ pub fn spans_schema() -> Schema {
     ];
 
     Schema {
-        identifier: Some(SchemaIdentifier { id: 1, version: 1 }),
         fields,
         primary_index: vec![0],
     }
@@ -109,7 +106,6 @@ pub fn events_schema() -> Schema {
     ];
 
     Schema {
-        identifier: Some(SchemaIdentifier { id: 2, version: 1 }),
         fields,
         primary_index: vec![],
     }

--- a/dozer-types/src/arrow_types/from_arrow.rs
+++ b/dozer-types/src/arrow_types/from_arrow.rs
@@ -196,7 +196,6 @@ fn handle_with_dozer_schema(
     }
 
     Ok(DozerSchema {
-        identifier: None,
         fields,
         primary_index: vec![],
     })
@@ -347,7 +346,6 @@ pub fn map_record_batch_to_dozer_records(
             values.push(value);
         }
         records.push(Record {
-            schema_id: schema.identifier,
             values,
             lifetime: None,
         });

--- a/dozer-types/src/arrow_types/tests.rs
+++ b/dozer-types/src/arrow_types/tests.rs
@@ -12,7 +12,7 @@ fn can_convert_from_arrow_to_dozer() {
     let field_c = arrow_types::Field::new("c", arrow_types::DataType::Utf8, false);
 
     let schema = arrow_types::Schema::new(vec![field_a.clone(), field_b, field_c]);
-    let _dozer_schema = DozerSchema::empty()
+    let _dozer_schema = DozerSchema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),
@@ -57,7 +57,7 @@ fn can_convert_from_arrow_to_dozer_with_metadata() {
     let field_d = arrow_types::Field::new("d", arrow_types::DataType::Utf8, false);
 
     let schema = arrow_types::Schema::new(vec![field_a.clone(), field_b, field_c, field_d]);
-    let dozer_schema = DozerSchema::empty()
+    let dozer_schema = DozerSchema::default()
         .field(
             FieldDefinition::new(
                 "a".to_string(),
@@ -119,7 +119,7 @@ fn roundtrip_record_to_record_batch() {
     use crate::arrow_types::to_arrow::map_to_arrow_schema;
     use crate::types::field::{arrow_field_test_cases, arrow_field_test_cases_schema};
 
-    let record: Record = Record::new(None, arrow_field_test_cases().collect());
+    let record: Record = Record::new(arrow_field_test_cases().collect());
     let record_batch: RecordBatch =
         map_record_to_arrow(record.clone(), &arrow_field_test_cases_schema()).unwrap();
     let res: Vec<Record> =

--- a/dozer-types/src/ingestion_types.rs
+++ b/dozer-types/src/ingestion_types.rs
@@ -16,10 +16,10 @@ pub struct IngestionMessage {
 }
 
 impl IngestionMessage {
-    pub fn new_op(txn: u64, seq_no: u64, op: Operation) -> Self {
+    pub fn new_op(txn: u64, seq_no: u64, table_index: usize, op: Operation) -> Self {
         Self {
             identifier: OpIdentifier::new(txn, seq_no),
-            kind: IngestionMessageKind::OperationEvent(op),
+            kind: IngestionMessageKind::OperationEvent { table_index, op },
         }
     }
 
@@ -42,7 +42,7 @@ impl IngestionMessage {
 /// All possible kinds of `IngestionMessage`.
 pub enum IngestionMessageKind {
     /// A CDC event.
-    OperationEvent(Operation),
+    OperationEvent { table_index: usize, op: Operation },
     /// A connector uses this message kind to notify Dozer that a initial snapshot of the source tables is started
     SnapshottingStarted,
     /// A connector uses this message kind to notify Dozer that a initial snapshot of the source tables is done,

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -788,7 +788,7 @@ pub fn arrow_field_test_cases() -> impl Iterator<Item = Field> {
 }
 
 pub fn arrow_field_test_cases_schema() -> Schema {
-    Schema::empty()
+    Schema::default()
         .field(
             FieldDefinition::new(
                 "uint1".to_string(),

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -59,19 +59,8 @@ impl FieldDefinition {
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
-pub struct SchemaIdentifier {
-    pub id: u32,
-    pub version: u16,
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
 pub struct Schema {
-    /// Unique identifier and version for this schema. This value is required only if the schema
-    /// is represented by a valid entry in the schema registry. For nested schemas, this field
-    /// is not applicable
-    pub identifier: Option<SchemaIdentifier>,
-
     /// fields contains a list of FieldDefinition for all the fields that appear in a record.
     /// Not necessarily all these fields will end up in the final object structure stored in
     /// the cache. Some fields might only be used for indexing purposes only.
@@ -85,12 +74,8 @@ pub struct Schema {
 }
 
 impl Schema {
-    pub fn empty() -> Schema {
-        Self {
-            identifier: None,
-            fields: Vec::new(),
-            primary_index: Vec::new(),
-        }
+    pub fn new() -> Schema {
+        Self::default()
     }
 
     pub fn field(&mut self, f: FieldDefinition, pk: bool) -> &mut Self {
@@ -160,9 +145,6 @@ pub struct Lifetime {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Record {
-    /// Schema implemented by this Record
-    pub schema_id: Option<SchemaIdentifier>,
-
     /// List of values, following the definitions of `fields` of the associated schema
     pub values: Vec<Field>,
 
@@ -171,25 +153,19 @@ pub struct Record {
 }
 
 impl Record {
-    pub fn new(schema_id: Option<SchemaIdentifier>, values: Vec<Field>) -> Record {
+    pub fn new(values: Vec<Field>) -> Record {
         Record {
-            schema_id,
             values,
             lifetime: None,
         }
     }
 
-    pub fn from_schema(schema: &Schema) -> Record {
-        Record {
-            schema_id: schema.identifier,
-            values: vec![Field::Null; schema.fields.len()],
-            lifetime: None,
-        }
+    pub fn nulls_from_schema(schema: &Schema) -> Record {
+        Self::nulls(schema.fields.len())
     }
 
-    pub fn nulls(schema_id: Option<SchemaIdentifier>, size: usize) -> Record {
+    pub fn nulls(size: usize) -> Record {
         Record {
-            schema_id,
             values: vec![Field::Null; size],
             lifetime: None,
         }


### PR DESCRIPTION
# Motivation

`SchemaIdentifier` is only used in `Connector`s. Their output record must have a `schema_id` that matches previous call of `get_schema`.  This has two problems:

1. The matching is very subtle and may confuse new implementors of `Connector`s.
2. `SchemaIdentifier` is not used anywhere else but it appears everywhere in the code because it's a member of fundamental types `Schema` and `Record`.

# Change

This PR removes the type `SchemaIdentifier` and corresponding member `Schema::identifier` and `Record::schema_id`. Turns out the real changes only need to happen in `Connector`s in `dozer-ingestion` and the `ConnectorSource`.

Instead of the implicit contract that `Record::schema_id` must match a previous generated `Schema::identifier`, we now ask the `Connector` to accompany every operation with a `table_index`, to directly show which table this operation belongs to. As a result:

- `ConnectorSource` doesn't need to maintain map from `SchemaIdentifier` to `PortHandle`. It keeps a `Vec<PortHandle>` instead.
- `DeltaLakeConnector`, `KafkaConnector`, `ObjectStoreConnector` and `SnowflakeConnector` were already using `table_index` as `SchemaIdentifier`. We change some type from `u32` to `usize` and do some renaming.
- `EthLogConnector` does table filtering by trying to find the table name on eth log event. We simply extract the `table_index` during this filtering process.
- `EthTraceConnector` always has only one table and the schema id was hardcoded. Now the `table_index` is hardcoded to `0`.
- `GrpcConnector` had a bug that it didn't respect table filtering. We implement table filtering and get `table_index` in the process.
- `PostgresConnector` used schema relation id as the schema identifier. We modified `SchemaHelper::get_tables` to apply table filtering and reordering there, and pass the `table_index` information along with returned `Vec<PostgresTableInfo>`.