### PR TITLE
feat: Allow to use client properties in login command

### DIFF
--- a/dozer-cli/src/cli/cloud.rs
+++ b/dozer-cli/src/cli/cloud.rs
@@ -26,6 +26,15 @@ pub enum CloudCommands {
     Login {
         #[arg(long = "organisation_slug")]
         organisation_slug: Option<String>,
+
+        #[arg(global = true, long = "profile_name")]
+        profile_name: Option<String>,
+
+        #[arg(global = true, long = "client_id")]
+        client_id: Option<String>,
+
+        #[arg(global = true, long = "client_secret")]
+        client_secret: Option<String>,
     },
     /// Deploy application to Dozer Cloud
     Deploy(DeployCommandArgs),

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -44,6 +44,9 @@ pub trait CloudOrchestrator {
         &mut self,
         cloud: Cloud,
         organisation_slug: Option<String>,
+        profile: Option<String>,
+        client_id: Option<String>,
+        client_secret: Option<String>,
     ) -> Result<(), OrchestrationError>;
     fn execute_secrets_command(
         &mut self,

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -181,9 +181,18 @@ fn run() -> Result<(), OrchestrationError> {
                 match cloud.command.clone() {
                     CloudCommands::Deploy(deploy) => dozer.deploy(cloud, deploy, cli.config_paths),
                     CloudCommands::Api(api) => dozer.api(cloud, api),
-                    CloudCommands::Login { organisation_slug } => {
-                        dozer.login(cloud, organisation_slug)
-                    }
+                    CloudCommands::Login {
+                        organisation_slug,
+                        profile_name,
+                        client_id,
+                        client_secret,
+                    } => dozer.login(
+                        cloud,
+                        organisation_slug,
+                        profile_name,
+                        client_id,
+                        client_secret,
+                    ),
                     CloudCommands::Secrets(command) => {
                         dozer.execute_secrets_command(cloud, command)
                     }

--- a/dozer-cli/src/simple/cloud_orchestrator.rs
+++ b/dozer-cli/src/simple/cloud_orchestrator.rs
@@ -356,6 +356,9 @@ impl CloudOrchestrator for SimpleOrchestrator {
         &mut self,
         cloud: Cloud,
         organisation_slug: Option<String>,
+        profile: Option<String>,
+        client_id: Option<String>,
+        client_secret: Option<String>,
     ) -> Result<(), OrchestrationError> {
         info!("Organisation and client details can be created in https://dashboard.dev.getdozer.io/login \n");
         let organisation_slug = match organisation_slug {
@@ -378,7 +381,7 @@ impl CloudOrchestrator for SimpleOrchestrator {
                     .unwrap_or(DEFAULT_CLOUD_TARGET_URL.to_string()),
             )
             .await?;
-            login_svc.login().await?;
+            login_svc.login(profile, client_id, client_secret).await?;
             Ok::<(), CloudLoginError>(())
         })?;
         Ok(())

--- a/dozer-tracing/src/telemetry.rs
+++ b/dozer-tracing/src/telemetry.rs
@@ -101,6 +101,7 @@ where
         + dozer_types::tracing::Subscriber,
 {
     global::set_text_map_propagator(TraceContextPropagator::new());
+
     let tracer = opentelemetry_jaeger::new_agent_pipeline()
         .with_service_name(app_name)
         .install_simple()


### PR DESCRIPTION
These changes allow to use login without questions
```
dozer cloud login --organisation-name {name} --profile-name {profile_name} --client-id {client_id} --client-secret {client_secret}
```