### PR TITLE
fix: do not require primary key for CdcType::FullChanges

### DIFF
--- a/dozer-cli/src/pipeline/connector_source.rs
+++ b/dozer-cli/src/pipeline/connector_source.rs
@@ -77,7 +77,7 @@ pub struct ConnectorSourceFactory {
 
 fn map_replication_type_to_output_port_type(typ: &CdcType) -> OutputPortType {
     match typ {
-        CdcType::FullChanges => OutputPortType::StatefulWithPrimaryKeyLookup,
+        CdcType::FullChanges => OutputPortType::Stateless,
         CdcType::OnlyPK => OutputPortType::StatefulWithPrimaryKeyLookup,
         CdcType::Nothing => OutputPortType::Stateless,
     }


### PR DESCRIPTION
As @chubei noted, in the case of `CdcType::FullChanges` the CDC backend provides the old values as well as the new values of a change; therefore, dozer does not need to keep track of the old record; hence, the primary key should not be required.