### PR TITLE
feat: make probabilistic optimizations optional and tunable in the config

### DIFF
--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -64,7 +64,7 @@ pub use dozer_ingestion::{
 pub use dozer_sql::pipeline::builder::QueryContext;
 pub use ui_helper::config_to_ui_dag;
 pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, PipelineError> {
-    let mut pipeline = AppPipeline::new();
+    let mut pipeline = AppPipeline::new_with_default_flags();
     statement_to_pipeline(sql, &mut pipeline, None)
 }
 

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -14,6 +14,7 @@ use dozer_types::{
     models::{
         api_config::{ApiConfig, AppGrpcOptions},
         api_endpoint::ApiEndpoint,
+        flags::Flags,
     },
 };
 use tokio::{runtime::Runtime, sync::RwLock};
@@ -292,6 +293,7 @@ async fn create_dag(
         dozer.config.sql.as_deref(),
         endpoint_and_logs,
         MultiProgress::new(),
+        Flags::default(),
     );
     let (_shutdown_sender, shutdown_receiver) = shutdown::new(&dozer.runtime);
     builder.build(&dozer.runtime, shutdown_receiver).await
@@ -324,8 +326,12 @@ fn get_dozer_run_instance(
 ) -> Result<SimpleOrchestrator, LiveError> {
     match req.request {
         Some(dozer_types::grpc_types::live::run_request::Request::Sql(req)) => {
-            let context = statement_to_pipeline(&req.sql, &mut AppPipeline::new(), None)
-                .map_err(LiveError::PipelineError)?;
+            let context = statement_to_pipeline(
+                &req.sql,
+                &mut AppPipeline::new(dozer.config.flags.clone().unwrap_or_default().into()),
+                None,
+            )
+            .map_err(LiveError::PipelineError)?;
 
             //overwrite sql
             dozer.config.sql = Some(req.sql);

--- a/dozer-cli/src/pipeline/builder.rs
+++ b/dozer-cli/src/pipeline/builder.rs
@@ -16,6 +16,7 @@ use dozer_types::indicatif::MultiProgress;
 use dozer_types::log::debug;
 use dozer_types::models::api_endpoint::ApiEndpoint;
 use dozer_types::models::connection::Connection;
+use dozer_types::models::flags::Flags;
 use dozer_types::models::source::Source;
 use dozer_types::parking_lot::Mutex;
 use std::hash::Hash;
@@ -57,6 +58,7 @@ pub struct PipelineBuilder<'a> {
     /// `ApiEndpoint` and its log.
     endpoint_and_logs: Vec<(ApiEndpoint, OptionLog)>,
     progress: MultiProgress,
+    flags: Flags,
 }
 
 impl<'a> PipelineBuilder<'a> {
@@ -66,6 +68,7 @@ impl<'a> PipelineBuilder<'a> {
         sql: Option<&'a str>,
         endpoint_and_logs: Vec<(ApiEndpoint, OptionLog)>,
         progress: MultiProgress,
+        flags: Flags,
     ) -> Self {
         Self {
             connections,
@@ -73,6 +76,7 @@ impl<'a> PipelineBuilder<'a> {
             sql,
             endpoint_and_logs,
             progress,
+            flags,
         }
     }
 
@@ -148,7 +152,7 @@ impl<'a> PipelineBuilder<'a> {
         let mut original_sources = vec![];
 
         let mut query_ctx = None;
-        let mut pipeline = AppPipeline::new();
+        let mut pipeline = AppPipeline::new((&self.flags).into());
 
         let mut transformed_sources = vec![];
 
@@ -205,7 +209,7 @@ impl<'a> PipelineBuilder<'a> {
 
         let mut pipelines: Vec<AppPipeline<SchemaSQLContext>> = vec![];
 
-        let mut pipeline = AppPipeline::new();
+        let mut pipeline = AppPipeline::new(self.flags.into());
 
         let mut available_output_tables: HashMap<String, OutputTableInfo> = HashMap::new();
 

--- a/dozer-cli/src/pipeline/tests/builder.rs
+++ b/dozer-cli/src/pipeline/tests/builder.rs
@@ -7,6 +7,7 @@ use dozer_types::models::config::Config;
 
 use dozer_types::indicatif::MultiProgress;
 use dozer_types::models::connection::{Connection, ConnectionConfig};
+use dozer_types::models::flags::Flags;
 use dozer_types::models::source::Source;
 
 fn get_default_config() -> Config {
@@ -66,6 +67,7 @@ fn load_multi_sources() {
             .map(|endpoint| (endpoint, None))
             .collect(),
         MultiProgress::new(),
+        Flags::default(),
     );
 
     let runtime = tokio::runtime::Builder::new_current_thread()

--- a/dozer-cli/src/simple/executor.rs
+++ b/dozer-cli/src/simple/executor.rs
@@ -5,6 +5,7 @@ use dozer_cache::dozer_log::replication::Log;
 use dozer_core::checkpoint::{CheckpointFactory, CheckpointFactoryOptions};
 use dozer_core::processor_record::ProcessorRecordStore;
 use dozer_types::models::api_endpoint::ApiEndpoint;
+use dozer_types::models::flags::Flags;
 use dozer_types::parking_lot::Mutex;
 use tokio::runtime::Runtime;
 
@@ -84,6 +85,7 @@ impl<'a> Executor<'a> {
         runtime: &Arc<Runtime>,
         executor_options: ExecutorOptions,
         shutdown: ShutdownReceiver,
+        flags: Flags,
     ) -> Result<DagExecutor, OrchestrationError> {
         let builder = PipelineBuilder::new(
             self.connections,
@@ -94,6 +96,7 @@ impl<'a> Executor<'a> {
                 .map(|(endpoint, log)| (endpoint.clone(), Some(log.log.clone())))
                 .collect(),
             self.multi_pb.clone(),
+            flags,
         );
 
         let dag = builder.build(runtime, shutdown).await?;

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -188,6 +188,7 @@ impl SimpleOrchestrator {
             &self.runtime,
             get_executor_options(&self.config),
             shutdown.clone(),
+            self.config.flags.clone().unwrap_or_default(),
         ))?;
 
         let app_grpc_config = get_app_grpc_config(&self.config);
@@ -289,6 +290,7 @@ impl SimpleOrchestrator {
             self.config.sql.as_deref(),
             endpoint_and_logs,
             self.multi_pb.clone(),
+            self.config.flags.clone().unwrap_or_default(),
         );
         let dag = self
             .runtime
@@ -374,7 +376,7 @@ impl SimpleOrchestrator {
 }
 
 pub fn validate_sql(sql: String) -> Result<(), PipelineError> {
-    statement_to_pipeline(&sql, &mut AppPipeline::new(), None).map_or_else(
+    statement_to_pipeline(&sql, &mut AppPipeline::new_with_default_flags(), None).map_or_else(
         |e| {
             error!(
                 "[sql][{}] Transforms validation error: {}",

--- a/dozer-core/src/app.rs
+++ b/dozer-core/src/app.rs
@@ -1,3 +1,4 @@
+use dozer_types::models::flags::{EnableProbabilisticOptimizations, Flags};
 use dozer_types::node::NodeHandle;
 
 use crate::appsource::{self, AppSourceManager};
@@ -28,12 +29,7 @@ pub struct AppPipeline<T> {
     processors: Vec<(NodeHandle, Box<dyn ProcessorFactory<T>>)>,
     sinks: Vec<(NodeHandle, Box<dyn SinkFactory<T>>)>,
     entry_points: Vec<(NodeHandle, PipelineEntryPoint)>,
-}
-
-impl<T> Default for AppPipeline<T> {
-    fn default() -> Self {
-        Self::new()
-    }
+    flags: PipelineFlags,
 }
 
 impl<T> AppPipeline<T> {
@@ -79,13 +75,18 @@ impl<T> AppPipeline<T> {
         self.edges.push(edge);
     }
 
-    pub fn new() -> Self {
+    pub fn new(flags: PipelineFlags) -> Self {
         Self {
             processors: Vec::new(),
             sinks: Vec::new(),
             edges: Vec::new(),
             entry_points: Vec::new(),
+            flags,
         }
+    }
+
+    pub fn new_with_default_flags() -> Self {
+        Self::new(Default::default())
     }
 
     pub fn get_entry_points_sources_names(&self) -> Vec<String> {
@@ -93,6 +94,38 @@ impl<T> AppPipeline<T> {
             .iter()
             .map(|(_, p)| p.source_name().to_string())
             .collect()
+    }
+
+    pub fn flags(&self) -> &PipelineFlags {
+        &self.flags
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipelineFlags {
+    pub enable_probabilistic_optimizations: EnableProbabilisticOptimizations,
+}
+
+impl From<&Flags> for PipelineFlags {
+    fn from(flags: &Flags) -> Self {
+        Self {
+            enable_probabilistic_optimizations: flags
+                .enable_probabilistic_optimizations
+                .clone()
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl From<Flags> for PipelineFlags {
+    fn from(flags: Flags) -> Self {
+        Self::from(&flags)
+    }
+}
+
+impl Default for PipelineFlags {
+    fn default() -> Self {
+        Flags::default().into()
     }
 }
 

--- a/dozer-core/src/tests/app.rs
+++ b/dozer-core/src/tests/app.rs
@@ -174,7 +174,7 @@ async fn test_app_dag() {
 
     let mut app = App::new(asm);
 
-    let mut p1 = AppPipeline::new();
+    let mut p1 = AppPipeline::new_with_default_flags();
     p1.add_processor(
         Box::new(NoopJoinProcessorFactory {}),
         "join",
@@ -197,7 +197,7 @@ async fn test_app_dag() {
 
     app.add_pipeline(p1);
 
-    let mut p2 = AppPipeline::new();
+    let mut p2 = AppPipeline::new_with_default_flags();
     p2.add_processor(
         Box::new(NoopJoinProcessorFactory {}),
         "join",

--- a/dozer-sql/src/pipeline/aggregation/factory.rs
+++ b/dozer-sql/src/pipeline/aggregation/factory.rs
@@ -17,14 +17,21 @@ pub struct AggregationProcessorFactory {
     id: String,
     projection: Select,
     _stateful: bool,
+    enable_probabilistic_optimizations: bool,
 }
 
 impl AggregationProcessorFactory {
-    pub fn new(id: String, projection: Select, stateful: bool) -> Self {
+    pub fn new(
+        id: String,
+        projection: Select,
+        stateful: bool,
+        enable_probabilistic_optimizations: bool,
+    ) -> Self {
         Self {
             id,
             projection,
             _stateful: stateful,
+            enable_probabilistic_optimizations,
         }
     }
 
@@ -90,6 +97,7 @@ impl ProcessorFactory<SchemaSQLContext> for AggregationProcessorFactory {
                 planner.having,
                 input_schema.clone(),
                 planner.post_aggregation_schema,
+                self.enable_probabilistic_optimizations,
             )?)
         };
         Ok(processor)

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_test_planner.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_test_planner.rs
@@ -84,6 +84,7 @@ fn test_planner_with_aggregator() {
         projection_planner.having,
         schema,
         projection_planner.post_aggregation_schema,
+        false,
     )
     .unwrap();
 

--- a/dozer-sql/src/pipeline/aggregation/tests/aggregation_tests_utils.rs
+++ b/dozer-sql/src/pipeline/aggregation/tests/aggregation_tests_utils.rs
@@ -36,6 +36,7 @@ pub(crate) fn init_processor(
         projection_planner.having,
         input_schema.clone(),
         projection_planner.post_aggregation_schema,
+        false,
     )
     .unwrap_or_else(|e| panic!("{}", e.to_string()));
 

--- a/dozer-sql/src/pipeline/mod.rs
+++ b/dozer-sql/src/pipeline/mod.rs
@@ -8,6 +8,7 @@ mod product;
 mod projection;
 mod selection;
 mod table_operator;
+mod utils;
 mod window;
 
 #[cfg(test)]

--- a/dozer-sql/src/pipeline/pipeline_builder/join_builder.rs
+++ b/dozer-sql/src/pipeline/pipeline_builder/join_builder.rs
@@ -55,6 +55,7 @@ pub(crate) fn insert_join_to_pipeline(
             left_name_or_alias.clone(),
             right_name_or_alias,
             join.join_operator.clone(),
+            pipeline.flags().enable_probabilistic_optimizations.in_joins,
         );
 
         let mut pipeline_entry_points = vec![];

--- a/dozer-sql/src/pipeline/product/join/factory.rs
+++ b/dozer-sql/src/pipeline/product/join/factory.rs
@@ -32,6 +32,7 @@ pub struct JoinProcessorFactory {
     left: Option<NameOrAlias>,
     right: Option<NameOrAlias>,
     join_operator: SqlJoinOperator,
+    enable_probabilistic_optimizations: bool,
 }
 
 impl JoinProcessorFactory {
@@ -40,12 +41,14 @@ impl JoinProcessorFactory {
         left: Option<NameOrAlias>,
         right: Option<NameOrAlias>,
         join_operator: SqlJoinOperator,
+        enable_probabilistic_optimizations: bool,
     ) -> Self {
         Self {
             id,
             left,
             right,
             join_operator,
+            enable_probabilistic_optimizations,
         }
     }
 }
@@ -180,12 +183,10 @@ impl ProcessorFactory<SchemaSQLContext> for JoinProcessorFactory {
 
         let join_operator = JoinOperator::new(
             join_type,
-            left_join_key_indexes,
-            right_join_key_indexes,
-            left_primary_key_indexes,
-            right_primary_key_indexes,
-            left_default_record,
-            right_default_record,
+            (left_join_key_indexes, right_join_key_indexes),
+            (left_primary_key_indexes, right_primary_key_indexes),
+            (left_default_record, right_default_record),
+            self.enable_probabilistic_optimizations,
         );
 
         Ok(Box::new(ProductProcessor::new(

--- a/dozer-sql/src/pipeline/product/set/mod.rs
+++ b/dozer-sql/src/pipeline/product/set/mod.rs
@@ -2,3 +2,4 @@ pub mod set_factory;
 mod set_processor;
 
 pub(crate) mod operator;
+pub(crate) mod record_map;

--- a/dozer-sql/src/pipeline/product/set/operator.rs
+++ b/dozer-sql/src/pipeline/product/set/operator.rs
@@ -1,5 +1,5 @@
+use super::record_map::{CountingRecordMap, CountingRecordMapEnum};
 use crate::pipeline::errors::PipelineError;
-use bloom::{CountingBloomFilter, ASMS};
 use dozer_core::processor_record::ProcessorRecord;
 use sqlparser::ast::{SetOperator, SetQuantifier};
 
@@ -28,7 +28,7 @@ impl SetOperation {
         &self,
         action: SetAction,
         record: ProcessorRecord,
-        record_map: &mut CountingBloomFilter,
+        record_map: &mut CountingRecordMapEnum,
     ) -> Result<Vec<(SetAction, ProcessorRecord)>, PipelineError> {
         match (self.op, self.quantifier) {
             (SetOperator::Union, SetQuantifier::All) => Ok(vec![(action, record)]),
@@ -43,7 +43,7 @@ impl SetOperation {
         &self,
         action: SetAction,
         record: ProcessorRecord,
-        record_map: &mut CountingBloomFilter,
+        record_map: &mut CountingRecordMapEnum,
     ) -> Result<Vec<(SetAction, ProcessorRecord)>, PipelineError> {
         match action {
             SetAction::Insert => self.union_insert(action, record, record_map),
@@ -55,7 +55,7 @@ impl SetOperation {
         &self,
         action: SetAction,
         record: ProcessorRecord,
-        record_map: &mut CountingBloomFilter,
+        record_map: &mut CountingRecordMapEnum,
     ) -> Result<Vec<(SetAction, ProcessorRecord)>, PipelineError> {
         let _count = self.update_map(record.clone(), false, record_map);
         if _count == 1 {
@@ -69,7 +69,7 @@ impl SetOperation {
         &self,
         action: SetAction,
         record: ProcessorRecord,
-        record_map: &mut CountingBloomFilter,
+        record_map: &mut CountingRecordMapEnum,
     ) -> Result<Vec<(SetAction, ProcessorRecord)>, PipelineError> {
         let _count = self.update_map(record.clone(), true, record_map);
         if _count == 0 {
@@ -83,8 +83,8 @@ impl SetOperation {
         &self,
         record: ProcessorRecord,
         decr: bool,
-        record_map: &mut CountingBloomFilter,
-    ) -> u32 {
+        record_map: &mut CountingRecordMapEnum,
+    ) -> u64 {
         if decr {
             record_map.remove(&record);
         } else {

--- a/dozer-sql/src/pipeline/product/set/record_map.rs
+++ b/dozer-sql/src/pipeline/product/set/record_map.rs
@@ -1,0 +1,158 @@
+use bloom::{CountingBloomFilter, ASMS};
+use dozer_core::processor_record::ProcessorRecord;
+use enum_dispatch::enum_dispatch;
+use std::collections::HashMap;
+
+#[enum_dispatch(CountingRecordMap)]
+pub enum CountingRecordMapEnum {
+    AccurateCountingRecordMap,
+    ProbabilisticCountingRecordMap,
+}
+
+#[enum_dispatch]
+pub trait CountingRecordMap {
+    /// Inserts a record, or increases its insertion count if it already exixts in the map.
+    fn insert(&mut self, record: &ProcessorRecord);
+
+    /// Decreases the insertion count of a record, and removes it if the count reaches zero.
+    fn remove(&mut self, record: &ProcessorRecord);
+
+    /// Returns an estimate of the number of times this record has been inserted into the filter.
+    /// Depending on the implementation, this number may not be accurate.
+    fn estimate_count(&self, record: &ProcessorRecord) -> u64;
+
+    /// Clears the map, removing all records.
+    fn clear(&mut self);
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccurateCountingRecordMap {
+    map: HashMap<ProcessorRecord, u64>,
+}
+
+impl AccurateCountingRecordMap {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+}
+
+impl CountingRecordMap for AccurateCountingRecordMap {
+    fn insert(&mut self, record: &ProcessorRecord) {
+        let count = self.map.entry(record.clone()).or_insert(0);
+        if *count < u64::max_value() {
+            *count += 1;
+        }
+    }
+
+    fn remove(&mut self, record: &ProcessorRecord) {
+        if let Some(count) = self.map.get_mut(record) {
+            *count -= 1;
+            if *count == 0 {
+                self.map.remove(record);
+            }
+        }
+    }
+
+    fn estimate_count(&self, record: &ProcessorRecord) -> u64 {
+        self.map.get(record).copied().unwrap_or(0)
+    }
+
+    fn clear(&mut self) {
+        self.map.clear();
+    }
+}
+
+pub struct ProbabilisticCountingRecordMap {
+    map: CountingBloomFilter,
+}
+
+impl ProbabilisticCountingRecordMap {
+    const BITS_PER_ENTRY: usize = 8;
+    const FALSE_POSITIVE_RATE: f32 = 0.01;
+    const EXPECTED_NUM_ITEMS: u32 = 10000000;
+
+    pub fn new() -> Self {
+        Self {
+            map: CountingBloomFilter::with_rate(
+                Self::BITS_PER_ENTRY,
+                Self::FALSE_POSITIVE_RATE,
+                Self::EXPECTED_NUM_ITEMS,
+            ),
+        }
+    }
+}
+
+impl CountingRecordMap for ProbabilisticCountingRecordMap {
+    fn insert(&mut self, record: &ProcessorRecord) {
+        self.map.insert(record);
+    }
+
+    fn remove(&mut self, record: &ProcessorRecord) {
+        self.map.remove(record);
+    }
+
+    fn estimate_count(&self, record: &ProcessorRecord) -> u64 {
+        self.map.estimate_count(record) as u64
+    }
+
+    fn clear(&mut self) {
+        self.map.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dozer_core::processor_record::{ProcessorRecord, ProcessorRecordStore};
+    use dozer_types::types::{Field, Record};
+
+    use super::{
+        AccurateCountingRecordMap, CountingRecordMap, CountingRecordMapEnum,
+        ProbabilisticCountingRecordMap,
+    };
+
+    fn test_map(mut map: CountingRecordMapEnum) {
+        let record_store = ProcessorRecordStore::new().unwrap();
+        let make_record = |fields: Vec<Field>| -> ProcessorRecord {
+            record_store.create_record(&Record::new(fields)).unwrap()
+        };
+
+        let a = make_record(vec![Field::String('a'.into())]);
+        let b = make_record(vec![Field::String('b'.into())]);
+
+        assert_eq!(map.estimate_count(&a), 0);
+        assert_eq!(map.estimate_count(&b), 0);
+
+        map.insert(&a);
+        map.insert(&b);
+        assert_eq!(map.estimate_count(&a), 1);
+        assert_eq!(map.estimate_count(&b), 1);
+
+        map.insert(&b);
+        map.insert(&b);
+        assert_eq!(map.estimate_count(&a), 1);
+        assert_eq!(map.estimate_count(&b), 3);
+
+        map.remove(&b);
+        assert_eq!(map.estimate_count(&a), 1);
+        assert_eq!(map.estimate_count(&b), 2);
+
+        map.remove(&a);
+        assert_eq!(map.estimate_count(&a), 0);
+        assert_eq!(map.estimate_count(&b), 2);
+
+        map.clear();
+        assert_eq!(map.estimate_count(&a), 0);
+        assert_eq!(map.estimate_count(&b), 0);
+    }
+
+    #[test]
+    fn test_maps() {
+        let accurate_map = AccurateCountingRecordMap::new().into();
+        test_map(accurate_map);
+
+        let probabilistic_map = ProbabilisticCountingRecordMap::new().into();
+        test_map(probabilistic_map);
+    }
+}

--- a/dozer-sql/src/pipeline/product/set/set_factory.rs
+++ b/dozer-sql/src/pipeline/product/set/set_factory.rs
@@ -20,12 +20,21 @@ use super::set_processor::SetProcessor;
 pub struct SetProcessorFactory {
     id: String,
     set_quantifier: SetQuantifier,
+    enable_probabilistic_optimizations: bool,
 }
 
 impl SetProcessorFactory {
     /// Creates a new [`FromProcessorFactory`].
-    pub fn new(id: String, set_quantifier: SetQuantifier) -> Self {
-        Self { id, set_quantifier }
+    pub fn new(
+        id: String,
+        set_quantifier: SetQuantifier,
+        enable_probabilistic_optimizations: bool,
+    ) -> Self {
+        Self {
+            id,
+            set_quantifier,
+            enable_probabilistic_optimizations,
+        }
     }
 }
 
@@ -81,6 +90,7 @@ impl ProcessorFactory<SchemaSQLContext> for SetProcessorFactory {
                 op: SetOperator::Union,
                 quantifier: self.set_quantifier,
             },
+            self.enable_probabilistic_optimizations,
         )?))
     }
 }

--- a/dozer-sql/src/pipeline/tests/builder_test.rs
+++ b/dozer-sql/src/pipeline/tests/builder_test.rs
@@ -190,7 +190,7 @@ impl Sink for TestSink {
 
 #[tokio::test]
 async fn test_pipeline_builder() {
-    let mut pipeline = AppPipeline::new();
+    let mut pipeline = AppPipeline::new_with_default_flags();
     let context = statement_to_pipeline(
         "SELECT COUNT(Spending), users.Country \
         FROM users \

--- a/dozer-sql/src/pipeline/utils/mod.rs
+++ b/dozer-sql/src/pipeline/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod record_hashtable_key;

--- a/dozer-sql/src/pipeline/utils/record_hashtable_key.rs
+++ b/dozer-sql/src/pipeline/utils/record_hashtable_key.rs
@@ -1,0 +1,32 @@
+use ahash::AHasher;
+use dozer_types::types::Field;
+use std::hash::{Hash, Hasher};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum RecordKey {
+    Accurate(Vec<Field>),
+    Hash(u64),
+}
+
+pub fn get_record_hash<'a, I>(fields_iter: I) -> u64
+where
+    I: Iterator<Item = &'a Field>,
+{
+    let mut hasher = AHasher::default();
+    for field in fields_iter {
+        field.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+#[test]
+fn test_record_hash() {
+    let record_a = vec![Field::Int(1), Field::String("a".into())];
+    let record_b = vec![Field::Int(2), Field::String("b".into())];
+
+    let hash_a = get_record_hash(record_a.iter());
+    let hash_b = get_record_hash(record_b.iter());
+
+    assert_ne!(record_a, record_b);
+    assert_ne!(hash_a, hash_b);
+}

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -291,7 +291,7 @@ impl TestPipeline {
         schemas: HashMap<String, Schema>,
         ops: Vec<(String, Operation)>,
     ) -> Result<TestPipeline, ExecutionError> {
-        let mut pipeline = AppPipeline::new();
+        let mut pipeline = AppPipeline::new_with_default_flags();
 
         let transform_response =
             statement_to_pipeline(&sql, &mut pipeline, Some("results".to_string())).unwrap();

--- a/dozer-types/protos/cloud_types.proto
+++ b/dozer-types/protos/cloud_types.proto
@@ -18,6 +18,13 @@ message Flags {
   bool grpc_web = 2;
   bool push_events = 3;
   bool authenticate_server_reflection = 4;
+  EnableProbabilisticOptimizations enable_probabilistic_optimizations = 5;
+}
+
+message EnableProbabilisticOptimizations {
+  bool in_sets = 1;
+  bool in_joins = 2;
+  bool in_aggregations = 3;
 }
 
 message Connection {

--- a/dozer-types/src/models/flags.rs
+++ b/dozer-types/src/models/flags.rs
@@ -19,6 +19,29 @@ pub struct Flags {
     #[prost(bool, tag = "4", default = false)]
     #[serde(default = "default_false")]
     pub authenticate_server_reflection: bool,
+
+    /// probablistic optimizations reduce memory consumption at the expense of accuracy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[prost(message, optional, tag = "5")]
+    pub enable_probabilistic_optimizations: Option<EnableProbabilisticOptimizations>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, prost::Message)]
+pub struct EnableProbabilisticOptimizations {
+    /// enable probabilistic optimizations in set operations (UNION, EXCEPT, INTERSECT); Default: false
+    #[prost(bool, tag = "1", default = false)]
+    #[serde(default = "default_false")]
+    pub in_sets: bool,
+
+    /// enable probabilistic optimizations in JOIN operations; Default: false
+    #[prost(bool, tag = "2", default = false)]
+    #[serde(default = "default_false")]
+    pub in_joins: bool,
+
+    /// enable probabilistic optimizations in aggregations (SUM, COUNT, MIN, etc.); Default: false
+    #[prost(bool, tag = "3", default = false)]
+    #[serde(default = "default_false")]
+    pub in_aggregations: bool,
 }
 
 fn default_true() -> bool {

--- a/dozer-types/src/tests/flags_config_yaml_deserialize.rs
+++ b/dozer-types/src/tests/flags_config_yaml_deserialize.rs
@@ -1,4 +1,7 @@
-use crate::models::{config::Config, flags::Flags};
+use crate::models::{
+    config::Config,
+    flags::{EnableProbabilisticOptimizations, Flags},
+};
 
 #[test]
 fn test_partial_flag_config_input() {
@@ -41,6 +44,16 @@ fn test_flags_default() {
             grpc_web: true,
             push_events: true,
             authenticate_server_reflection: false,
+            enable_probabilistic_optimizations: None,
         }
     );
+
+    assert_eq!(
+        EnableProbabilisticOptimizations::default(),
+        EnableProbabilisticOptimizations {
+            in_sets: false,
+            in_joins: false,
+            in_aggregations: false
+        }
+    )
 }


### PR DESCRIPTION
Resolves #1875. 

Probabilistic optimization sacrifices accuracy in order to reduce memory consumption. In certain parts of the pipeline, a Bloom Filter is used ([set_processor](https://github.com/getdozer/dozer/blob/2e3ba96c3f4bdf9a691747191ab15617564d8ca2/dozer-sql/src/pipeline/product/set/set_processor.rs#L20)), while in other parts, hash tables that store only the hash of the keys instead of the full keys are used ([aggregation_processor](https://github.com/getdozer/dozer/blob/2e3ba96c3f4bdf9a691747191ab15617564d8ca2/dozer-sql/src/pipeline/aggregation/processor.rs#L59) and [join_processor](https://github.com/getdozer/dozer/blob/2e3ba96c3f4bdf9a691747191ab15617564d8ca2/dozer-sql/src/pipeline/product/join/operator.rs#L57-L58)).

This PR makes these optimizations disabled by default and offers user-configurable flags to enable each of these optimizations separately.

This is an example of how to turn-on probabilistic optimizations for each processor in the Dozer configuration.

```yaml
flags:
  enable_probabilistic_optimizations:
    in_sets: true  # enable probabilistic optimizations in set operations (UNION, EXCEPT, INTERSECT); Default: false
    in_joins: true  # enable probabilistic optimizations in JOIN operations; Default: false
    in_aggregations: true  # enable probabilistic optimizations in aggregations (SUM, COUNT, MIN, etc.); Default: false
```