### PR TITLE
test: provide a MySQL service for CI coverage tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -40,6 +40,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mysql:
+        image: mysql:8
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_ROOT_HOST: '%'
+          MYSQL_DATABASE: test
+        options: >-
+          --health-cmd "mysqladmin ping -uroot --password=mysql"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
A local MySQL service is required to run some integration tests in the coverage CI workflow.