### PR TITLE
Write dozer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dozer-config.test.*
 log4rs.yaml
 .DS_Store
 queries
+dozer.lock
 
 .dozer/
 logs/

--- a/dozer-cli/src/errors.rs
+++ b/dozer-cli/src/errors.rs
@@ -128,6 +128,9 @@ pub enum CliError {
     MissingConfigOverride(String),
     #[error("Failed to deserialize config from json: {0}")]
     DeserializeConfigFromJson(#[source] serde_json::Error),
+    // Generic IO error
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 #[derive(Error, Debug)]

--- a/dozer-cli/src/simple/build/contract/mod.rs
+++ b/dozer-cli/src/simple/build/contract/mod.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
 };
 
-use dozer_cache::dozer_log::{home_dir::BuildPath, schemas::EndpointSchema};
+use dozer_cache::dozer_log::schemas::EndpointSchema;
 use dozer_core::{
     dag_schemas::DagSchemas,
     daggy::{self, NodeIndex},
@@ -162,13 +162,13 @@ impl Contract {
         })
     }
 
-    pub fn serialize(&self, build_path: &BuildPath) -> Result<(), BuildError> {
-        serde_json_to_path(&build_path.dag_path, &self)?;
+    pub fn serialize(&self, path: &Path) -> Result<(), BuildError> {
+        serde_json_to_path(path, &self)?;
         Ok(())
     }
 
-    pub fn deserialize(build_path: &BuildPath) -> Result<Self, BuildError> {
-        serde_json_from_path(&build_path.dag_path)
+    pub fn deserialize(path: &Path) -> Result<Self, BuildError> {
+        serde_json_from_path(path)
     }
 }
 
@@ -222,6 +222,7 @@ fn serde_json_to_path(path: impl AsRef<Path>, value: &impl Serialize) -> Result<
     let file = OpenOptions::new()
         .create(true)
         .write(true)
+        .truncate(true)
         .open(path.as_ref())
         .map_err(|e| BuildError::FileSystem(path.as_ref().into(), e))?;
     serde_json::to_writer_pretty(file, value).map_err(BuildError::SerdeJson)

--- a/dozer-cli/src/simple/build/mod.rs
+++ b/dozer-cli/src/simple/build/mod.rs
@@ -16,11 +16,14 @@ pub use contract::{Contract, PipelineContract};
 pub async fn build(
     home_dir: &HomeDir,
     contract: &Contract,
+    existing_contract: Option<&Contract>,
     storage_config: &DataStorage,
 ) -> Result<(), BuildError> {
-    if let Some(build_id) = needs_build(home_dir, contract, storage_config).await? {
+    if let Some(build_id) =
+        new_build_id(home_dir, contract, existing_contract, storage_config).await?
+    {
         let build_name = build_id.name().to_string();
-        create_build(home_dir, build_id, contract)?;
+        build_endpoint_protos(home_dir, build_id, contract)?;
         info!("Created new build {build_name}");
     } else {
         info!("Building not needed");
@@ -28,9 +31,10 @@ pub async fn build(
     Ok(())
 }
 
-async fn needs_build(
+async fn new_build_id(
     home_dir: &HomeDir,
     contract: &Contract,
+    existing_contract: Option<&Contract>,
     storage_config: &DataStorage,
 ) -> Result<Option<BuildId>, BuildError> {
     let build_path = home_dir
@@ -38,6 +42,10 @@ async fn needs_build(
         .map_err(|(path, error)| BuildError::FileSystem(path.into(), error))?;
     let Some(build_path) = build_path else {
         return Ok(Some(BuildId::first()));
+    };
+
+    let Some(existing_contract) = existing_contract else {
+        return Ok(Some(build_path.id.next()));
     };
 
     let mut futures = vec![];
@@ -52,20 +60,18 @@ async fn needs_build(
     if !try_join_all(futures)
         .await?
         .into_iter()
-        .all(|is_empty| is_empty)
+        .all(std::convert::identity)
     {
         return Ok(Some(build_path.id.next()));
     }
 
-    let existing_contract = Contract::deserialize(&build_path)?;
     for (endpoint, schema) in &contract.endpoints {
         if let Some(existing_schema) = existing_contract.endpoints.get(endpoint) {
             if schema == existing_schema {
                 continue;
             }
-        } else {
-            return Ok(Some(build_path.id.next()));
         }
+        return Ok(Some(build_path.id.next()));
     }
     Ok(None)
 }
@@ -75,7 +81,7 @@ async fn is_empty(storage: Box<dyn Storage>, prefix: String) -> Result<bool, Bui
     Ok(objects.objects.is_empty())
 }
 
-fn create_build(
+fn build_endpoint_protos(
     home_dir: &HomeDir,
     build_id: BuildId,
     contract: &Contract,
@@ -103,8 +109,6 @@ fn create_build(
         build_path.descriptor_path.as_ref(),
         &resources,
     )?;
-
-    contract.serialize(&build_path)?;
 
     Ok(())
 }

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -1,4 +1,5 @@
 use super::executor::{run_dag_executor, Executor};
+use super::Contract;
 use crate::errors::OrchestrationError;
 use crate::pipeline::PipelineBuilder;
 use crate::shutdown::ShutdownReceiver;
@@ -15,10 +16,12 @@ use dozer_api::auth::{Access, Authorizer};
 use dozer_api::grpc::internal::internal_pipeline_server::start_internal_pipeline_server;
 use dozer_api::{grpc, rest, CacheEndpoint};
 use dozer_cache::cache::LmdbRwCacheManager;
+use dozer_cache::dozer_log::camino::Utf8PathBuf;
 use dozer_cache::dozer_log::home_dir::HomeDir;
 use dozer_core::app::AppPipeline;
 use dozer_core::dag_schemas::DagSchemas;
 use dozer_tracing::LabelsAndProgress;
+use dozer_types::constants::LOCK_FILE;
 use dozer_types::models::flags::default_push_events;
 use tokio::select;
 
@@ -39,7 +42,6 @@ use futures::{FutureExt, StreamExt, TryFutureExt};
 use metrics::{describe_counter, describe_histogram};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
 
 use std::sync::Arc;
 use std::thread;
@@ -48,14 +50,21 @@ use tokio::sync::broadcast;
 
 #[derive(Clone)]
 pub struct SimpleOrchestrator {
+    pub base_directory: Utf8PathBuf,
     pub config: Config,
     pub runtime: Arc<Runtime>,
     pub labels: LabelsAndProgress,
 }
 
 impl SimpleOrchestrator {
-    pub fn new(config: Config, runtime: Arc<Runtime>, labels: LabelsAndProgress) -> Self {
+    pub fn new(
+        base_directory: Utf8PathBuf,
+        config: Config,
+        runtime: Arc<Runtime>,
+        labels: LabelsAndProgress,
+    ) -> Self {
         Self {
+            base_directory,
             config,
             runtime,
             labels,
@@ -173,14 +182,28 @@ impl SimpleOrchestrator {
         Ok(())
     }
 
+    pub fn home_dir(&self) -> Utf8PathBuf {
+        self.base_directory.join(&self.config.home_dir)
+    }
+
+    pub fn cache_dir(&self) -> Utf8PathBuf {
+        self.base_directory.join(&self.config.cache_dir)
+    }
+
+    pub fn lockfile_path(&self) -> Utf8PathBuf {
+        self.base_directory.join(LOCK_FILE)
+    }
+
     pub fn run_apps(
         &mut self,
         shutdown: ShutdownReceiver,
         api_notifier: Option<Sender<bool>>,
     ) -> Result<(), OrchestrationError> {
-        let home_dir = HomeDir::new(self.config.home_dir.clone(), self.config.cache_dir.clone());
+        let home_dir = HomeDir::new(self.home_dir(), self.cache_dir());
+        let contract = Contract::deserialize(self.lockfile_path().as_std_path())?;
         let executor = self.runtime.block_on(Executor::new(
             &home_dir,
+            &contract,
             &self.config.connections,
             &self.config.sources,
             self.config.sql.as_deref(),
@@ -270,7 +293,9 @@ impl SimpleOrchestrator {
         force: bool,
         shutdown: ShutdownReceiver,
     ) -> Result<(), OrchestrationError> {
-        let home_dir = HomeDir::new(self.config.home_dir.clone(), self.config.cache_dir.clone());
+        let home_dir = self.home_dir();
+        let cache_dir = self.cache_dir();
+        let home_dir = HomeDir::new(home_dir, cache_dir);
 
         info!(
             "Initiating app: {}",
@@ -327,10 +352,19 @@ impl SimpleOrchestrator {
             enable_on_event,
         )?;
 
+        let contract_path = self.lockfile_path();
+        let existing_contract = Contract::deserialize(contract_path.as_std_path()).ok();
+
         // Run build
         let storage_config = get_storage_config(&self.config);
-        self.runtime
-            .block_on(build::build(&home_dir, &contract, &storage_config))?;
+        self.runtime.block_on(build::build(
+            &home_dir,
+            &contract,
+            existing_contract.as_ref(),
+            &storage_config,
+        ))?;
+
+        contract.serialize(contract_path.as_std_path())?;
 
         Ok(())
     }
@@ -338,16 +372,16 @@ impl SimpleOrchestrator {
     // Cleaning the entire folder as there will be inconsistencies
     // between pipeline, cache and generated proto files.
     pub fn clean(&mut self) -> Result<(), OrchestrationError> {
-        let cache_dir = PathBuf::from(self.config.cache_dir.clone());
+        let cache_dir = self.cache_dir();
         if cache_dir.exists() {
             fs::remove_dir_all(&cache_dir)
-                .map_err(|e| ExecutionError::FileSystemError(cache_dir, e))?;
+                .map_err(|e| ExecutionError::FileSystemError(cache_dir.into_std_path_buf(), e))?;
         };
 
-        let home_dir = PathBuf::from(self.config.home_dir.clone());
+        let home_dir = self.home_dir();
         if home_dir.exists() {
             fs::remove_dir_all(&home_dir)
-                .map_err(|e| ExecutionError::FileSystemError(home_dir, e))?;
+                .map_err(|e| ExecutionError::FileSystemError(home_dir.into_std_path_buf(), e))?;
         };
 
         Ok(())

--- a/dozer-log/src/home_dir.rs
+++ b/dozer-log/src/home_dir.rs
@@ -9,10 +9,10 @@ pub struct HomeDir {
 pub type Error = (Utf8PathBuf, std::io::Error);
 
 impl HomeDir {
-    pub fn new(home_dir: String, cache_dir: String) -> Self {
+    pub fn new(home_dir: Utf8PathBuf, cache_dir: Utf8PathBuf) -> Self {
         Self {
-            home_dir: home_dir.into(),
-            cache_dir: cache_dir.into(),
+            home_dir,
+            cache_dir,
         }
     }
 

--- a/dozer-tests/src/e2e_tests/runner/local.rs
+++ b/dozer-tests/src/e2e_tests/runner/local.rs
@@ -1,5 +1,6 @@
 use std::{path::Path, process::Command};
 
+use dozer_types::constants::LOCK_FILE;
 use dozer_utils::{
     process::{run_command, run_docker_compose},
     Cleanup,
@@ -49,6 +50,7 @@ impl Runner {
 
                     // Start dozer.
                     cleanups.push(Cleanup::RemoveDirectory(case.dozer_config.home_dir.clone()));
+                    cleanups.push(Cleanup::RemoveFile(LOCK_FILE.to_owned()));
                     cleanups.extend(spawn_dozer(&self.dozer_bin, &case.dozer_config_path));
 
                     // Run test case.
@@ -69,6 +71,7 @@ impl Runner {
                             ));
                         }
                         cleanups.push(Cleanup::RemoveDirectory(case.dozer_config.home_dir.clone()));
+                        cleanups.push(Cleanup::RemoveFile(LOCK_FILE.to_owned()));
 
                         (Command::new(&self.dozer_bin), cleanups)
                     },

--- a/dozer-tests/src/tests/e2e/mod.rs
+++ b/dozer-tests/src/tests/e2e/mod.rs
@@ -32,9 +32,7 @@ struct DozerE2eTest {
 impl DozerE2eTest {
     async fn new(config_str: &str) -> Self {
         let temp_dir = TempDir::new("tests").unwrap();
-        let mut config = serde_yaml::from_str::<Config>(config_str).unwrap();
-        config.home_dir = temp_dir.path().to_str().unwrap().to_string();
-        config.cache_dir = temp_dir.path().join("cache").to_str().unwrap().to_string();
+        let config = serde_yaml::from_str::<Config>(config_str).unwrap();
 
         let api_grpc = config
             .api
@@ -54,7 +52,12 @@ impl DozerE2eTest {
         }
 
         let runtime = Runtime::new().expect("Failed to create runtime");
-        let mut dozer = SimpleOrchestrator::new(config, Arc::new(runtime), Default::default());
+        let mut dozer = SimpleOrchestrator::new(
+            temp_dir.path().to_path_buf().try_into().unwrap(),
+            config,
+            Arc::new(runtime),
+            Default::default(),
+        );
         let (shutdown_sender, shutdown_receiver) = shutdown::new(&dozer.runtime);
         let dozer_thread = std::thread::spawn(move || {
             dozer.run_all(shutdown_receiver).unwrap();

--- a/dozer-types/src/constants.rs
+++ b/dozer-types/src/constants.rs
@@ -4,3 +4,4 @@ pub const DEFAULT_CONFIG_PATH_PATTERNS: &[&str] = &["./dozer-config.*", "./queri
 pub const DEFAULT_CLOUD_TARGET_URL: &str = "https://api.dev.getdozer.io";
 pub const DEFAULT_QUERIES_DIRECTORY: &str = "queries";
 pub const DEFAULT_LAMBDAS_DIRECTORY: &str = "lambdas";
+pub const LOCK_FILE: &str = "dozer.lock";

--- a/dozer-utils/src/cleanup.rs
+++ b/dozer-utils/src/cleanup.rs
@@ -5,6 +5,7 @@ use dozer_types::log::error;
 #[must_use]
 pub enum Cleanup {
     RemoveDirectory(String),
+    RemoveFile(String),
     KillProcess(Child),
     DockerCompose(String),
 }
@@ -15,6 +16,11 @@ impl Drop for Cleanup {
             Cleanup::RemoveDirectory(dir) => {
                 if let Err(e) = std::fs::remove_dir_all(&dir) {
                     error!("Failed to remove directory {}: {}", dir, e);
+                }
+            }
+            Cleanup::RemoveFile(file) => {
+                if let Err(e) = std::fs::remove_file(&file) {
+                    error!("Failed to remove file {}: {}", file, e);
                 }
             }
             Cleanup::KillProcess(child) => {


### PR DESCRIPTION
Currently, this always writes the lock file to the current working directory.
Ideally we would follow the `dozer-config.yaml` around, but that is currently
impractical because of the implementation of the `-c` flag, combining `*.sql` and
`dozer-config.*`.
