### PR TITLE
chore: Remove unused trait `ExpressionExecutor`.

### DIFF
--- a/dozer-sql/src/pipeline/aggregation/avg.rs
+++ b/dozer-sql/src/pipeline/aggregation/avg.rs
@@ -5,7 +5,7 @@ use crate::pipeline::errors::PipelineError::InvalidValue;
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Avg;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use dozer_types::arrow::datatypes::ArrowNativeTypeOp;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;

--- a/dozer-sql/src/pipeline/aggregation/max.rs
+++ b/dozer-sql/src/pipeline/aggregation/max.rs
@@ -2,7 +2,7 @@ use crate::pipeline::aggregation::aggregator::{update_map, Aggregator};
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Max;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::{argv, calculate_err, calculate_err_field};
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::types::{Field, FieldType, Schema, SourceDefinition};

--- a/dozer-sql/src/pipeline/aggregation/max_value.rs
+++ b/dozer-sql/src/pipeline/aggregation/max_value.rs
@@ -2,7 +2,7 @@ use crate::pipeline::aggregation::aggregator::{update_val_map, Aggregator};
 use crate::pipeline::errors::PipelineError::InvalidReturnType;
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::aggregate::AggregateFunctionType::MaxValue;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::{argv, calculate_err};
 use dozer_types::types::{Field, FieldType, Schema, SourceDefinition};
 use std::collections::BTreeMap;

--- a/dozer-sql/src/pipeline/aggregation/min.rs
+++ b/dozer-sql/src/pipeline/aggregation/min.rs
@@ -2,7 +2,7 @@ use crate::pipeline::aggregation::aggregator::{update_map, Aggregator};
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Min;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::{argv, calculate_err, calculate_err_field};
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::types::{Field, FieldType, Schema, SourceDefinition};

--- a/dozer-sql/src/pipeline/aggregation/min_value.rs
+++ b/dozer-sql/src/pipeline/aggregation/min_value.rs
@@ -2,7 +2,7 @@ use crate::pipeline::aggregation::aggregator::{update_val_map, Aggregator};
 use crate::pipeline::errors::PipelineError::InvalidReturnType;
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::aggregate::AggregateFunctionType::MinValue;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::{argv, calculate_err};
 use dozer_types::types::{Field, FieldType, Schema, SourceDefinition};
 use std::collections::BTreeMap;

--- a/dozer-sql/src/pipeline/aggregation/processor.rs
+++ b/dozer-sql/src/pipeline/aggregation/processor.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::pipeline::errors::PipelineError;
-use crate::pipeline::expression::execution::ExpressionExecutor;
 use crate::pipeline::{aggregation::aggregator::Aggregator, expression::execution::Expression};
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::executor_operation::ProcessorOperation;

--- a/dozer-sql/src/pipeline/aggregation/sum.rs
+++ b/dozer-sql/src/pipeline/aggregation/sum.rs
@@ -2,7 +2,7 @@ use crate::pipeline::aggregation::aggregator::Aggregator;
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::aggregate::AggregateFunctionType;
 use crate::pipeline::expression::aggregate::AggregateFunctionType::Sum;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::{argv, calculate_err_field};
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;

--- a/dozer-sql/src/pipeline/expression/arg_utils.rs
+++ b/dozer-sql/src/pipeline/expression/arg_utils.rs
@@ -1,6 +1,6 @@
 use crate::pipeline::errors::PipelineError::InvalidFunctionArgumentType;
 use crate::pipeline::errors::{FieldTypes, PipelineError};
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::pipeline::expression::scalar::common::ScalarFunctionType;
 use dozer_types::types::{FieldType, Schema};
 

--- a/dozer-sql/src/pipeline/expression/case.rs
+++ b/dozer-sql/src/pipeline/expression/case.rs
@@ -1,5 +1,5 @@
 use crate::pipeline::errors::PipelineError;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::types::{Field, Schema};
 use std::iter::zip;

--- a/dozer-sql/src/pipeline/expression/cast.rs
+++ b/dozer-sql/src/pipeline/expression/cast.rs
@@ -8,7 +8,7 @@ use dozer_types::{
 
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 
-use super::execution::{Expression, ExpressionExecutor, ExpressionType};
+use super::execution::{Expression, ExpressionType};
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]

--- a/dozer-sql/src/pipeline/expression/comparison.rs
+++ b/dozer-sql/src/pipeline/expression/comparison.rs
@@ -625,7 +625,7 @@ macro_rules! define_comparison {
     };
 }
 
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 
 pub fn evaluate_lt(
     schema: &Schema,

--- a/dozer-sql/src/pipeline/expression/conditional.rs
+++ b/dozer-sql/src/pipeline/expression/conditional.rs
@@ -2,7 +2,7 @@ use crate::pipeline::errors::PipelineError::{
     InvalidConditionalExpression, InvalidFunction, NotEnoughArguments,
 };
 use crate::pipeline::errors::{FieldTypes, PipelineError};
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::types::{Field, FieldType, Schema};
 use std::fmt::{Display, Formatter};

--- a/dozer-sql/src/pipeline/expression/datetime.rs
+++ b/dozer-sql/src/pipeline/expression/datetime.rs
@@ -3,7 +3,7 @@ use crate::pipeline::errors::PipelineError::{
 };
 use crate::pipeline::errors::{FieldTypes, PipelineError};
 use crate::pipeline::expression::datetime::PipelineError::InvalidValue;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::chrono::{DateTime, Datelike, FixedOffset, Offset, Timelike, Utc};

--- a/dozer-sql/src/pipeline/expression/execution.rs
+++ b/dozer-sql/src/pipeline/expression/execution.rs
@@ -297,15 +297,12 @@ impl ExpressionType {
     }
 }
 
-impl Expression {}
-
-pub trait ExpressionExecutor: Send + Sync {
-    fn evaluate(&self, record: &ProcessorRecord, schema: &Schema) -> Result<Field, PipelineError>;
-    fn get_type(&self, schema: &Schema) -> Result<ExpressionType, PipelineError>;
-}
-
-impl ExpressionExecutor for Expression {
-    fn evaluate(&self, record: &ProcessorRecord, schema: &Schema) -> Result<Field, PipelineError> {
+impl Expression {
+    pub fn evaluate(
+        &self,
+        record: &ProcessorRecord,
+        schema: &Schema,
+    ) -> Result<Field, PipelineError> {
         match self {
             Expression::Literal(field) => Ok(field.clone()),
             Expression::Column { index } => Ok(record.get_field_by_index(*index as u32).clone()),
@@ -358,7 +355,7 @@ impl ExpressionExecutor for Expression {
         }
     }
 
-    fn get_type(&self, schema: &Schema) -> Result<ExpressionType, PipelineError> {
+    pub fn get_type(&self, schema: &Schema) -> Result<ExpressionType, PipelineError> {
         match self {
             Expression::Literal(field) => {
                 let field_type = get_field_type(field);

--- a/dozer-sql/src/pipeline/expression/geo/distance.rs
+++ b/dozer-sql/src/pipeline/expression/geo/distance.rs
@@ -9,7 +9,7 @@ use crate::{arg_point, arg_str};
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::types::{Field, FieldType, Schema};
 
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::pipeline::expression::geo::common::GeoFunctionType;
 use dozer_types::geo::GeodesicDistance;
 use dozer_types::geo::HaversineDistance;

--- a/dozer-sql/src/pipeline/expression/geo/point.rs
+++ b/dozer-sql/src/pipeline/expression/geo/point.rs
@@ -6,7 +6,7 @@ use crate::pipeline::errors::{FieldTypes, PipelineError};
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::types::{DozerPoint, Field, FieldType, Schema};
 
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::pipeline::expression::geo::common::GeoFunctionType;
 
 pub(crate) fn validate_point(

--- a/dozer-sql/src/pipeline/expression/in_list.rs
+++ b/dozer-sql/src/pipeline/expression/in_list.rs
@@ -2,7 +2,7 @@ use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::types::{Field, Schema};
 
 use crate::pipeline::errors::PipelineError;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 
 pub(crate) fn evaluate_in_list(
     schema: &Schema,

--- a/dozer-sql/src/pipeline/expression/json_functions.rs
+++ b/dozer-sql/src/pipeline/expression/json_functions.rs
@@ -2,7 +2,7 @@ use crate::pipeline::errors::PipelineError;
 use crate::pipeline::errors::PipelineError::{
     InvalidArgument, InvalidFunction, InvalidFunctionArgument, InvalidValue,
 };
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 
 use crate::jsonpath::{JsonPathFinder, JsonPathInst};
 use dozer_core::processor_record::ProcessorRecord;

--- a/dozer-sql/src/pipeline/expression/logical.rs
+++ b/dozer-sql/src/pipeline/expression/logical.rs
@@ -1,5 +1,5 @@
 use crate::pipeline::errors::PipelineError;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::types::{Field, Schema};
 

--- a/dozer-sql/src/pipeline/expression/mathematical.rs
+++ b/dozer-sql/src/pipeline/expression/mathematical.rs
@@ -1,7 +1,7 @@
 use crate::pipeline::errors::OperationError;
 use crate::pipeline::errors::PipelineError;
 use crate::pipeline::errors::SqlError::Operation;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::rust_decimal::Decimal;
 use dozer_types::types::Schema;

--- a/dozer-sql/src/pipeline/expression/python_udf.rs
+++ b/dozer-sql/src/pipeline/expression/python_udf.rs
@@ -1,7 +1,7 @@
 use crate::pipeline::errors::PipelineError;
 use crate::pipeline::errors::PipelineError::UnsupportedSqlError;
 use crate::pipeline::errors::UnsupportedSqlError::GenericError;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::pyo3::types::PyTuple;

--- a/dozer-sql/src/pipeline/expression/scalar/common.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/common.rs
@@ -1,6 +1,6 @@
 use crate::argv;
 use crate::pipeline::errors::PipelineError;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 use crate::pipeline::expression::scalar::number::{evaluate_abs, evaluate_round};
 use crate::pipeline::expression::scalar::string::{
     evaluate_concat, evaluate_length, evaluate_to_char, evaluate_ucase, validate_concat,

--- a/dozer-sql/src/pipeline/expression/scalar/number.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/number.rs
@@ -1,6 +1,6 @@
 use crate::pipeline::errors::PipelineError;
 use crate::pipeline::errors::PipelineError::InvalidFunctionArgument;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use crate::pipeline::expression::scalar::common::ScalarFunctionType;
 use dozer_core::processor_record::ProcessorRecord;
 use dozer_types::ordered_float::OrderedFloat;

--- a/dozer-sql/src/pipeline/expression/scalar/string.rs
+++ b/dozer-sql/src/pipeline/expression/scalar/string.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 
 use crate::pipeline::errors::PipelineError;
 
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor, ExpressionType};
+use crate::pipeline::expression::execution::{Expression, ExpressionType};
 
 use crate::pipeline::expression::arg_utils::validate_arg_type;
 use crate::pipeline::expression::scalar::common::ScalarFunctionType;

--- a/dozer-sql/src/pipeline/expression/tests/execution.rs
+++ b/dozer-sql/src/pipeline/expression/tests/execution.rs
@@ -1,5 +1,5 @@
 use crate::pipeline::builder::SchemaSQLContext;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use crate::pipeline::expression::mathematical::evaluate_sub;
 use crate::pipeline::expression::operator::{BinaryOperatorType, UnaryOperatorType};
 use crate::pipeline::expression::scalar::common::ScalarFunctionType;

--- a/dozer-sql/src/pipeline/planner/projection.rs
+++ b/dozer-sql/src/pipeline/planner/projection.rs
@@ -2,7 +2,7 @@
 
 use crate::pipeline::errors::PipelineError;
 use crate::pipeline::expression::builder::ExpressionBuilder;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use crate::pipeline::pipeline_builder::from_builder::string_from_sql_object_name;
 use dozer_types::types::{FieldDefinition, Schema};
 use sqlparser::ast::{Expr, Ident, Select, SelectItem};

--- a/dozer-sql/src/pipeline/projection/factory.rs
+++ b/dozer-sql/src/pipeline/projection/factory.rs
@@ -13,9 +13,7 @@ use sqlparser::ast::{Expr, Ident, SelectItem};
 use crate::pipeline::builder::SchemaSQLContext;
 use crate::pipeline::{
     errors::PipelineError,
-    expression::{
-        builder::ExpressionBuilder, execution::Expression, execution::ExpressionExecutor,
-    },
+    expression::{builder::ExpressionBuilder, execution::Expression},
 };
 
 use super::processor::ProjectionProcessor;

--- a/dozer-sql/src/pipeline/projection/processor.rs
+++ b/dozer-sql/src/pipeline/projection/processor.rs
@@ -1,5 +1,5 @@
 use crate::pipeline::errors::PipelineError;
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::epoch::Epoch;

--- a/dozer-sql/src/pipeline/selection/processor.rs
+++ b/dozer-sql/src/pipeline/selection/processor.rs
@@ -1,4 +1,4 @@
-use crate::pipeline::expression::execution::{Expression, ExpressionExecutor};
+use crate::pipeline::expression::execution::Expression;
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::epoch::Epoch;
 use dozer_core::executor_operation::ProcessorOperation;

--- a/dozer-sql/src/pipeline/table_operator/lifetime.rs
+++ b/dozer-sql/src/pipeline/table_operator/lifetime.rs
@@ -1,10 +1,7 @@
 use dozer_core::processor_record::{ProcessorRecord, ProcessorRecordRef};
 use dozer_types::types::{DozerDuration, Lifetime, Schema};
 
-use crate::pipeline::{
-    errors::TableOperatorError,
-    expression::execution::{Expression, ExpressionExecutor},
-};
+use crate::pipeline::{errors::TableOperatorError, expression::execution::Expression};
 
 use super::operator::{TableOperator, TableOperatorType};
 


### PR DESCRIPTION
It's only implemented by `Expression`