### PR TITLE
Run sql-tests with custom libtest-mimic harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "regex",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -2355,7 +2355,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "itertools 0.11.0",
  "log",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -2828,6 +2828,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hashbrown 0.13.2",
+ "libtest-mimic",
  "mongodb",
  "multimap",
  "reqwest",
@@ -2928,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0188e3c3ba8df5753894d54461f0e39bc91741dc5b22e1c46999ec2c71f4e4"
+checksum = "079044df30bb07de7d846d41a184c4b00e66ebdac93ee459253474f3a47e50ae"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
@@ -4375,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "libtest-mimic"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b603516767d1ab23d0de09d023e62966c3322f7148297c35cf3d97aa8b37fa"
+checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
 dependencies = [
  "clap 4.3.11",
  "termcolor",
@@ -4591,7 +4592,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -6370,13 +6371,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-automata 0.3.6",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -6389,6 +6391,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6396,9 +6409,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "remove_dir_all"
@@ -7403,9 +7416,9 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.11.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71378f7ef90bc4d448f2d84c11898adca45ced916d95df16d233a0e6da39f118"
+checksum = "ee18b0100bc1e1a6d1f9aa242b263c34d3f475f3a2de49da2affa6c00223a2ec"
 dependencies = [
  "async-trait",
  "educe",
@@ -7413,7 +7426,7 @@ dependencies = [
  "futures",
  "glob",
  "humantime",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "libtest-mimic",
  "md-5 0.10.5",
  "owo-colors",

--- a/dozer-tests/Cargo.toml
+++ b/dozer-tests/Cargo.toml
@@ -14,7 +14,8 @@ path = "src/dozer_tests.rs"
 name = "dozer-test-client"
 path = "src/dozer_test_client.rs"
 
-[[bin]]
+[[test]]
+harness = false
 name = "sql-tests"
 path = "src/sql_tests/logic_test.rs"
 
@@ -26,14 +27,13 @@ dozer-cli = { path = "../dozer-cli" }
 dozer-tracing = { path = "../dozer-tracing" }
 
 reqwest = { version = "0.11.14", features = ["json", "rustls-tls"], default-features = false }
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.25.0", features = ["full", "rt"] }
 bson = { version = "2.5.0", optional = true }
 mongodb = { version = "2.3.1", optional = true }
 futures = { version = "0.3.26", optional = true }
 env_logger = "0.10.0"
 clap = { version = "4.1.11", features = ["derive"] }
 rusqlite = { version = "0.28.0", features = ["bundled", "column_decltype", "hooks"] }
-sqllogictest = "0.11.1"
 async-trait = "0.1.53"
 dozer-core = { path = "../dozer-core" }
 dozer-sql = { path = "../dozer-sql" }
@@ -54,6 +54,8 @@ sqlparser = {git = "https://github.com/getdozer/sqlparser-rs.git" }
 rusqlite = { version = "0.28.0", features = ["bundled", "column_decltype"] }
 csv = "1.2"
 tempdir = "0.3.7"
+sqllogictest = "0.15.3"
+libtest-mimic = "0.6.1"
 
 [features]
 mongodb = ["dep:bson", "dep:mongodb", "dep:futures"]

--- a/dozer-tests/src/sql_tests/arg.rs
+++ b/dozer-tests/src/sql_tests/arg.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use sqllogictest::harness;
 
 #[derive(Parser, Debug, Clone)]
 pub struct SqlLogicTestArgs {
@@ -19,4 +20,7 @@ pub struct SqlLogicTestArgs {
         help = "The arg is used to enable auto complete mode"
     )]
     pub complete: bool,
+
+    #[command(flatten)]
+    pub harness_args: harness::Arguments,
 }

--- a/dozer-tests/src/sql_tests/logic_test.rs
+++ b/dozer-tests/src/sql_tests/logic_test.rs
@@ -19,7 +19,12 @@ use helper::mapper::SqlMapper;
 use helper::pipeline::TestPipeline;
 use helper::schema::get_table_name;
 
-use sqllogictest::{default_validator, parse_file, update_test_file, AsyncDB, DBOutput, Runner};
+use libtest_mimic::Trial;
+use sqllogictest::default_column_validator;
+use sqllogictest::harness;
+use sqllogictest::DefaultColumnType;
+use sqllogictest::{default_validator, AsyncDB, DBOutput, Runner};
+use tokio::runtime::Runtime;
 use validator::Validator;
 use walkdir::WalkDir;
 
@@ -53,10 +58,9 @@ impl Dozer {
 #[async_trait::async_trait]
 impl AsyncDB for Dozer {
     type Error = DozerSqlLogicTestError;
+    type ColumnType = DefaultColumnType;
 
-    async fn run(&mut self, sql: &str) -> Result<DBOutput> {
-        println!("SQL [{}] is running", sql);
-
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>> {
         let ast = SqlParser::parse_sql(&DozerDialect {}, sql)?;
         let statement: &Statement = &ast[0];
         match statement {
@@ -103,45 +107,14 @@ impl AsyncDB for Dozer {
     }
 }
 
-fn create_dozer() -> Result<Dozer> {
+async fn create_dozer() -> Result<Dozer> {
     // create dozer
     let source_db = SqlMapper::default();
     let dozer = Dozer::create(source_db);
     Ok(dozer)
 }
 
-const BASE_PATH: &str = "dozer-tests/src/sql_tests";
-
-#[tokio::test]
-async fn logic_test() -> Result<()> {
-    env_logger::init();
-
-    let suits = std::fs::read_dir("src/sql_tests/full").unwrap();
-    let mut files = vec![];
-    for suit in suits {
-        let suit = suit.unwrap().path();
-        for entry in WalkDir::new(suit)
-            .min_depth(0)
-            .max_depth(100)
-            .sort_by(|a, b| a.file_name().cmp(b.file_name()))
-            .into_iter()
-            .filter(|e| !e.as_ref().unwrap().file_type().is_dir())
-        {
-            files.push(entry)
-        }
-    }
-    for file in files.into_iter() {
-        let file_path = file.as_ref().unwrap().path();
-
-        let mut runner = Runner::new(create_dozer()?);
-        let records = parse_file(file_path).unwrap();
-        // Run dozer to check if dozer's outputs satisfy expected results
-        for record in records.iter() {
-            runner.run_async(record.clone()).await.unwrap();
-        }
-    }
-    Ok(())
-}
+const BASE_PATH: &str = "src/sql_tests";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -175,27 +148,38 @@ async fn main() -> Result<()> {
             files.push(entry)
         }
     }
+
+    let mut tests = vec![];
     for file in files.into_iter() {
-        let file_path = file.as_ref().unwrap().path();
+        let file_path = file.unwrap().path().to_owned();
 
         if complete {
             // Use validator db to generate expected results
-            let mut validator_runner = Runner::new(Validator::create());
+            let mut validator_runner = Runner::new(Validator::create);
             let col_separator = " ";
             let validator = default_validator;
-            update_test_file(file_path, &mut validator_runner, col_separator, validator)
+            validator_runner
+                .update_test_file(
+                    &file_path,
+                    col_separator,
+                    validator,
+                    default_column_validator,
+                )
                 .await
                 .unwrap();
         }
 
-        let mut runner = Runner::new(create_dozer()?);
-        let records = parse_file(file_path).unwrap();
-        // Run dozer to check if dozer's outputs satisfy expected results
-        for record in records.iter() {
-            runner.run_async(record.clone()).await.unwrap();
-        }
+        tests.push(Trial::test(
+            file_path.to_str().unwrap().to_owned(),
+            move || {
+                let mut tester = Runner::new(create_dozer);
+                let runtime = Runtime::new().unwrap();
+                runtime.block_on(tester.run_file_async(file_path))?;
+                Ok(())
+            },
+        ));
     }
-    Ok(())
+    harness::run(&args.harness_args, tests).exit();
 }
 
 fn delete_dir_contents(dir: std::fs::ReadDir) {

--- a/dozer-tests/src/sql_tests/validator.rs
+++ b/dozer-tests/src/sql_tests/validator.rs
@@ -1,6 +1,6 @@
 use crate::error::DozerSqlLogicTestError;
 use rusqlite::types::Type;
-use sqllogictest::{AsyncDB, DBOutput};
+use sqllogictest::{AsyncDB, DBOutput, DefaultColumnType};
 
 // Used in `complete` mode, to generate results
 pub struct Validator {
@@ -8,18 +8,19 @@ pub struct Validator {
 }
 
 impl Validator {
-    pub fn create() -> Self {
-        Self {
+    pub async fn create() -> Result<Self, DozerSqlLogicTestError> {
+        Ok(Self {
             conn: rusqlite::Connection::open_in_memory().unwrap(),
-        }
+        })
     }
 }
 
 #[async_trait::async_trait]
 impl AsyncDB for Validator {
     type Error = DozerSqlLogicTestError;
+    type ColumnType = DefaultColumnType;
 
-    async fn run(&mut self, sql: &str) -> Result<DBOutput, Self::Error> {
+    async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error> {
         let sql = sql.trim_start();
         if sql.to_lowercase().starts_with("select") || sql.to_lowercase().starts_with("with") {
             let mut stmt = self.conn.prepare(sql)?;


### PR DESCRIPTION
Makes filtering sql test behave the same as filtering `libtest` tests and makes the output look like `libtest`.

In general, this is in the "less surprising" category.