### PR TITLE
fix: Truncate credentials file when new profiles added or updated

### DIFF
--- a/dozer-cli/src/simple/cloud/login.rs
+++ b/dozer-cli/src/simple/cloud/login.rs
@@ -44,6 +44,7 @@ impl CredentialInfo {
         let f = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .open(file_path)?;
         let mut current_credential_infos: Vec<CredentialInfo> = CredentialInfo::read_profile()?;
         current_credential_infos.append(&mut vec![self.clone()]);


### PR DESCRIPTION
Without truncate partial profile information were left in credentials file (when new details length are shorter than old one)