### PR TITLE
feat: Introduce MySQL Connector

### DIFF
--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -45,6 +45,10 @@ tokio-postgres-rustls = "0.10.0"
 rustls-native-certs = "0.6.2"
 rand = "0.8.5"
 url = "2.4.0"
+mysql_async = { version = "0.32.2", default-features = false, features = ["default-rustls"] }
+mysql_common = { version = "0.30", default-features = false, features = ["chrono", "rust_decimal"] }
+chrono = "0.4.26"
+geozero = { version = "0.10.0", default-features = false, features = ["with-wkb"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/dozer-ingestion/src/connectors/mod.rs
+++ b/dozer-ingestion/src/connectors/mod.rs
@@ -3,6 +3,7 @@ pub mod ethereum;
 pub mod grpc;
 #[cfg(feature = "kafka")]
 pub mod kafka;
+pub mod mysql;
 pub mod object_store;
 pub mod postgres;
 
@@ -43,6 +44,7 @@ use self::ethereum::{EthLogConnector, EthTraceConnector};
 
 use self::grpc::connector::GrpcConnector;
 use self::grpc::{ArrowAdapter, DefaultAdapter};
+use self::mysql::connector::{mysql_connection_opts_from_url, MySQLConnector};
 use crate::connectors::snowflake::connector::SnowflakeConnector;
 use crate::errors::ConnectorError::{MissingConfiguration, WrongConnectionConfiguration};
 
@@ -238,6 +240,14 @@ pub fn get_connector(connection: Connection) -> Result<Box<dyn Connector>, Conne
         }
         #[cfg(not(feature = "mongodb"))]
         ConnectionConfig::MongoDB(_) => Err(ConnectorError::MongodbFeatureNotEnabled),
+        ConnectionConfig::MySQL(mysql_config) => {
+            let opts = mysql_connection_opts_from_url(&mysql_config.url)?;
+            Ok(Box::new(MySQLConnector::new(
+                mysql_config.url,
+                opts,
+                mysql_config.server_id,
+            )))
+        }
     }
 }
 

--- a/dozer-ingestion/src/connectors/mysql/binlog.rs
+++ b/dozer-ingestion/src/connectors/mysql/binlog.rs
@@ -1,0 +1,657 @@
+use super::{
+    conversion::{IntoField, IntoFields, IntoJsonValue},
+    schema::{ColumnDefinition, TableDefinition},
+};
+use crate::{
+    errors::{ConnectorError, MySQLConnectorError},
+    ingestion::Ingestor,
+};
+use dozer_types::{
+    ingestion_types::IngestionMessage,
+    log::trace,
+    types::{FieldType, Operation, Record},
+};
+use dozer_types::{json_types::JsonValue, types::Field};
+use futures::StreamExt;
+use mysql_async::{prelude::Queryable, BinlogStream, Conn, Pool};
+use mysql_common::{
+    binlog::{
+        self,
+        events::{RowsEventRows, TableMapEvent},
+        jsonb::{Array, ComplexValue, Object, StorageFormat},
+        row::BinlogRow,
+        value::BinlogValue,
+    },
+    Row,
+};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+#[derive(Debug, Clone)]
+pub struct BinlogPosition {
+    pub filename: Vec<u8>,
+    pub position: u64,
+}
+
+pub async fn get_master_binlog_position(
+    conn: &mut Conn,
+) -> Result<BinlogPosition, MySQLConnectorError> {
+    let (filename, position) = {
+        let mut row: Row = conn
+            .exec_first("SHOW MASTER STATUS", ())
+            .await
+            .map_err(MySQLConnectorError::QueryExecutionError)?
+            .unwrap();
+        (row.take(0).unwrap(), row.take(1).unwrap())
+    };
+
+    Ok(BinlogPosition { filename, position })
+}
+
+pub async fn get_binlog_format(conn: &mut Conn) -> Result<String, MySQLConnectorError> {
+    let mut row: Row = conn
+        .exec_first("SELECT @@binlog_format", ())
+        .await
+        .map_err(MySQLConnectorError::QueryExecutionError)?
+        .unwrap();
+    let binlog_logging_format = row.take(0).unwrap();
+    Ok(binlog_logging_format)
+}
+
+pub struct BinlogIngestor<'a, 'b, 'c, 'd, 'e> {
+    ingestor: &'a Ingestor,
+    binlog_stream: Option<BinlogStream>,
+    tables: &'b [TableDefinition],
+    next_position: BinlogPosition,
+    stop_position: Option<BinlogPosition>,
+    local_stop_position: Option<u64>,
+    server_id: u32,
+    txn: &'c mut u64,
+    conn_pool: &'d Pool,
+    conn_url: &'e String,
+    column_definitions_cache: ColumnDefinitionsCache<'b>,
+}
+
+impl<'a, 'b, 'c, 'd, 'e> BinlogIngestor<'a, 'b, 'c, 'd, 'e> {
+    pub fn new(
+        ingestor: &'a Ingestor,
+        tables: &'b [TableDefinition],
+        start_position: BinlogPosition,
+        stop_position: Option<BinlogPosition>,
+        server_id: u32,
+        txn: &'c mut u64,
+        (conn_pool, conn_url): (&'d Pool, &'e String),
+    ) -> Self {
+        Self {
+            ingestor,
+            binlog_stream: None,
+            tables,
+            next_position: start_position,
+            stop_position,
+            local_stop_position: None,
+            server_id,
+            txn,
+            conn_pool,
+            conn_url,
+            column_definitions_cache: ColumnDefinitionsCache::new(tables),
+        }
+    }
+}
+
+impl BinlogIngestor<'_, '_, '_, '_, '_> {
+    async fn connect(&self) -> Result<Conn, MySQLConnectorError> {
+        self.conn_pool
+            .get_conn()
+            .await
+            .map_err(|err| MySQLConnectorError::ConnectionFailure(self.conn_url.clone(), err))
+    }
+
+    async fn open_binlog(&mut self) -> Result<(), MySQLConnectorError> {
+        let binlog_stream = self
+            .connect()
+            .await?
+            .get_binlog_stream(
+                mysql_async::BinlogRequest::new(self.server_id)
+                    .with_filename(self.next_position.filename.as_slice())
+                    .with_pos(self.next_position.position),
+            )
+            .await
+            .map_err(MySQLConnectorError::BinlogOpenError)?;
+
+        self.binlog_stream = Some(binlog_stream);
+
+        self.local_stop_position = self.stop_position.as_ref().and_then(|stop_position| {
+            if self.next_position.filename == stop_position.filename {
+                Some(stop_position.position)
+            } else {
+                None
+            }
+        });
+
+        Ok(())
+    }
+
+    pub async fn ingest(&mut self) -> Result<(), ConnectorError> {
+        if self.binlog_stream.is_none() {
+            self.open_binlog().await?;
+        }
+
+        let mut seq_no = 0;
+        let mut table_cache = BinlogTableCache::new(self.tables);
+
+        'binlog_read: while let Some(event) = self.binlog_stream.as_mut().unwrap().next().await {
+            let binlog_event = event.map_err(MySQLConnectorError::BinlogReadError)?;
+
+            self.next_position.position = binlog_event.header().log_pos().into();
+
+            let event_type = match binlog_event.header().event_type() {
+                Ok(event_type) => event_type,
+                _ => {
+                    continue;
+                }
+            };
+
+            use mysql_common::binlog::{consts::EventType::*, events::EventData::*};
+            match event_type {
+                ROTATE_EVENT => {
+                    let rotate_event =
+                        match binlog_event.read_data().map_err(binlog_io_error)?.unwrap() {
+                            RotateEvent(rotate_event) => rotate_event,
+                            _ => unreachable!(),
+                        };
+
+                    if rotate_event.name_raw() != self.next_position.filename.as_slice() {
+                        self.next_position = BinlogPosition {
+                            filename: rotate_event.name_raw().into(),
+                            position: rotate_event.position(),
+                        };
+
+                        self.open_binlog().await?;
+                    }
+
+                    table_cache.binlog_rotate();
+                }
+
+                QUERY_EVENT => {
+                    let query_event =
+                        match binlog_event.read_data().map_err(binlog_io_error)?.unwrap() {
+                            QueryEvent(query_event) => query_event,
+                            _ => unreachable!(),
+                        };
+
+                    if query_event.query_raw() == b"BEGIN" {
+                        self.ingestor
+                            .handle_message(IngestionMessage::new_snapshotting_started(
+                                *self.txn, seq_no,
+                            ))
+                            .map_err(ConnectorError::IngestorError)?;
+                    }
+                }
+
+                XID_EVENT => {
+                    self.ingestor
+                        .handle_message(IngestionMessage::new_snapshotting_done(*self.txn, seq_no))
+                        .map_err(ConnectorError::IngestorError)?;
+
+                    *self.txn += 1;
+                    seq_no = 0;
+                }
+
+                WRITE_ROWS_EVENT | UPDATE_ROWS_EVENT | DELETE_ROWS_EVENT | WRITE_ROWS_EVENT_V1
+                | UPDATE_ROWS_EVENT_V1 | DELETE_ROWS_EVENT_V1 => {
+                    let event_data =
+                        match binlog_event.read_data().map_err(binlog_io_error)?.unwrap() {
+                            RowsEvent(event_data) => event_data,
+                            _ => unreachable!(),
+                        };
+
+                    let rows_event = BinlogRowsEvent(event_data);
+
+                    let binlog_table_id = rows_event.table_id();
+
+                    let tme = self.get_tme(binlog_table_id)?;
+
+                    if let Some(table) = table_cache.get_corresponding_table(tme) {
+                        self.handle_rows_event(&rows_event, table, tme, &mut seq_no)?;
+                    }
+                }
+
+                event_type => {
+                    trace!("other binlog event {event_type:?}");
+                }
+            }
+
+            match self.local_stop_position {
+                Some(stop_position) if self.next_position.position >= stop_position => {
+                    break 'binlog_read;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_rows_event(
+        &self,
+        rows_event: &BinlogRowsEvent<'_>,
+        table: &TableDefinition,
+        tme: &TableMapEvent,
+        seq_no: &mut u64,
+    ) -> Result<(), ConnectorError> {
+        for op in self.make_rows_operations(rows_event, table, tme) {
+            self.ingestor
+                .handle_message(IngestionMessage::new_op(
+                    *self.txn,
+                    *seq_no,
+                    table.table_index,
+                    op?,
+                ))
+                .map_err(ConnectorError::IngestorError)?;
+        }
+        *seq_no += 1;
+
+        Ok(())
+    }
+
+    fn get_tme(&self, binlog_table_id: u64) -> Result<&TableMapEvent<'_>, MySQLConnectorError> {
+        self.binlog_stream
+            .as_ref()
+            .unwrap()
+            .get_tme(binlog_table_id)
+            .ok_or_else(|| {
+                MySQLConnectorError::BinlogError(format!(
+                    "Missing table-map-event for table_id: {binlog_table_id}"
+                ))
+            })
+    }
+
+    // Select the intersection between the columns present in the row and the columns in the table.
+    //
+    // Returns the index and field type of each selected column.
+    //
+    // # Parameters
+    // - `row_columns`: The zero-based indexes of columns present in the binlog row.
+    // - `table_definition`: The table definition.
+    fn select_columns(
+        &self,
+        row_columns: Vec<usize>,
+        table_definition: &TableDefinition,
+    ) -> Vec<(usize, &FieldType)> {
+        let table_columns = self
+            .column_definitions_cache
+            .get_columns_of_table(table_definition.table_index)
+            .unwrap();
+        let columns = row_columns
+            .iter()
+            .enumerate()
+            .filter_map(|(i, col)| table_columns.get(col).map(|cd| (i, &cd.typ)))
+            .collect::<Vec<_>>();
+
+        columns
+    }
+
+    fn rows_iter<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
+        &'a self,
+        rows_event: &'b BinlogRowsEvent<'_>,
+        table: &'c TableDefinition,
+        tme: &'d TableMapEvent,
+    ) -> impl Iterator<Item = Result<RowValues, MySQLConnectorError>> + 'r {
+        let rows = rows_event.rows(tme);
+        let selected_columns = (
+            rows_event
+                .columns_before_image()
+                .map(|rows| self.select_columns(rows.collect(), table)),
+            rows_event
+                .columns_after_image()
+                .map(|rows| self.select_columns(rows.collect(), table)),
+        );
+
+        rows.map(move |row| -> Result<RowValues, MySQLConnectorError> {
+            fn into_fields(
+                row: Option<BinlogRow>,
+                selected_columns: Option<&Vec<(usize, &FieldType)>>,
+            ) -> Result<Option<Vec<Field>>, MySQLConnectorError> {
+                let value = if let Some(row) = row {
+                    Some(row.into_fields(selected_columns.unwrap())?)
+                } else {
+                    None
+                };
+                Ok(value)
+            }
+
+            let row = row.map_err(binlog_io_error)?;
+
+            let old_values = into_fields(row.0, selected_columns.0.as_ref())?;
+            let new_values = into_fields(row.1, selected_columns.1.as_ref())?;
+
+            Ok(RowValues {
+                old_values,
+                new_values,
+            })
+        })
+    }
+
+    fn make_rows_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
+        &'a self,
+        rows_event: &'b BinlogRowsEvent<'_>,
+        table: &'c TableDefinition,
+        tme: &'d TableMapEvent,
+    ) -> Box<dyn Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r> {
+        if rows_event.is_write() {
+            Box::new(self.make_insert_operations(rows_event, table, tme))
+        } else if rows_event.is_update() {
+            Box::new(self.make_update_operations(rows_event, table, tme))
+        } else if rows_event.is_delete() {
+            Box::new(self.make_delete_operations(rows_event, table, tme))
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn make_insert_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
+        &'a self,
+        rows_event: &'b BinlogRowsEvent<'_>,
+        table: &'c TableDefinition,
+        tme: &'d TableMapEvent,
+    ) -> impl Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r {
+        self.rows_iter(rows_event, table, tme).map(|row| {
+            let RowValues { new_values, .. } = row?;
+
+            let op: Operation = Operation::Insert {
+                new: Record::new(new_values.unwrap()),
+            };
+
+            Ok(op)
+        })
+    }
+
+    fn make_update_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
+        &'a self,
+        rows_event: &'b BinlogRowsEvent<'_>,
+        table: &'c TableDefinition,
+        tme: &'d TableMapEvent,
+    ) -> impl Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r {
+        self.rows_iter(rows_event, table, tme).map(|row| {
+            let RowValues {
+                old_values,
+                new_values,
+            } = row?;
+
+            let op: Operation = Operation::Update {
+                old: Record::new(old_values.unwrap()),
+                new: Record::new(new_values.unwrap()),
+            };
+
+            Ok(op)
+        })
+    }
+
+    fn make_delete_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
+        &'a self,
+        rows_event: &'b BinlogRowsEvent<'_>,
+        table: &'c TableDefinition,
+        tme: &'d TableMapEvent,
+    ) -> impl Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r {
+        self.rows_iter(rows_event, table, tme).map(|row| {
+            let RowValues { old_values, .. } = row?;
+
+            let op: Operation = Operation::Delete {
+                old: Record::new(old_values.unwrap()),
+            };
+
+            Ok(op)
+        })
+    }
+}
+
+struct RowValues {
+    pub old_values: Option<Vec<Field>>, // present in Update and Delete operations
+    pub new_values: Option<Vec<Field>>, // present in Update and Insert operations
+}
+
+struct ColumnDefinitionsCache<'a> {
+    cache: Vec<HashMap<usize, &'a ColumnDefinition>>,
+}
+
+impl<'a> ColumnDefinitionsCache<'a> {
+    pub fn new(table_definitions: &'a [TableDefinition]) -> Self {
+        Self {
+            cache: table_definitions
+                .iter()
+                .map(|td| {
+                    td.columns
+                        .iter()
+                        .map(|c| ((c.ordinal_position - 1) as usize, c))
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+
+    pub fn get_columns_of_table(
+        &self,
+        table_index: usize,
+    ) -> Option<&HashMap<usize, &ColumnDefinition>> {
+        self.cache.get(table_index)
+    }
+}
+
+pub fn binlog_io_error(err: std::io::Error) -> MySQLConnectorError {
+    MySQLConnectorError::BinlogReadError(mysql_async::Error::Io(mysql_async::IoError::Io(err)))
+}
+
+impl<'a> IntoFields<'a> for BinlogRow {
+    type Ctx = &'a [(usize, &'a FieldType)];
+
+    fn into_fields(
+        self,
+        selected_columns: &[(usize, &FieldType)],
+    ) -> Result<Vec<Field>, MySQLConnectorError> {
+        let mut binlog_row = self;
+        let mut fields = Vec::new();
+        for (i, field_type) in selected_columns.iter().copied() {
+            let value = binlog_row.take(i);
+            fields.push(value.into_field(field_type)?);
+        }
+        Ok(fields)
+    }
+}
+
+impl<'a, 'b> IntoField<'a> for Option<BinlogValue<'b>> {
+    type Ctx = &'a FieldType;
+
+    fn into_field(self, field_type: &FieldType) -> Result<Field, MySQLConnectorError> {
+        let binlog_value = self;
+
+        if binlog_value.is_none() {
+            return Ok(Field::Null);
+        }
+
+        let field = match binlog_value.unwrap() {
+            BinlogValue::Value(value) => value.into_field(field_type)?,
+            BinlogValue::Jsonb(value) => Field::Json(value.into_json_value()?),
+            BinlogValue::JsonDiff(_) => todo!(),
+        };
+
+        Ok(field)
+    }
+}
+
+impl<'a> IntoJsonValue for binlog::jsonb::Value<'a> {
+    fn into_json_value(self) -> Result<JsonValue, MySQLConnectorError> {
+        use binlog::jsonb::Value::*;
+        let json_value = match self {
+            Null => JsonValue::Null,
+            Bool(v) => JsonValue::Bool(v),
+            I16(v) => JsonValue::Number((v as f64).into()),
+            U16(v) => JsonValue::Number((v as f64).into()),
+            I32(v) => JsonValue::Number((v as f64).into()),
+            U32(v) => JsonValue::Number((v as f64).into()),
+            I64(v) => JsonValue::Number((v as f64).into()),
+            U64(v) => JsonValue::Number((v as f64).into()),
+            F64(v) => JsonValue::Number(v.into()),
+            String(v) => JsonValue::String(v.str().into_owned()),
+            SmallArray(v) => v.into_json_value()?,
+            LargeArray(v) => v.into_json_value()?,
+            SmallObject(v) => v.into_json_value()?,
+            LargeObject(v) => v.into_json_value()?,
+            Opaque(v) => JsonValue::Object({
+                let mut map = BTreeMap::new();
+                map.insert(
+                    "value_type".into(),
+                    JsonValue::from(u8::from(v.value_type()) as usize),
+                );
+                map.insert("data".into(), JsonValue::from(v.data()));
+                map
+            }),
+        };
+
+        Ok(json_value)
+    }
+}
+
+impl<'a, T: StorageFormat> IntoJsonValue for ComplexValue<'a, T, Array> {
+    fn into_json_value(self) -> Result<JsonValue, MySQLConnectorError> {
+        Ok(JsonValue::Array({
+            let mut vec = Vec::new();
+            for value in self.iter() {
+                vec.push(value.map_err(binlog_io_error)?.into_json_value()?);
+            }
+            vec
+        }))
+    }
+}
+
+impl<'a, T: StorageFormat> IntoJsonValue for ComplexValue<'a, T, Object> {
+    fn into_json_value(self) -> Result<JsonValue, MySQLConnectorError> {
+        Ok(JsonValue::Object({
+            let mut map = BTreeMap::new();
+            for entry in self.iter() {
+                let (key, value) = entry.map_err(binlog_io_error)?;
+                map.insert(key.value().into_owned(), value.into_json_value()?);
+            }
+            map
+        }))
+    }
+}
+
+pub struct BinlogTableCache<'a> {
+    tables: &'a [TableDefinition],
+    binlog_table_id_to_table_map: HashMap<u64, &'a TableDefinition>,
+    known_missing: HashSet<u64>,
+}
+
+impl BinlogTableCache<'_> {
+    pub fn new(tables: &[TableDefinition]) -> BinlogTableCache<'_> {
+        BinlogTableCache {
+            tables,
+            binlog_table_id_to_table_map: HashMap::new(),
+            known_missing: HashSet::new(),
+        }
+    }
+
+    pub fn binlog_rotate(&mut self) {
+        // binlog table ids are not guranteed to be consistent across binlog rotates
+        self.binlog_table_id_to_table_map.clear();
+        self.known_missing.clear();
+    }
+
+    pub fn get_corresponding_table(&mut self, tme: &TableMapEvent<'_>) -> Option<&TableDefinition> {
+        let binlog_table_id = tme.table_id();
+        if let Some(found) = self.binlog_table_id_to_table_map.get(&binlog_table_id) {
+            Some(found)
+        } else if self.known_missing.contains(&binlog_table_id) {
+            None
+        } else {
+            // see if we can find it
+            if let Some(value) = self.tables.iter().find(
+                |TableDefinition {
+                     table_name,
+                     database_name,
+                     ..
+                 }| {
+                    database_name.as_bytes() == tme.database_name_raw()
+                        && table_name.as_bytes() == tme.table_name_raw()
+                },
+            ) {
+                self.binlog_table_id_to_table_map
+                    .insert(binlog_table_id, value);
+                Some(value)
+            } else {
+                self.known_missing.insert(binlog_table_id);
+                None
+            }
+        }
+    }
+}
+
+struct BinlogRowsEvent<'a>(binlog::events::RowsEventData<'a>);
+
+macro_rules! rows_event_apply {
+    (
+        $event_data:expr,
+        event.$($op:tt)*
+    ) => {
+        {
+            use mysql_common::binlog::events::RowsEventData::*;
+            match $event_data {
+                WriteRowsEvent(event) => event.$($op)*,
+                UpdateRowsEvent(event) => event.$($op)*,
+                DeleteRowsEvent(event) => event.$($op)*,
+                WriteRowsEventV1(event) => event.$($op)*,
+                UpdateRowsEventV1(event) => event.$($op)*,
+                DeleteRowsEventV1(event) => event.$($op)*,
+                _ => unreachable!(),
+            }
+        }
+    };
+}
+
+impl<'a> BinlogRowsEvent<'a> {
+    pub fn table_id(&self) -> u64 {
+        rows_event_apply!(&self.0, event.table_id())
+    }
+
+    pub fn rows(&'a self, tme: &'a TableMapEvent<'a>) -> RowsEventRows<'a> {
+        rows_event_apply!(&self.0, event.rows(tme))
+    }
+
+    pub fn columns_before_image(&'a self) -> Option<impl Iterator<Item = usize> + 'a> {
+        use binlog::events::RowsEventData::*;
+        let value = match &self.0 {
+            UpdateRowsEventV1(event) => Some(event.columns_before_image()),
+            DeleteRowsEventV1(event) => Some(event.columns_before_image()),
+            UpdateRowsEvent(event) => Some(event.columns_before_image()),
+            DeleteRowsEvent(event) => Some(event.columns_before_image()),
+            _ => None,
+        };
+        value.map(|bitslice| bitslice.iter_ones())
+    }
+
+    pub fn columns_after_image(&'a self) -> Option<impl Iterator<Item = usize> + 'a> {
+        use binlog::events::RowsEventData::*;
+        let value = match &self.0 {
+            UpdateRowsEventV1(event) => Some(event.columns_after_image()),
+            WriteRowsEventV1(event) => Some(event.columns_after_image()),
+            UpdateRowsEvent(event) => Some(event.columns_after_image()),
+            WriteRowsEvent(event) => Some(event.columns_after_image()),
+            _ => None,
+        };
+        value.map(|bitslice| bitslice.iter_ones())
+    }
+
+    pub fn is_write(&self) -> bool {
+        use binlog::events::RowsEventData::*;
+        matches!(&self.0, WriteRowsEventV1(_) | WriteRowsEvent(_))
+    }
+
+    pub fn is_update(&self) -> bool {
+        use binlog::events::RowsEventData::*;
+        matches!(&self.0, UpdateRowsEventV1(_) | UpdateRowsEvent(_))
+    }
+
+    pub fn is_delete(&self) -> bool {
+        use binlog::events::RowsEventData::*;
+        matches!(&self.0, DeleteRowsEventV1(_) | DeleteRowsEvent(_))
+    }
+}

--- a/dozer-ingestion/src/connectors/mysql/connector.rs
+++ b/dozer-ingestion/src/connectors/mysql/connector.rs
@@ -1,0 +1,378 @@
+use super::{
+    binlog::{get_binlog_format, get_master_binlog_position, BinlogIngestor, BinlogPosition},
+    conversion::IntoFields,
+    helpers::{escape_identifier, qualify_table_name},
+    schema::{ColumnDefinition, SchemaHelper, TableDefinition},
+};
+use crate::{
+    connectors::{
+        CdcType, Connector, SourceSchema, SourceSchemaResult, TableIdentifier, TableInfo,
+    },
+    errors::MySQLConnectorError,
+};
+use crate::{errors::ConnectorError, ingestion::Ingestor};
+use dozer_types::{
+    ingestion_types::IngestionMessage,
+    types::{FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition},
+};
+use mysql_async::{prelude::Queryable, Conn, Opts, Pool};
+use tonic::async_trait;
+
+#[derive(Debug)]
+pub struct MySQLConnector {
+    conn_url: String,
+    conn_pool: Pool,
+    server_id: Option<u32>,
+}
+
+pub fn mysql_connection_opts_from_url(url: &str) -> Result<Opts, MySQLConnectorError> {
+    Opts::from_url(url).map_err(MySQLConnectorError::InvalidConnectionURLError)
+}
+
+impl MySQLConnector {
+    pub fn new(conn_url: String, opts: Opts, server_id: Option<u32>) -> MySQLConnector {
+        MySQLConnector {
+            conn_url,
+            conn_pool: Pool::new(opts),
+            server_id,
+        }
+    }
+}
+
+#[async_trait]
+impl Connector for MySQLConnector {
+    fn types_mapping() -> Vec<(String, Option<dozer_types::types::FieldType>)>
+    where
+        Self: Sized,
+    {
+        vec![
+            ("decimal".into(), Some(FieldType::Decimal)),
+            ("tinyint unsigned".into(), Some(FieldType::UInt)),
+            ("tinyint".into(), Some(FieldType::Int)),
+            ("smallint unsigned".into(), Some(FieldType::UInt)),
+            ("smallint".into(), Some(FieldType::Int)),
+            ("mediumint unsigned".into(), Some(FieldType::UInt)),
+            ("mediumint".into(), Some(FieldType::Int)),
+            ("int unsigned".into(), Some(FieldType::UInt)),
+            ("int".into(), Some(FieldType::Int)),
+            ("bigint unsigned".into(), Some(FieldType::UInt)),
+            ("bigint".into(), Some(FieldType::Int)),
+            ("float".into(), Some(FieldType::Float)),
+            ("double".into(), Some(FieldType::Float)),
+            ("timestamp".into(), Some(FieldType::Timestamp)),
+            ("time".into(), Some(FieldType::Duration)),
+            ("year".into(), Some(FieldType::Int)),
+            ("date".into(), Some(FieldType::Date)),
+            ("datetime".into(), Some(FieldType::Timestamp)),
+            ("varchar".into(), Some(FieldType::Text)),
+            ("varbinary".into(), Some(FieldType::Binary)),
+            ("char".into(), Some(FieldType::String)),
+            ("binary".into(), Some(FieldType::Binary)),
+            ("tinyblob".into(), Some(FieldType::Binary)),
+            ("blob".into(), Some(FieldType::Binary)),
+            ("mediumblob".into(), Some(FieldType::Binary)),
+            ("longblob".into(), Some(FieldType::Binary)),
+            ("tinytext".into(), Some(FieldType::Text)),
+            ("text".into(), Some(FieldType::Text)),
+            ("mediumtext".into(), Some(FieldType::Text)),
+            ("longtext".into(), Some(FieldType::Text)),
+            ("point".into(), Some(FieldType::Point)),
+            ("json".into(), Some(FieldType::Json)),
+            ("bit".into(), Some(FieldType::Int)),
+            ("enum".into(), Some(FieldType::String)),
+            ("set".into(), Some(FieldType::String)),
+            ("null".into(), None),
+            ("linestring".into(), None),
+            ("polygon".into(), None),
+            ("multipoint".into(), None),
+            ("multilinestring".into(), None),
+            ("multipolygon".into(), None),
+            ("geomcollection".into(), None),
+            ("geometry".into(), None),
+        ]
+    }
+
+    async fn validate_connection(&self) -> Result<(), ConnectorError> {
+        let _ = self.connect().await?;
+
+        Ok(())
+    }
+
+    async fn list_tables(&self) -> Result<Vec<TableIdentifier>, ConnectorError> {
+        let tables = self.schema_helper().list_tables().await?;
+        Ok(tables)
+    }
+
+    async fn validate_tables(&self, tables: &[TableIdentifier]) -> Result<(), ConnectorError> {
+        let existing_tables = self.list_tables().await?;
+        for table in tables {
+            if !existing_tables.contains(table) {
+                Err(ConnectorError::TableNotFound(qualify_table_name(
+                    table.schema.as_deref(),
+                    &table.name,
+                )))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn list_columns(
+        &self,
+        tables: Vec<TableIdentifier>,
+    ) -> Result<Vec<TableInfo>, ConnectorError> {
+        let tables_infos = self.schema_helper().list_columns(tables).await?;
+        Ok(tables_infos)
+    }
+
+    async fn get_schemas(
+        &self,
+        table_infos: &[TableInfo],
+    ) -> Result<Vec<SourceSchemaResult>, ConnectorError> {
+        if table_infos.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let table_definitions = self
+            .schema_helper()
+            .get_table_definitions(table_infos)
+            .await?;
+
+        let binlog_logging_format: String = get_binlog_format(&mut self.connect().await?).await?;
+        let cdc_type = if binlog_logging_format == "ROW" {
+            CdcType::FullChanges
+        } else {
+            CdcType::Nothing
+        };
+
+        let schemas = table_definitions
+            .into_iter()
+            .map(|TableDefinition { columns, .. }| {
+                let primary_index = columns
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, ColumnDefinition { primary_key, .. })| *primary_key)
+                    .map(|(i, _)| i)
+                    .collect();
+                Ok(SourceSchema {
+                    schema: Schema {
+                        fields: columns
+                            .into_iter()
+                            .map(
+                                |ColumnDefinition {
+                                     name,
+                                     typ,
+                                     nullable,
+                                     ..
+                                 }| {
+                                    FieldDefinition {
+                                        name,
+                                        typ,
+                                        nullable,
+                                        source: SourceDefinition::Dynamic,
+                                    }
+                                },
+                            )
+                            .collect(),
+                        primary_index,
+                    },
+                    cdc_type,
+                })
+            })
+            .collect();
+
+        Ok(schemas)
+    }
+
+    async fn start(
+        &self,
+        ingestor: &Ingestor,
+        tables: Vec<TableInfo>,
+    ) -> Result<(), ConnectorError> {
+        self.replicate(ingestor, tables).await.map_err(Into::into)
+    }
+}
+
+impl MySQLConnector {
+    async fn connect(&self) -> Result<Conn, MySQLConnectorError> {
+        self.conn_pool
+            .get_conn()
+            .await
+            .map_err(|err| MySQLConnectorError::ConnectionFailure(self.conn_url.clone(), err))
+    }
+
+    fn schema_helper(&self) -> SchemaHelper<'_, '_> {
+        SchemaHelper::new(&self.conn_url, &self.conn_pool)
+    }
+
+    async fn replicate(
+        &self,
+        ingestor: &Ingestor,
+        table_infos: Vec<TableInfo>,
+    ) -> Result<(), ConnectorError> {
+        let mut txn = 0;
+
+        let table_definitions = self
+            .schema_helper()
+            .get_table_definitions(&table_infos)
+            .await?;
+        let binlog_positions = self
+            .replicate_tables(ingestor, &table_definitions, &mut txn)
+            .await?;
+
+        let binlog_position = self
+            .sync_with_binlog(ingestor, binlog_positions, &mut txn)
+            .await?;
+
+        self.ingest_binlog(
+            ingestor,
+            &table_definitions,
+            binlog_position,
+            None,
+            &mut txn,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn replicate_tables(
+        &self,
+        ingestor: &Ingestor,
+        table_definitions: &[TableDefinition],
+        txn: &mut u64,
+    ) -> Result<Vec<(TableDefinition, BinlogPosition)>, ConnectorError> {
+        let mut binlog_position_per_table = Vec::new();
+
+        let mut conn = self.connect().await?;
+
+        for (table_index, td) in table_definitions.iter().enumerate() {
+            conn.query_drop(format!(
+                "LOCK TABLES {} READ",
+                qualify_table_name(Some(&td.database_name), &td.table_name)
+            ))
+            .await
+            .map_err(MySQLConnectorError::QueryExecutionError)?;
+
+            let mut seq_no = 0u64;
+
+            ingestor
+                .handle_message(IngestionMessage::new_snapshotting_started(*txn, seq_no))
+                .map_err(ConnectorError::IngestorError)?;
+
+            let mut rows = conn
+                .exec_iter(
+                    format!(
+                        "SELECT {} from {}",
+                        td.columns
+                            .iter()
+                            .map(|ColumnDefinition { name, .. }| escape_identifier(name))
+                            .collect::<Vec<String>>()
+                            .join(", "),
+                        qualify_table_name(Some(&td.database_name), &td.table_name)
+                    ),
+                    (),
+                )
+                .await
+                .map_err(MySQLConnectorError::QueryExecutionError)?;
+
+            let field_types: Vec<FieldType> = td
+                .columns
+                .iter()
+                .map(|ColumnDefinition { typ, .. }| *typ)
+                .collect();
+
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(MySQLConnectorError::QueryResultError)?
+            {
+                let op: Operation = Operation::Insert {
+                    new: Record::new(row.into_fields(&field_types)?),
+                };
+
+                seq_no += 1;
+                ingestor
+                    .handle_message(IngestionMessage::new_op(*txn, seq_no, table_index, op))
+                    .map_err(ConnectorError::IngestorError)?;
+            }
+
+            let binlog_position = get_master_binlog_position(&mut conn).await?;
+
+            conn.query_drop("UNLOCK TABLES")
+                .await
+                .map_err(MySQLConnectorError::QueryExecutionError)?;
+
+            seq_no += 1;
+            ingestor
+                .handle_message(IngestionMessage::new_snapshotting_done(*txn, seq_no))
+                .map_err(ConnectorError::IngestorError)?;
+
+            binlog_position_per_table.push((td.clone(), binlog_position));
+
+            *txn += 1;
+        }
+
+        Ok(binlog_position_per_table)
+    }
+
+    async fn sync_with_binlog(
+        &self,
+        ingestor: &Ingestor,
+        binlog_positions: Vec<(TableDefinition, BinlogPosition)>,
+        txn: &mut u64,
+    ) -> Result<BinlogPosition, ConnectorError> {
+        assert!(!binlog_positions.is_empty());
+
+        let position = {
+            let mut last_position = None;
+            let mut synced_tables = Vec::new();
+
+            for (table, position) in binlog_positions.into_iter() {
+                synced_tables.push(table);
+
+                if let Some(start_position) = last_position {
+                    let end_position = position.clone();
+
+                    self.ingest_binlog(
+                        ingestor,
+                        &synced_tables,
+                        start_position,
+                        Some(end_position),
+                        txn,
+                    )
+                    .await?;
+                }
+
+                last_position = Some(position);
+            }
+
+            last_position.unwrap()
+        };
+
+        Ok(position)
+    }
+
+    async fn ingest_binlog(
+        &self,
+        ingestor: &Ingestor,
+        tables: &[TableDefinition],
+        start_position: BinlogPosition,
+        stop_position: Option<BinlogPosition>,
+        txn: &mut u64,
+    ) -> Result<(), ConnectorError> {
+        let server_id = self.server_id.unwrap_or(0xd07e5);
+
+        let mut binlog_ingestor = BinlogIngestor::new(
+            ingestor,
+            tables,
+            start_position,
+            stop_position,
+            server_id,
+            txn,
+            (&self.conn_pool, &self.conn_url),
+        );
+
+        binlog_ingestor.ingest().await
+    }
+}

--- a/dozer-ingestion/src/connectors/mysql/conversion.rs
+++ b/dozer-ingestion/src/connectors/mysql/conversion.rs
@@ -1,0 +1,192 @@
+use crate::errors::MySQLConnectorError;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Offset, Utc};
+use dozer_types::{
+    json_types::{serde_json_to_json_value, JsonValue},
+    rust_decimal::Decimal,
+    serde_json,
+    types::{DozerDuration, DozerPoint, Field, FieldType, TimeUnit},
+};
+use geozero::{wkb, GeomProcessor};
+use mysql_common::{Row, Value};
+use std::time::Duration;
+
+pub fn get_field_type_for_mysql_column_type(
+    column_type: &str,
+) -> Result<FieldType, MySQLConnectorError> {
+    let data_type = {
+        let space = column_type.find(' ');
+        let parenthesis = column_type.find('(');
+        let end = {
+            let max = column_type.len();
+            std::cmp::min(space.unwrap_or(max), parenthesis.unwrap_or(max))
+        };
+        &column_type[0..end]
+    };
+    let is_array = column_type.ends_with(" array");
+    let is_unsigned = column_type.contains(" unsigned");
+
+    if is_array {
+        return Err(MySQLConnectorError::UnsupportedFieldType(data_type.into()));
+    }
+
+    let field_type = match data_type {
+        "decimal" => FieldType::Decimal,
+        "int" | "tinyint" | "smallint" | "mediumint" | "bigint" => {
+            if is_unsigned {
+                FieldType::UInt
+            } else {
+                FieldType::Int
+            }
+        }
+        "float" | "double" => FieldType::Float,
+        "timestamp" => FieldType::Timestamp,
+        "time" => FieldType::Duration,
+        "year" => FieldType::Int,
+        "date" => FieldType::Date,
+        "datetime" => FieldType::Timestamp,
+        "varchar" => FieldType::Text,
+        "varbinary" => FieldType::Binary,
+        "char" => FieldType::String,
+        "binary" => FieldType::Binary,
+        "tinyblob" => FieldType::Binary,
+        "blob" => FieldType::Binary,
+        "mediumblob" => FieldType::Binary,
+        "longblob" => FieldType::Binary,
+        "tinytext" => FieldType::Text,
+        "text" => FieldType::Text,
+        "mediumtext" => FieldType::Text,
+        "longtext" => FieldType::Text,
+        "point" => FieldType::Point,
+        "json" => FieldType::Json,
+        "bit" => FieldType::Int,
+        "enum" => FieldType::String,
+        "set" => FieldType::String,
+        "null" | "linestring" | "polygon" | "multipoint" | "multilinestring" | "multipolygon"
+        | "geomcollection" | "geometry" => {
+            Err(MySQLConnectorError::UnsupportedFieldType(data_type.into()))?
+        }
+        _ => Err(MySQLConnectorError::UnsupportedFieldType(data_type.into()))?,
+    };
+
+    Ok(field_type)
+}
+
+pub trait IntoFields<'a> {
+    type Ctx: 'a;
+
+    fn into_fields(self, ctx: Self::Ctx) -> Result<Vec<Field>, MySQLConnectorError>;
+}
+
+impl<'a> IntoFields<'a> for Row {
+    type Ctx = &'a [FieldType];
+
+    fn into_fields(self, field_types: &[FieldType]) -> Result<Vec<Field>, MySQLConnectorError> {
+        let mut row = self;
+        let mut fields = Vec::new();
+        for i in 0..row.len() {
+            let field = row
+                .take::<Value, usize>(i)
+                .into_field(field_types.get(i).unwrap())?;
+            fields.push(field);
+        }
+        Ok(fields)
+    }
+}
+
+pub trait IntoField<'a> {
+    type Ctx: 'a;
+
+    fn into_field(self, ctx: Self::Ctx) -> Result<Field, MySQLConnectorError>;
+}
+
+impl<'a> IntoField<'a> for Option<Value> {
+    type Ctx = &'a FieldType;
+
+    fn into_field(self, field_type: &FieldType) -> Result<Field, MySQLConnectorError> {
+        if let Some(value) = self {
+            value.into_field(field_type)
+        } else {
+            Ok(Field::Null)
+        }
+    }
+}
+
+impl<'a> IntoField<'a> for Value {
+    type Ctx = &'a FieldType;
+
+    fn into_field(self, field_type: &FieldType) -> Result<Field, MySQLConnectorError> {
+        use mysql_common::value::convert::from_value_opt;
+        use Value::*;
+
+        let value = self;
+
+        let field = if let NULL = value {
+            Field::Null
+        } else {
+            match field_type {
+                FieldType::UInt => Field::UInt(from_value_opt::<u64>(value)?),
+                FieldType::U128 => Field::U128(from_value_opt::<u128>(value)?),
+                FieldType::Int => Field::Int(from_value_opt::<i64>(value)?),
+                FieldType::I128 => Field::I128(from_value_opt::<i128>(value)?),
+                FieldType::Float => Field::Float(from_value_opt::<f64>(value)?.into()),
+                FieldType::Boolean => Field::Boolean(from_value_opt::<bool>(value)?),
+                FieldType::String => Field::String(from_value_opt::<String>(value)?),
+                FieldType::Text => Field::Text(from_value_opt::<String>(value)?),
+                FieldType::Binary => Field::Binary(from_value_opt::<Vec<u8>>(value)?),
+                FieldType::Decimal => Field::Decimal(from_value_opt::<Decimal>(value)?),
+                FieldType::Timestamp => {
+                    let date_time = from_value_opt::<NaiveDateTime>(value)?;
+                    Field::Timestamp(DateTime::from_utc(date_time, Utc.fix()))
+                }
+                FieldType::Date => Field::Date(from_value_opt::<NaiveDate>(value)?),
+                FieldType::Json => {
+                    let json =
+                        serde_json_to_json_value(from_value_opt::<serde_json::Value>(value)?)?;
+                    Field::Json(json)
+                }
+                FieldType::Point => {
+                    let bytes = from_value_opt::<Vec<u8>>(value)?;
+                    let (_srid, mut wkb_point) = bytes.as_slice().split_at(4);
+                    let mut wkb_processor = PointProcessor::new();
+                    wkb::process_wkb_geom(&mut wkb_point, &mut wkb_processor).unwrap();
+                    if let Some(point) = wkb_processor.point {
+                        Field::Point(point)
+                    } else {
+                        Err(mysql_common::FromValueError(Value::Bytes(bytes)))?
+                    }
+                }
+                FieldType::Duration => Field::Duration(DozerDuration(
+                    from_value_opt::<Duration>(value)?,
+                    TimeUnit::Microseconds,
+                )),
+            }
+        };
+
+        Ok(field)
+    }
+}
+
+pub trait IntoJsonValue {
+    fn into_json_value(self) -> Result<JsonValue, MySQLConnectorError>;
+}
+
+struct PointProcessor {
+    point: Option<DozerPoint>,
+}
+
+impl PointProcessor {
+    pub fn new() -> Self {
+        Self { point: None }
+    }
+}
+
+impl GeomProcessor for PointProcessor {
+    fn dimensions(&self) -> geozero::CoordDimensions {
+        geozero::CoordDimensions::xy()
+    }
+
+    fn xy(&mut self, x: f64, y: f64, _idx: usize) -> geozero::error::Result<()> {
+        self.point = Some((x, y).into());
+        Ok(())
+    }
+}

--- a/dozer-ingestion/src/connectors/mysql/helpers.rs
+++ b/dozer-ingestion/src/connectors/mysql/helpers.rs
@@ -1,0 +1,11 @@
+pub fn escape_identifier(identifier: &str) -> String {
+    format!("`{}`", identifier.replace('`', "``"))
+}
+
+pub fn qualify_table_name(schema: Option<&str>, name: &str) -> String {
+    if let Some(schema) = schema {
+        format!("{}.{}", escape_identifier(schema), escape_identifier(name))
+    } else {
+        escape_identifier(name)
+    }
+}

--- a/dozer-ingestion/src/connectors/mysql/mod.rs
+++ b/dozer-ingestion/src/connectors/mysql/mod.rs
@@ -1,0 +1,5 @@
+mod binlog;
+pub mod connector;
+mod conversion;
+pub(crate) mod helpers;
+mod schema;

--- a/dozer-ingestion/src/connectors/mysql/schema.rs
+++ b/dozer-ingestion/src/connectors/mysql/schema.rs
@@ -1,0 +1,314 @@
+use super::conversion::get_field_type_for_mysql_column_type;
+use crate::{
+    connectors::{mysql::helpers::escape_identifier, TableIdentifier, TableInfo},
+    errors::MySQLConnectorError,
+};
+use dozer_types::types::FieldType;
+use mysql_async::{from_row, prelude::Queryable, BinaryProtocol, Conn, Pool, QueryResult};
+use mysql_common::Value;
+
+#[derive(Clone, Debug)]
+pub struct TableDefinition {
+    pub table_index: usize,
+    pub table_name: String,
+    pub database_name: String,
+    pub columns: Vec<ColumnDefinition>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ColumnDefinition {
+    pub ordinal_position: u32,
+    pub name: String,
+    pub typ: FieldType,
+    pub nullable: bool,
+    pub primary_key: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct SchemaHelper<'a, 'b> {
+    conn_url: &'a String,
+    conn_pool: &'b Pool,
+}
+
+impl SchemaHelper<'_, '_> {
+    pub fn new<'a, 'b>(conn_url: &'a String, conn_pool: &'b Pool) -> SchemaHelper<'a, 'b> {
+        SchemaHelper {
+            conn_url,
+            conn_pool,
+        }
+    }
+
+    pub async fn list_tables(&self) -> Result<Vec<TableIdentifier>, MySQLConnectorError> {
+        let mut conn = self.connect().await?;
+
+        let mut rows = conn
+            .exec_iter(
+                "
+                    SELECT table_name, table_schema FROM information_schema.tables
+                    WHERE table_schema = DATABASE()
+                    AND table_type = 'BASE TABLE'
+                ",
+                (),
+            )
+            .await
+            .map_err(MySQLConnectorError::QueryExecutionError)?;
+
+        let tables = rows
+            .map(|row| {
+                let (table_name, table_schema) = from_row(row);
+
+                TableIdentifier {
+                    schema: Some(table_schema),
+                    name: table_name,
+                }
+            })
+            .await
+            .map_err(MySQLConnectorError::QueryResultError)?;
+
+        Ok(tables)
+    }
+
+    pub async fn list_columns(
+        &self,
+        tables: Vec<TableIdentifier>,
+    ) -> Result<Vec<TableInfo>, MySQLConnectorError> {
+        if tables.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut conn = self.connect().await?;
+        let mut rows = Self::query_information_schema_columns(
+            &mut conn,
+            &tables,
+            &["table_name", "table_schema", "column_name"],
+        )
+        .await?;
+
+        let table_infos = rows
+            .reduce(
+                Vec::new(),
+                |mut table_infos, row: (String, String, String)| {
+                    let (table_name, table_schema, column_name) = row;
+
+                    let last_table = table_infos.last_mut();
+                    match last_table {
+                        Some(TableInfo {
+                            name,
+                            schema: Some(schema),
+                            ..
+                        }) if *name == table_name && *schema == table_schema => {
+                            last_table.unwrap().column_names.push(column_name);
+                        }
+                        _ => table_infos.push(TableInfo {
+                            schema: Some(table_schema),
+                            name: table_name,
+                            column_names: vec![column_name],
+                        }),
+                    }
+
+                    table_infos
+                },
+            )
+            .await
+            .map_err(MySQLConnectorError::QueryResultError)?;
+
+        Ok(table_infos)
+    }
+
+    pub async fn get_table_definitions(
+        &self,
+        table_infos: &[TableInfo],
+    ) -> Result<Vec<TableDefinition>, MySQLConnectorError> {
+        if table_infos.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut conn = self.connect().await?;
+        let mut rows = Self::query_information_schema_columns(
+            &mut conn,
+            table_infos,
+            &[
+                "table_name",
+                "table_schema",
+                "column_name",
+                "column_type",
+                "is_nullable",
+                "column_key",
+                "ordinal_position",
+            ],
+        )
+        .await?;
+
+        let mut table_definitions: Vec<TableDefinition> = Vec::new();
+        {
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(MySQLConnectorError::QueryResultError)?
+            {
+                let (
+                    table_name,
+                    table_schema,
+                    column_name,
+                    column_type,
+                    is_nullable,
+                    column_key,
+                    ordinal_position,
+                ) = from_row::<(String, String, String, String, String, String, u32)>(row);
+
+                let nullable = is_nullable == "YES";
+                let primary_key = column_key == "PRI";
+                let column_definiton = ColumnDefinition {
+                    ordinal_position,
+                    name: column_name.clone(),
+                    typ: get_field_type_for_mysql_column_type(&column_type)?,
+                    nullable,
+                    primary_key,
+                };
+
+                match table_definitions.last_mut() {
+                    Some(td) if td.table_name == table_name && td.database_name == table_schema => {
+                        td.columns.push(column_definiton);
+                    }
+                    _ => {
+                        let table_index = table_definitions.len();
+                        let td = TableDefinition {
+                            table_index,
+                            table_name,
+                            database_name: table_schema,
+                            columns: vec![column_definiton],
+                        };
+                        table_definitions.push(td);
+                    }
+                }
+            }
+        }
+
+        Ok(table_definitions)
+    }
+
+    async fn query_information_schema_columns<'a, 'b, T>(
+        conn: &'b mut Conn,
+        table_infos: &'a [T],
+        select_columns: &[&str],
+    ) -> Result<QueryResult<'b, 'static, BinaryProtocol>, MySQLConnectorError>
+    where
+        TableInfoRef<'a>: From<&'a T>,
+    {
+        let mut query_params: Vec<Value> = Vec::new();
+        let query = format!(
+            "
+                SELECT {}
+                FROM information_schema.columns
+                WHERE {}
+                ORDER BY {}, ordinal_position ASC
+            ",
+            select_columns
+                .iter()
+                .copied()
+                .map(escape_identifier)
+                .collect::<Vec<_>>()
+                .join(", "),
+            // where clause: filter by table name and table schema
+            table_infos
+                .iter()
+                .map(Into::into)
+                .map(
+                    |TableInfoRef {
+                         schema,
+                         name,
+                         column_names,
+                     }| {
+                        query_params.push(name.into());
+                        let mut condition = "(table_name = ? AND table_schema = ".to_string();
+                        if let Some(schema) = schema {
+                            query_params.push(schema.into());
+                            condition.push('?');
+                        } else {
+                            condition.push_str("DATABASE()");
+                        }
+                        if !column_names.is_empty() {
+                            condition.push_str(" AND column_name IN (");
+                            for (i, column) in column_names.iter().enumerate() {
+                                query_params.push(column.into());
+                                if i == 0 {
+                                    condition.push('?');
+                                } else {
+                                    condition.push_str(", ?");
+                                }
+                            }
+                            condition.push(')');
+                        }
+                        condition.push(')');
+                        condition
+                    }
+                )
+                .collect::<Vec<String>>()
+                .join(" OR "),
+            // order by clause: preserve the order of the input tables in the output
+            {
+                let mut case = String::from("CASE ");
+
+                table_infos.iter().map(Into::into).enumerate().for_each(
+                    |(i, TableInfoRef { schema, name, .. })| {
+                        case.push_str("WHEN (table_name = ? AND table_schema = ");
+                        query_params.push(name.into());
+
+                        if let Some(schema) = schema {
+                            query_params.push(schema.into());
+                            case.push('?');
+                        } else {
+                            case.push_str("DATABASE()");
+                        }
+                        case.push(')');
+                        case.push_str(" THEN ? ");
+                        query_params.push(i.into());
+                    },
+                );
+
+                case.push_str("END ASC");
+                case
+            }
+        );
+
+        let rows = conn
+            .exec_iter(query, query_params)
+            .await
+            .map_err(MySQLConnectorError::QueryExecutionError)?;
+
+        Ok(rows)
+    }
+
+    async fn connect(&self) -> Result<Conn, MySQLConnectorError> {
+        self.conn_pool
+            .get_conn()
+            .await
+            .map_err(|err| MySQLConnectorError::ConnectionFailure(self.conn_url.clone(), err))
+    }
+}
+
+struct TableInfoRef<'a> {
+    pub schema: Option<&'a str>,
+    pub name: &'a str,
+    pub column_names: &'a [String],
+}
+
+impl<'a> From<&'a TableIdentifier> for TableInfoRef<'a> {
+    fn from(value: &'a TableIdentifier) -> Self {
+        Self {
+            schema: value.schema.as_deref(),
+            name: &value.name,
+            column_names: &[],
+        }
+    }
+}
+
+impl<'a> From<&'a TableInfo> for TableInfoRef<'a> {
+    fn from(value: &'a TableInfo) -> Self {
+        Self {
+            schema: value.schema.as_deref(),
+            name: &value.name,
+            column_names: &value.column_names,
+        }
+    }
+}

--- a/dozer-tests/src/e2e_tests/cases/mysql-chinook/dozer-config.yaml
+++ b/dozer-tests/src/e2e_tests/cases/mysql-chinook/dozer-config.yaml
@@ -1,0 +1,29 @@
+app_name: chinook-mysql
+
+connections:
+  - name: chinook_mysql
+    config: !MySQL
+      url: mysql://root:mysql@localhost:3306/Chinook
+
+sources:
+  - name: employee
+    table_name: Employee
+    connection: chinook_mysql
+
+  - name: invoice
+    table_name: Invoice
+    columns:
+      - InvoiceId
+      - CustomerId
+      - InvoiceDate
+      - Total
+    connection: chinook_mysql
+
+endpoints:
+  - name: employee
+    path: /employee
+    table_name: employee
+
+  - name: invoice
+    path: /invoice
+    table_name: invoice

--- a/dozer-tests/src/e2e_tests/cases/mysql-chinook/expectations.json
+++ b/dozer-tests/src/e2e_tests/cases/mysql-chinook/expectations.json
@@ -1,0 +1,238 @@
+[
+    "HealthyService",
+    {
+        "Endpoint": {
+            "endpoint": "employee",
+            "expectations": [
+                {
+                    "Schema": {
+                        "fields": [
+                            {
+                                "name": "EmployeeId",
+                                "typ": "Int",
+                                "nullable": false,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "LastName",
+                                "typ": "Text",
+                                "nullable": false,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "FirstName",
+                                "typ": "Text",
+                                "nullable": false,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "Title",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "ReportsTo",
+                                "typ": "Int",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "BirthDate",
+                                "typ": "Timestamp",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "HireDate",
+                                "typ": "Timestamp",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "Address",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "City",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "State",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "Country",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "PostalCode",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "Phone",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "Fax",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "Email",
+                                "typ": "Text",
+                                "nullable": true,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "employee"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "Endpoint": {
+            "endpoint": "invoice",
+            "expectations": [
+                {
+                    "Schema": {
+                        "fields": [
+                            {
+                                "name": "InvoiceId",
+                                "typ": "Int",
+                                "nullable": false,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "invoice"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CustomerId",
+                                "typ": "Int",
+                                "nullable": false,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "invoice"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "InvoiceDate",
+                                "typ": "Timestamp",
+                                "nullable": false,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "invoice"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "Total",
+                                "typ": "Decimal",
+                                "nullable": false,
+                                "source": {
+                                    "Table": {
+                                        "connection": "chinook_mysql",
+                                        "name": "invoice"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/dozer-tests/src/e2e_tests/connections/chinook_mysql/Dockerfile
+++ b/dozer-tests/src/e2e_tests/connections/chinook_mysql/Dockerfile
@@ -1,0 +1,7 @@
+FROM mysql:8
+
+COPY ./download.sh .
+RUN sh download.sh
+RUN mv ./data/init.sql /docker-entrypoint-initdb.d/init.sql
+
+COPY ./is_ready.sh /usr/bin/

--- a/dozer-tests/src/e2e_tests/connections/chinook_mysql/download.sh
+++ b/dozer-tests/src/e2e_tests/connections/chinook_mysql/download.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+curl --create-dirs -o ./data/init.sql https://raw.githubusercontent.com/lerocha/chinook-database/e7e6d5f008e35d3f89d8b8a4f8d38e3bfa7e34bd/ChinookDatabase/DataSources/Chinook_MySql.sql
+
+cat >>./data/init.sql <<'EOSQL'
+
+CREATE TABLE `ready` (`ready` INT);
+INSERT INTO `ready` (`ready`) VALUES (1);
+
+EOSQL

--- a/dozer-tests/src/e2e_tests/connections/chinook_mysql/is_ready.sh
+++ b/dozer-tests/src/e2e_tests/connections/chinook_mysql/is_ready.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+r=`mysql -u root --password=$MYSQL_ROOT_PASSWORD --batch --silent --database=Chinook -e 'SELECT COUNT(*) > 0 FROM ready'`
+[ "$r" = 1 ]

--- a/dozer-tests/src/e2e_tests/connections/chinook_mysql/service.yaml
+++ b/dozer-tests/src/e2e_tests/connections/chinook_mysql/service.yaml
@@ -1,0 +1,16 @@
+container_name: chinook_mysql
+build:
+  context: .
+ports:
+  - target: 3306
+    published: 3306
+environment:
+  - MYSQL_ROOT_PASSWORD=mysql
+  - MYSQL_ROOT_HOST=%
+healthcheck:
+  test:
+    - CMD-SHELL
+    - is_ready.sh
+  interval: 5s
+  timeout: 5s
+  retries: 15

--- a/dozer-tests/src/e2e_tests/runner/running_env.rs
+++ b/dozer-tests/src/e2e_tests/runner/running_env.rs
@@ -359,6 +359,14 @@ fn write_dozer_config_for_running_in_docker_compose(
                 let _ = url.set_port(Some(map_port(url.port().unwrap_or(27017))));
                 mongo.connection_string = url.to_string();
             }
+            ConnectionConfig::MySQL(mysql) => {
+                let mut url = url::Url::parse(&mysql.url).unwrap();
+                url.set_host(Some(&connection.name)).unwrap();
+                const MYSQL_DEFAULT_PORT: u16 = 3306;
+                url.set_port(Some(map_port(url.port().unwrap_or(MYSQL_DEFAULT_PORT))))
+                    .unwrap();
+                mysql.url = url.into();
+            }
         }
     }
 

--- a/dozer-types/src/ingestion_types.rs
+++ b/dozer-types/src/ingestion_types.rs
@@ -420,6 +420,14 @@ pub struct MongodbConfig {
     pub connection_string: String,
 }
 
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, ::prost::Message, Hash)]
+pub struct MySQLConfig {
+    #[prost(string, tag = "1")]
+    pub url: String,
+    #[prost(uint32, optional, tag = "2")]
+    pub server_id: Option<u32>,
+}
+
 fn default_false() -> bool {
     false
 }

--- a/dozer-types/src/models/connection.rs
+++ b/dozer-types/src/models/connection.rs
@@ -1,6 +1,6 @@
 use crate::ingestion_types::{
-    DeltaLakeConfig, EthConfig, GrpcConfig, KafkaConfig, LocalStorage, MongodbConfig, S3Storage,
-    SnowflakeConfig,
+    DeltaLakeConfig, EthConfig, GrpcConfig, KafkaConfig, LocalStorage, MongodbConfig, MySQLConfig,
+    S3Storage, SnowflakeConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -194,4 +194,7 @@ pub enum ConnectionConfig {
     #[prost(message, tag = "9")]
     /// In yaml, present as tag: `!MongoDB`
     MongoDB(MongodbConfig),
+    #[prost(message, tag = "10")]
+    /// In yaml, present as tag" `!MySQL`
+    MySQL(MySQLConfig),
 }


### PR DESCRIPTION
Define and implement a MySQL connector for Dozer. 

It operates similarly to the Postgres connector; especially when it comes to listing tables, columns, and schemas.

For replication, MySQL CDC is used to replay database changes in Dozer, after initially copying the table contents with a simple SELECT query.

The connector implementation is pretty much complete with the only exception of partial updates to JSON fields, which is a feature in MySQL that does not have pre-existing support in Dozer as far as I could tell.

closes #1670
/claim #1670