### PR TITLE
ci: introduce labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 # Note that any updates to this files will not be applied in CI
 # until this file is merged into main. This is due to oddities of the labeller Github Action.
 'doc-update-needed':
-  - dozer-types/src/model/*
+  - dozer-types/src/models/*
   - dozer-cli/src/cli/types.rs
-  - dozer-types/protos/*.rs
+  - dozer-types/protos/*
   - dozer-api/src/generator/protoc/generator/template/proto.tmpl

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+# Note that any updates to this files will not be applied in CI
+# until this file is merged into main. This is due to oddities of the labeller Github Action.
+'doc-update-needed':
+  - dozer-types/src/model/*
+  - dozer-cli/src/cli/types.rs
+  - dozer-types/protos/*.rs
+  - dozer-api/src/generator/protoc/generator/template/proto.tmpl

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Run labeler
+        uses: actions/labeler@v4
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Resolves: #1882 

Create a Github Action that runs on certain file changes and labels a PR as doc-update-needed.

Uses: https://github.com/marketplace/actions/labeler

Add label 'doc-update-needed' for:
  - dozer-types/src/models/*
  - dozer-cli/src/cli/types.rs
  - dozer-types/protos/*
  - dozer-api/src/generator/protoc/generator/template/proto.tmpl

This was tested in my forked repository:
See: https://github.com/tungbq/dozer/pulls
![image](https://github.com/getdozer/dozer/assets/85242618/78067adf-f1a5-4449-90c9-956b8ace00f2)
