### PR TITLE
chore: setup MySQL and MariaDB services in the CI

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -40,19 +40,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      mysql:
-        image: mysql:8
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: mysql
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_DATABASE: test
-        options: >-
-          --health-cmd "mysqladmin ping -uroot --password=mysql"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - name: Configure AWS credentials
@@ -107,6 +94,8 @@ jobs:
         uses: supercharge/mongodb-github-action@1.8.0
 
       - uses: ./.github/workflows/setup-snowflake-and-kafka
+
+      - uses: ./.github/workflows/setup-mysql-and-mariadb
 
       - name: Run connectors tests
         env:

--- a/.github/workflows/setup-mysql-and-mariadb/action.yaml
+++ b/.github/workflows/setup-mysql-and-mariadb/action.yaml
@@ -1,0 +1,20 @@
+name: Setup MySQL and MariaDB
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run MySQL
+      shell: bash
+      run: |
+        docker run -d --name mysql \
+            -e MYSQL_ROOT_PASSWORD=mysql -e MYSQL_ROOT_HOST=% -e MYSQL_DATABASE=test \
+            -p 3306:3306 \
+            mysql:8 --log-bin --binlog-format=row
+
+    - name: Run MariaDB
+      shell: bash
+      run: |
+        docker run -d --name mariadb \
+            -e MARIADB_ROOT_PASSWORD=mariadb -e MARIADB_ROOT_HOST=% -e MARIADB_DATABASE=test \
+            -p 3307:3306 \
+            mariadb:11 --log-bin --binlog-format=row


### PR DESCRIPTION
The MySQL connector should be tested against MariaDB as well, because it has been failing recently on MariaDB.

#1867 depends on this.