### PR TITLE
fix: resume connectors on network errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,6 +2666,7 @@ version = "0.1.35"
 dependencies = [
  "base64 0.21.0",
  "bson",
+ "bytes",
  "chrono",
  "criterion",
  "crossbeam",

--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -50,6 +50,7 @@ mysql_async = { version = "0.32.2", default-features = false, features = ["defau
 mysql_common = { version = "0.30", default-features = false, features = ["chrono", "rust_decimal"] }
 chrono = "0.4.26"
 geozero = { version = "0.10.0", default-features = false, features = ["with-wkb"] }
+bytes = "1.4.0"
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/dozer-ingestion/src/connectors/kafka/connector.rs
+++ b/dozer-ingestion/src/connectors/kafka/connector.rs
@@ -141,19 +141,14 @@ async fn run(
     ingestor: &Ingestor,
     schema_registry_url: &Option<String>,
 ) -> Result<(), ConnectorError> {
-    let con: BaseConsumer = ClientConfig::new()
+    let mut client_config = ClientConfig::new();
+    client_config
         .set("bootstrap.servers", broker)
         .set("group.id", "dozer")
-        .set("enable.auto.commit", "true")
-        .create()
-        .map_err(KafkaConnectionError)?;
-
-    let topics: Vec<&str> = tables.iter().map(|t| t.name.as_ref()).collect();
-    con.subscribe(topics.iter().as_slice())
-        .map_err(KafkaConnectionError)?;
+        .set("enable.auto.commit", "true");
 
     let consumer = StreamConsumerBasic::default();
     consumer
-        .run(con, ingestor, tables, schema_registry_url)
+        .run(client_config, ingestor, tables, schema_registry_url)
         .await
 }

--- a/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
@@ -6,6 +6,7 @@ use crate::connectors::{CdcType, SourceSchema};
 use crate::errors::KafkaError::{JsonDecodeError, SchemaRegistryFetchError};
 use crate::errors::KafkaSchemaError::TypeNotSupported;
 use crate::errors::{ConnectorError, KafkaError, KafkaSchemaError};
+use dozer_types::log::error;
 use dozer_types::serde_json;
 use dozer_types::serde_json::Value;
 use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
@@ -65,13 +66,21 @@ impl SchemaRegistry {
         table_name: &str,
         is_key: bool,
     ) -> Result<DebeziumSchemaStruct, KafkaError> {
-        let schema_result =
-            schema_registry_converter::async_impl::schema_registry::get_schema_by_subject(
+        let schema_result = loop {
+            match schema_registry_converter::async_impl::schema_registry::get_schema_by_subject(
                 sr_settings,
                 &SubjectNameStrategy::TopicNameStrategy(table_name.to_string(), is_key),
             )
             .await
-            .map_err(SchemaRegistryFetchError)?;
+            {
+                Ok(schema_result) => break schema_result,
+                Err(err) if err.retriable => {
+                    error!("schema registry fetch error {err}. retrying...");
+                    continue;
+                }
+                Err(err) => return Err(SchemaRegistryFetchError(err)),
+            }
+        };
 
         serde_json::from_str::<DebeziumSchemaStruct>(&schema_result.schema).map_err(JsonDecodeError)
     }

--- a/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
+++ b/dozer-ingestion/src/connectors/kafka/debezium/schema_registry.rs
@@ -75,7 +75,9 @@ impl SchemaRegistry {
             {
                 Ok(schema_result) => break schema_result,
                 Err(err) if err.retriable => {
-                    error!("schema registry fetch error {err}. retrying...");
+                    const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+                    error!("schema registry fetch error {err}. retrying in {RETRY_INTERVAL:?}...");
+                    tokio::time::sleep(RETRY_INTERVAL).await;
                     continue;
                 }
                 Err(err) => return Err(SchemaRegistryFetchError(err)),

--- a/dozer-ingestion/src/connectors/kafka/mod.rs
+++ b/dozer-ingestion/src/connectors/kafka/mod.rs
@@ -4,6 +4,7 @@ pub mod no_schema_registry_basic;
 pub mod schema_registry_basic;
 pub mod stream_consumer;
 pub mod stream_consumer_basic;
+mod stream_consumer_helper;
 #[cfg(any(test, feature = "debezium_bench"))]
 pub mod test_utils;
 #[cfg(test)]

--- a/dozer-ingestion/src/connectors/kafka/stream_consumer.rs
+++ b/dozer-ingestion/src/connectors/kafka/stream_consumer.rs
@@ -2,14 +2,14 @@ use crate::errors::ConnectorError;
 use crate::ingestion::Ingestor;
 
 use crate::connectors::TableInfo;
-use rdkafka::consumer::BaseConsumer;
+use rdkafka::ClientConfig;
 use tonic::async_trait;
 
 #[async_trait]
 pub trait StreamConsumer {
     async fn run(
         &self,
-        con: BaseConsumer,
+        client_config: ClientConfig,
         ingestor: &Ingestor,
         tables: Vec<TableInfo>,
         schema_registry_url: &Option<String>,

--- a/dozer-ingestion/src/connectors/kafka/stream_consumer_helper.rs
+++ b/dozer-ingestion/src/connectors/kafka/stream_consumer_helper.rs
@@ -1,0 +1,102 @@
+use crate::errors::ConnectorError;
+use crate::errors::KafkaError::KafkaConnectionError;
+use rdkafka::{
+    consumer::{BaseConsumer, Consumer},
+    message::BorrowedMessage,
+    util::Timeout,
+    ClientConfig, Message, Offset,
+};
+use std::collections::HashMap;
+
+pub struct StreamConsumerHelper;
+
+pub type OffsetsMap = HashMap<String, (i32, i64)>; // key: topic, value: (partition, offset)
+
+impl StreamConsumerHelper {
+    pub async fn start(
+        client_config: &ClientConfig,
+        topics: &[&str],
+    ) -> Result<BaseConsumer, ConnectorError> {
+        Self::resume_impl(client_config, topics, None).await
+    }
+
+    pub async fn resume(
+        client_config: &ClientConfig,
+        topics: &[&str],
+        offsets: &OffsetsMap,
+    ) -> Result<BaseConsumer, ConnectorError> {
+        Self::resume_impl(client_config, topics, Some(offsets)).await
+    }
+
+    pub fn update_offsets(offsets: &mut OffsetsMap, message: &BorrowedMessage<'_>) {
+        let _ = offsets.insert(
+            message.topic().into(),
+            (message.partition(), message.offset()),
+        );
+    }
+
+    async fn resume_impl(
+        client_config: &ClientConfig,
+        topics: &[&str],
+        offsets: Option<&OffsetsMap>,
+    ) -> Result<BaseConsumer, ConnectorError> {
+        loop {
+            match Self::try_resume(client_config, topics, offsets).await {
+                Ok(con) => return Ok(con),
+                Err(err) if is_network_failure(&err) => continue,
+                Err(err) => Err(KafkaConnectionError(err))?,
+            }
+        }
+    }
+
+    async fn try_resume(
+        client_config: &ClientConfig,
+        topics: &[&str],
+        offsets: Option<&OffsetsMap>,
+    ) -> Result<BaseConsumer, rdkafka::error::KafkaError> {
+        let con: BaseConsumer = client_config.create()?;
+        con.subscribe(topics.iter().as_slice())?;
+
+        if let Some(offsets) = offsets {
+            for (topic, &(partition, offset)) in offsets.iter() {
+                con.seek(topic, partition, Offset::Offset(offset), Timeout::Never)?;
+            }
+        }
+
+        Ok(con)
+    }
+}
+
+pub fn is_network_failure(err: &rdkafka::error::KafkaError) -> bool {
+    use rdkafka::error::KafkaError::*;
+    let error_code = match err {
+        ConsumerCommit(error_code) => error_code,
+        Flush(error_code) => error_code,
+        Global(error_code) => error_code,
+        GroupListFetch(error_code) => error_code,
+        MessageConsumption(error_code) => error_code,
+        MessageProduction(error_code) => error_code,
+        MetadataFetch(error_code) => error_code,
+        OffsetFetch(error_code) => error_code,
+        Rebalance(error_code) => error_code,
+        SetPartitionOffset(error_code) => error_code,
+        StoreOffset(error_code) => error_code,
+        MockCluster(error_code) => error_code,
+        Transaction(rdkafka_err) => return rdkafka_err.is_retriable(),
+        _ => todo!(),
+    };
+    use rdkafka::types::RDKafkaErrorCode::*;
+    matches!(
+        error_code,
+        Fail | BrokerTransportFailure
+            | Resolve
+            | MessageTimedOut
+            | AllBrokersDown
+            | OperationTimedOut
+            | TimedOutQueue
+            | Retry
+            | PollExceeded
+            | RequestTimedOut
+            | NetworkException
+    )
+}

--- a/dozer-ingestion/src/connectors/mysql/connection.rs
+++ b/dozer-ingestion/src/connectors/mysql/connection.rs
@@ -1,0 +1,198 @@
+use crate::retry_on_network_failure;
+use mysql_async::{prelude::Queryable, BinlogRequest, BinlogStream, Params, Pool};
+use mysql_common::{prelude::FromRow, Row};
+use tokio::sync::mpsc::Receiver;
+
+#[derive(Debug)]
+pub struct Conn {
+    pool: mysql_async::Pool,
+    inner: mysql_async::Conn,
+}
+
+impl Conn {
+    pub async fn new(pool: mysql_async::Pool) -> Result<Conn, mysql_async::Error> {
+        let conn = new_mysql_connection(&pool).await?;
+        Ok(Conn { pool, inner: conn })
+    }
+
+    pub async fn exec_first<'a: 'b, 'b, T, P>(
+        &'a mut self,
+        query: &str,
+        params: P,
+    ) -> Result<Option<T>, mysql_async::Error>
+    where
+        P: Into<Params> + Send + Copy + 'b,
+        T: FromRow + Send + 'static,
+    {
+        retry_on_network_failure!(
+            "query",
+            self.inner.exec_first(query, params).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub fn exec_iter(&mut self, query: String, params: Vec<mysql_common::Value>) -> QueryResult {
+        exec_iter_impl(self.pool.clone(), query, params)
+    }
+
+    #[allow(unused)]
+    pub async fn exec_drop<'a: 'b, 'b, P>(
+        &'a mut self,
+        query: &str,
+        params: P,
+    ) -> Result<(), mysql_async::Error>
+    where
+        P: Into<Params> + Send + Copy + 'b,
+    {
+        retry_on_network_failure!(
+            "query",
+            self.inner.exec_drop(query, params).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn query_drop(&mut self, query: &str) -> Result<(), mysql_async::Error> {
+        retry_on_network_failure!(
+            "query",
+            self.inner.query_drop(query).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn get_binlog_stream(
+        self,
+        request: BinlogRequest<'_>,
+    ) -> Result<BinlogStream, mysql_async::Error> {
+        let mut inner = self.inner;
+        retry_on_network_failure!(
+            "get_binlog_stream",
+            inner.get_binlog_stream(request.clone()).await,
+            is_network_failure,
+            inner = new_mysql_connection(&self.pool).await?
+        )
+    }
+
+    async fn reconnect(&mut self) -> Result<(), mysql_async::Error> {
+        self.inner = new_mysql_connection(&self.pool).await?;
+        Ok(())
+    }
+}
+
+async fn new_mysql_connection(pool: &Pool) -> Result<mysql_async::Conn, mysql_async::Error> {
+    retry_on_network_failure!("connect", pool.get_conn().await, is_network_failure)
+}
+
+pub fn is_network_failure(err: &mysql_async::Error) -> bool {
+    use mysql_async::DriverError::*;
+    use mysql_async::Error::*;
+    matches!(err, Driver(ConnectionClosed) | Io(_))
+}
+
+fn add_query_offset(query: &str, offset: u64) -> String {
+    assert!(query
+        .trim_start()
+        .get(0..7)
+        .map(|s| s.to_uppercase() == "SELECT ")
+        .unwrap_or(false));
+
+    if offset == 0 {
+        query.into()
+    } else {
+        format!("{query} OFFSET {offset}")
+    }
+}
+
+fn exec_iter_impl(pool: Pool, query: String, params: Vec<mysql_common::Value>) -> QueryResult {
+    // this is basically a generator/coroutine using a channel to communicate the results
+    let (sender, receiver) = tokio::sync::mpsc::channel(10);
+
+    tokio::spawn(async move {
+        let mut cursor_position: u64 = 0;
+        'main: loop {
+            let mut conn = match new_mysql_connection(&pool).await {
+                Ok(conn) => conn,
+                Err(err) => {
+                    let _ = sender.send(Err(err)).await;
+                    break;
+                }
+            };
+            let mut rows = match retry_on_network_failure!(
+                "query",
+                conn.exec_iter(add_query_offset(&query, cursor_position), &params)
+                    .await,
+                is_network_failure,
+                continue 'main
+            ) {
+                Ok(rows) => rows,
+                Err(err) => {
+                    let _ = sender.send(Err(err)).await;
+                    break;
+                }
+            };
+            loop {
+                let result = retry_on_network_failure!(
+                    "query",
+                    rows.next().await,
+                    is_network_failure,
+                    continue 'main
+                );
+                let stop = result.is_err() || result.as_ref().unwrap().is_none();
+                if sender.send(result).await.is_err() {
+                    break;
+                }
+                if stop {
+                    break;
+                }
+                cursor_position += 1;
+            }
+            break;
+        }
+    });
+
+    QueryResult::new(receiver)
+}
+
+pub struct QueryResult {
+    receiver: Receiver<Result<Option<Row>, mysql_async::Error>>,
+}
+
+impl QueryResult {
+    pub fn new(receiver: Receiver<Result<Option<Row>, mysql_async::Error>>) -> Self {
+        Self { receiver }
+    }
+
+    pub async fn next(&mut self) -> Option<Result<Row, mysql_async::Error>> {
+        self.receiver.recv().await?.transpose()
+    }
+
+    pub async fn map<F, U>(&mut self, mut fun: F) -> Result<Vec<U>, mysql_async::Error>
+    where
+        F: FnMut(Row) -> U,
+    {
+        let mut acc = Vec::new();
+        while let Some(result) = self.next().await {
+            let row = result?;
+            acc.push(fun(mysql_async::from_row(row)));
+        }
+        Ok(acc)
+    }
+
+    pub async fn reduce<T, F, U>(
+        &mut self,
+        mut init: U,
+        mut fun: F,
+    ) -> Result<U, mysql_async::Error>
+    where
+        F: FnMut(U, T) -> U,
+        T: FromRow + Send + 'static,
+    {
+        while let Some(result) = self.next().await {
+            let row = result?;
+            init = fun(init, mysql_async::from_row(row));
+        }
+        Ok(init)
+    }
+}

--- a/dozer-ingestion/src/connectors/mysql/mod.rs
+++ b/dozer-ingestion/src/connectors/mysql/mod.rs
@@ -1,4 +1,5 @@
 mod binlog;
+mod connection;
 pub mod connector;
 mod conversion;
 pub(crate) mod helpers;

--- a/dozer-ingestion/src/connectors/postgres/connection.rs
+++ b/dozer-ingestion/src/connectors/postgres/connection.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod helper;
 mod tables_validator;
 pub mod validator;

--- a/dozer-ingestion/src/connectors/postgres/connection/client.rs
+++ b/dozer-ingestion/src/connectors/postgres/connection/client.rs
@@ -1,0 +1,260 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{ready, Poll};
+
+use futures::future::BoxFuture;
+use futures::lock::Mutex;
+use futures::stream::BoxStream;
+use futures::Stream;
+use tokio_postgres::types::ToSql;
+use tokio_postgres::{Config, CopyBothDuplex, Row, SimpleQueryMessage, Statement, ToStatement};
+
+use super::helper;
+use crate::connectors::postgres::connection::helper::is_network_failure;
+use crate::errors::PostgresConnectorError;
+use crate::retry_on_network_failure;
+
+#[derive(Debug)]
+pub struct Client {
+    config: tokio_postgres::Config,
+    inner: tokio_postgres::Client,
+}
+
+impl Client {
+    pub fn new(config: Config, client: tokio_postgres::Client) -> Self {
+        Self {
+            config,
+            inner: client,
+        }
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    pub async fn prepare(&mut self, query: &str) -> Result<Statement, tokio_postgres::Error> {
+        retry_on_network_failure!(
+            "prepare",
+            self.inner.prepare(query).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn simple_query(
+        &mut self,
+        query: &str,
+    ) -> Result<Vec<SimpleQueryMessage>, tokio_postgres::Error> {
+        retry_on_network_failure!(
+            "simple_query",
+            self.inner.simple_query(query).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn query_one<T>(
+        &mut self,
+        statement: &T,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Row, tokio_postgres::Error>
+    where
+        T: ?Sized + ToStatement,
+    {
+        retry_on_network_failure!(
+            "query_one",
+            self.inner.query_one(statement, params).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn query<T>(
+        &mut self,
+        statement: &T,
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Vec<Row>, tokio_postgres::Error>
+    where
+        T: ?Sized + ToStatement,
+    {
+        retry_on_network_failure!(
+            "query",
+            self.inner.query(statement, params).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn query_raw(
+        &mut self,
+        query: String,
+        params: Vec<String>,
+    ) -> Result<BoxStream<'static, Result<Row, tokio_postgres::Error>>, tokio_postgres::Error> {
+        let client = Self::connect(self.config.clone()).await?;
+        let row_stream = RowStream::new(client, query, params).await?;
+        Ok(Box::pin(row_stream))
+    }
+
+    pub async fn copy_both_simple<T>(
+        &mut self,
+        query: &str,
+    ) -> Result<CopyBothDuplex<T>, tokio_postgres::Error>
+    where
+        T: bytes::Buf + 'static + Send,
+    {
+        retry_on_network_failure!(
+            "copy_both_simple",
+            self.inner.copy_both_simple(query).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn batch_execute(&mut self, query: &str) -> Result<(), tokio_postgres::Error> {
+        retry_on_network_failure!(
+            "batch_execute",
+            self.inner.batch_execute(query).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+
+    pub async fn reconnect(&mut self) -> Result<(), tokio_postgres::Error> {
+        let new_client = Self::connect(self.config.clone()).await?;
+        self.inner = new_client.inner;
+        Ok(())
+    }
+
+    pub async fn connect(config: Config) -> Result<Client, tokio_postgres::Error> {
+        let client = match helper::connect(config).await {
+            Ok(client) => client,
+            Err(PostgresConnectorError::ConnectionFailure(err)) => return Err(err),
+            Err(err) => panic!("unexpected error {err}"),
+        };
+        Ok(client)
+    }
+
+    async fn query_raw_internal(
+        &mut self,
+        statement: Statement,
+        params: Vec<String>,
+    ) -> Result<tokio_postgres::RowStream, tokio_postgres::Error> {
+        retry_on_network_failure!(
+            "query_raw",
+            self.inner.query_raw(&statement, &params).await,
+            is_network_failure,
+            self.reconnect().await?
+        )
+    }
+}
+
+pub struct RowStream {
+    client: Arc<Mutex<Client>>,
+    query: String,
+    query_params: Vec<String>,
+    cursor_position: u64,
+    inner: Pin<Box<tokio_postgres::RowStream>>,
+    pending_resume: Option<
+        BoxFuture<'static, Result<(Client, tokio_postgres::RowStream), tokio_postgres::Error>>,
+    >,
+}
+
+impl RowStream {
+    pub async fn new(
+        mut client: Client,
+        query: String,
+        params: Vec<String>,
+    ) -> Result<Self, tokio_postgres::Error> {
+        let statement = client.prepare(&query).await?;
+        let inner = client.query_raw_internal(statement, params.clone()).await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+            query,
+            query_params: params,
+            cursor_position: 0,
+            inner: Box::pin(inner),
+            pending_resume: None,
+        })
+    }
+
+    fn resume(
+        &mut self,
+    ) -> BoxFuture<'static, Result<(Client, tokio_postgres::RowStream), tokio_postgres::Error>>
+    {
+        async fn resume_async(
+            client: Arc<Mutex<Client>>,
+            query: String,
+            params: Vec<String>,
+            offset: u64,
+        ) -> Result<(Client, tokio_postgres::RowStream), tokio_postgres::Error> {
+            let config = client.lock().await.config().clone();
+            // reconnect
+            let mut client = Client::connect(config).await?;
+            // send query with offset
+            let statement = client.prepare(&add_query_offset(&query, offset)).await?;
+            let row_stream = client.query_raw_internal(statement, params).await?;
+            Ok((client, row_stream))
+        }
+
+        Box::pin(resume_async(
+            self.client.clone(),
+            self.query.clone(),
+            self.query_params.clone(),
+            self.cursor_position,
+        ))
+    }
+}
+
+impl Stream for RowStream {
+    type Item = Result<Row, tokio_postgres::Error>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            if let Some(resume) = this.pending_resume.as_mut() {
+                match ready!(resume.as_mut().poll(cx)) {
+                    Ok((client, inner)) => {
+                        this.pending_resume = None;
+                        this.client = Arc::new(Mutex::new(client));
+                        this.inner = Box::pin(inner);
+                    }
+                    Err(err) => return Poll::Ready(Some(Err(err))),
+                }
+            }
+
+            match ready!(this.inner.as_mut().poll_next(cx)) {
+                Some(Ok(row)) => {
+                    this.cursor_position += 1;
+                    return Poll::Ready(Some(Ok(row)));
+                }
+                Some(Err(err)) => {
+                    if is_network_failure(&err) {
+                        this.pending_resume = Some(this.resume());
+                        continue;
+                    } else {
+                        return Poll::Ready(Some(Err(err)));
+                    }
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+fn add_query_offset(query: &str, offset: u64) -> String {
+    assert!(query
+        .trim_start()
+        .get(0..7)
+        .map(|s| s.to_uppercase() == "SELECT ")
+        .unwrap_or(false));
+
+    if offset == 0 {
+        query.into()
+    } else {
+        format!("{query} OFFSET {offset}")
+    }
+}

--- a/dozer-ingestion/src/connectors/postgres/connector.rs
+++ b/dozer-ingestion/src/connectors/postgres/connector.rs
@@ -15,8 +15,9 @@ use crate::connectors::postgres::schema::helper::{SchemaHelper, DEFAULT_SCHEMA_N
 use crate::errors::ConnectorError::PostgresConnectorError;
 use crate::errors::PostgresConnectorError::{CreatePublicationError, DropPublicationError};
 use tokio_postgres::config::ReplicationMode;
-use tokio_postgres::{Client, Config};
+use tokio_postgres::Config;
 
+use super::connection::client::Client;
 use super::connection::helper;
 
 #[derive(Clone, Debug)]
@@ -220,7 +221,7 @@ impl PostgresConnector {
 
     pub async fn create_publication(
         &self,
-        client: Client,
+        mut client: Client,
         table_identifiers: Option<&[TableIdentifier]>,
     ) -> Result<(), ConnectorError> {
         let publication_name = self.get_publication_name();

--- a/dozer-ingestion/src/connectors/postgres/schema/helper.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/helper.rs
@@ -153,7 +153,7 @@ impl SchemaHelper {
         tables: Option<&[ListOrFilterColumns]>,
     ) -> Result<RowsWithColumnsMap, PostgresConnectorError> {
         let mut tables_columns_map: HashMap<SchemaTableIdentifier, Vec<String>> = HashMap::new();
-        let client = helper::connect(self.conn_config.clone()).await?;
+        let mut client = helper::connect(self.conn_config.clone()).await?;
         let query = if let Some(tables) = tables {
             tables.iter().for_each(|t| {
                 if let Some(columns) = t.columns.clone() {

--- a/dozer-ingestion/src/connectors/postgres/schema/tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/schema/tests.rs
@@ -24,7 +24,7 @@ where
 #[serial]
 async fn test_connector_get_tables() {
     run_connector_test("postgres", |app_config| async move {
-        let client = get_client(app_config).await;
+        let mut client = get_client(app_config).await;
 
         let mut rng = rand::thread_rng();
 
@@ -59,7 +59,7 @@ async fn test_connector_get_tables() {
 #[serial]
 async fn test_connector_get_schema_with_selected_columns() {
     run_connector_test("postgres", |app_config| async move {
-        let client = get_client(app_config).await;
+        let mut client = get_client(app_config).await;
 
         let mut rng = rand::thread_rng();
 
@@ -94,7 +94,7 @@ async fn test_connector_get_schema_with_selected_columns() {
 #[serial]
 async fn test_connector_get_schema_without_selected_columns() {
     run_connector_test("postgres", |app_config| async move {
-        let client = get_client(app_config).await;
+        let mut client = get_client(app_config).await;
 
         let mut rng = rand::thread_rng();
 
@@ -134,7 +134,7 @@ async fn test_connector_get_schema_without_selected_columns() {
 #[serial]
 async fn test_connector_view_cannot_be_used() {
     run_connector_test("postgres", |app_config| async move {
-        let client = get_client(app_config).await;
+        let mut client = get_client(app_config).await;
 
         let mut rng = rand::thread_rng();
 

--- a/dozer-ingestion/src/connectors/postgres/snapshotter.rs
+++ b/dozer-ingestion/src/connectors/postgres/snapshotter.rs
@@ -43,7 +43,7 @@ impl<'a> PostgresSnapshotter<'a> {
         conn_config: tokio_postgres::Config,
         sender: Sender<Result<(usize, Operation), ConnectorError>>,
     ) -> Result<(), ConnectorError> {
-        let client_plain = connection_helper::connect(conn_config)
+        let mut client_plain = connection_helper::connect(conn_config)
             .await
             .map_err(PostgresConnectorError)?;
 
@@ -63,7 +63,7 @@ impl<'a> PostgresSnapshotter<'a> {
 
         let empty_vec: Vec<String> = Vec::new();
         let row_stream = client_plain
-            .query_raw(&stmt, empty_vec)
+            .query_raw(query, empty_vec)
             .await
             .map_err(|e| PostgresConnectorError(InvalidQueryError(e)))?;
         tokio::pin!(row_stream);
@@ -176,7 +176,7 @@ mod tests {
                 .as_ref()
                 .unwrap();
 
-            let test_client = TestPostgresClient::new(config).await;
+            let mut test_client = TestPostgresClient::new(config).await;
 
             let mut rng = rand::thread_rng();
             let table_name = format!("test_table_{}", rng.gen::<u32>());
@@ -234,7 +234,7 @@ mod tests {
                 .as_ref()
                 .unwrap();
 
-            let test_client = TestPostgresClient::new(config).await;
+            let mut test_client = TestPostgresClient::new(config).await;
 
             let mut rng = rand::thread_rng();
             let table_name = format!("test_table_{}", rng.gen::<u32>());

--- a/dozer-ingestion/src/connectors/postgres/test_utils.rs
+++ b/dozer-ingestion/src/connectors/postgres/test_utils.rs
@@ -5,7 +5,9 @@ use std::error::Error;
 use crate::connectors::postgres::replication_slot_helper::ReplicationSlotHelper;
 use dozer_types::models::config::Config;
 use std::str::FromStr;
-use tokio_postgres::{error::DbError, Client, Error as PostgresError, SimpleQueryMessage};
+use tokio_postgres::{error::DbError, Error as PostgresError, SimpleQueryMessage};
+
+use super::connection::client::Client;
 
 pub async fn get_client(app_config: Config) -> TestPostgresClient {
     let config = app_config
@@ -19,24 +21,24 @@ pub async fn get_client(app_config: Config) -> TestPostgresClient {
     TestPostgresClient::new(config).await
 }
 
-pub async fn create_slot(client_ref: &Client, slot_name: &str) -> PgLsn {
-    client_ref
+pub async fn create_slot(client_mut: &mut Client, slot_name: &str) -> PgLsn {
+    client_mut
         .simple_query("BEGIN READ ONLY ISOLATION LEVEL REPEATABLE READ;")
         .await
         .unwrap();
 
-    let created_lsn = ReplicationSlotHelper::create_replication_slot(client_ref, slot_name)
+    let created_lsn = ReplicationSlotHelper::create_replication_slot(client_mut, slot_name)
         .await
         .unwrap()
         .unwrap();
-    client_ref.simple_query("COMMIT;").await.unwrap();
+    client_mut.simple_query("COMMIT;").await.unwrap();
 
     PgLsn::from_str(&created_lsn).unwrap()
 }
 
 pub async fn retry_drop_active_slot(
     e: PostgresError,
-    client_ref: &Client,
+    client_mut: &mut Client,
     slot_name: &str,
 ) -> Result<Vec<SimpleQueryMessage>, PostgresError> {
     match e.source() {
@@ -46,12 +48,12 @@ pub async fn retry_drop_active_slot(
                 let err = db_error.to_string();
                 let parts = err.rsplit_once(' ').unwrap();
 
-                client_ref
+                client_mut
                     .simple_query(format!("select pg_terminate_backend('{}');", parts.1).as_ref())
                     .await
                     .unwrap();
 
-                ReplicationSlotHelper::drop_replication_slot(client_ref, slot_name).await
+                ReplicationSlotHelper::drop_replication_slot(client_mut, slot_name).await
             }
             _ => Err(e),
         },

--- a/dozer-ingestion/src/connectors/postgres/tests/client.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/client.rs
@@ -1,8 +1,8 @@
+use crate::connectors::postgres::connection::client::Client;
 use crate::connectors::postgres::connection::helper::{connect, map_connection_config};
 use dozer_types::models::connection::ConnectionConfig;
 use dozer_types::rust_decimal::Decimal;
 use std::fmt::Write;
-use tokio_postgres::Client;
 
 pub struct TestPostgresClient {
     client: Client,
@@ -30,11 +30,11 @@ impl TestPostgresClient {
         }
     }
 
-    pub async fn execute_query(&self, query: &str) {
+    pub async fn execute_query(&mut self, query: &str) {
         self.client.query(query, &[]).await.unwrap();
     }
 
-    pub async fn create_simple_table(&self, schema: &str, table_name: &str) {
+    pub async fn create_simple_table(&mut self, schema: &str, table_name: &str) {
         self.execute_query(&format!(
             "CREATE TABLE {schema}.{table_name}
             (   
@@ -47,7 +47,7 @@ impl TestPostgresClient {
         .await;
     }
 
-    pub async fn create_view(&self, schema: &str, table_name: &str, view_name: &str) {
+    pub async fn create_view(&mut self, schema: &str, table_name: &str, view_name: &str) {
         self.execute_query(&format!(
             "CREATE VIEW {schema}.{view_name} AS
             SELECT id, name
@@ -56,22 +56,22 @@ impl TestPostgresClient {
         .await;
     }
 
-    pub async fn drop_schema(&self, schema: &str) {
+    pub async fn drop_schema(&mut self, schema: &str) {
         self.execute_query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
             .await;
     }
 
-    pub async fn drop_table(&self, schema: &str, table_name: &str) {
+    pub async fn drop_table(&mut self, schema: &str, table_name: &str) {
         self.execute_query(&format!("DROP TABLE IF EXISTS {schema}.{table_name}"))
             .await;
     }
 
-    pub async fn create_schema(&self, schema: &str) {
+    pub async fn create_schema(&mut self, schema: &str) {
         self.drop_schema(schema).await;
         self.execute_query(&format!("CREATE SCHEMA {schema}")).await;
     }
 
-    pub async fn insert_rows(&self, table_name: &str, count: u64, offset: Option<u64>) {
+    pub async fn insert_rows(&mut self, table_name: &str, count: u64, offset: Option<u64>) {
         let offset = offset.map_or(0, |o| o);
         let mut buf = String::new();
         for i in 0..count {

--- a/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
+++ b/dozer-ingestion/src/connectors/postgres/tests/continue_replication_tests.rs
@@ -49,17 +49,17 @@ mod tests {
             connector.create_publication(client, None).await.unwrap();
 
             // Creating slot
-            let client = helper::connect(replication_conn_config.clone())
+            let mut client = helper::connect(replication_conn_config.clone())
                 .await
                 .unwrap();
             let slot_name = connector.get_slot_name();
-            let _parsed_lsn = create_slot(&client, &slot_name).await;
+            let _parsed_lsn = create_slot(&mut client, &slot_name).await;
 
             // let result = connector
             //     .can_start_from((u64::from(parsed_lsn), 0))
             //     .unwrap();
 
-            ReplicationSlotHelper::drop_replication_slot(&client, &slot_name)
+            ReplicationSlotHelper::drop_replication_slot(&mut client, &slot_name)
                 .await
                 .unwrap();
             // assert!(
@@ -83,7 +83,7 @@ mod tests {
                 .as_ref()
                 .unwrap();
 
-            let test_client = TestPostgresClient::new(config).await;
+            let mut test_client = TestPostgresClient::new(config).await;
             let mut rng = rand::thread_rng();
             let table_name = format!("test_table_{}", rng.gen::<u32>());
             let connector_name = format!("pg_connector_{}", rng.gen::<u32>());
@@ -114,12 +114,12 @@ mod tests {
                 .unwrap();
 
             // Creating slot
-            let client = helper::connect(replication_conn_config.clone())
+            let mut client = helper::connect(replication_conn_config.clone())
                 .await
                 .unwrap();
 
             let slot_name = connector.get_slot_name();
-            let _parsed_lsn = create_slot(&client, &slot_name).await;
+            let _parsed_lsn = create_slot(&mut client, &slot_name).await;
 
             // let config = IngestionConfig::default();
             // let (ingestor, mut iterator) = Ingestor::initialize_channel(config);
@@ -166,9 +166,10 @@ mod tests {
             //     }
             // }
 
-            if let Err(e) = ReplicationSlotHelper::drop_replication_slot(&client, &slot_name).await
+            if let Err(e) =
+                ReplicationSlotHelper::drop_replication_slot(&mut client, &slot_name).await
             {
-                retry_drop_active_slot(e, &client, &slot_name)
+                retry_drop_active_slot(e, &mut client, &slot_name)
                     .await
                     .unwrap();
             }

--- a/dozer-ingestion/src/lib.rs
+++ b/dozer-ingestion/src/lib.rs
@@ -3,3 +3,4 @@ pub mod errors;
 pub mod ingestion;
 #[cfg(test)]
 pub mod test_util;
+mod utils;

--- a/dozer-ingestion/src/test_util.rs
+++ b/dozer-ingestion/src/test_util.rs
@@ -20,7 +20,7 @@ async fn warm_up(app_config: &Config) {
             .port(replenished_config.port as u16)
             .ssl_mode(replenished_config.sslmode);
 
-        let client = TestPostgresClient::new_with_postgres_config(config).await;
+        let mut client = TestPostgresClient::new_with_postgres_config(config).await;
         client
             .execute_query(&format!(
                 "DROP DATABASE IF EXISTS {}",

--- a/dozer-ingestion/src/utils.rs
+++ b/dozer-ingestion/src/utils.rs
@@ -6,10 +6,12 @@ macro_rules! retry_on_network_failure {
                 ok @ Ok(_) => break ok,
                 Err(err) => {
                     if ($network_error_predicate)(&err) {
+                        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
                         dozer_types::log::error!(
-                            "network error during {}: {err:?}. retrying...",
+                            "network error during {}: {err:?}. retrying in {RETRY_INTERVAL:?}...",
                             $description
                         );
+                        tokio::time::sleep(RETRY_INTERVAL).await;
                         $($reconnect)?
                     } else {
                         break Err(err);

--- a/dozer-ingestion/src/utils.rs
+++ b/dozer-ingestion/src/utils.rs
@@ -1,0 +1,21 @@
+#[macro_export]
+macro_rules! retry_on_network_failure {
+    ($description:expr, $operation:expr, $network_error_predicate:expr $(, $reconnect:expr)?) => {
+        loop {
+            match $operation {
+                ok @ Ok(_) => break ok,
+                Err(err) => {
+                    if ($network_error_predicate)(&err) {
+                        dozer_types::log::error!(
+                            "network error during {}: {err:?}. retrying...",
+                            $description
+                        );
+                        $($reconnect)?
+                    } else {
+                        break Err(err);
+                    }
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
This PR includes MySQL, Postgres, and Kafka connectors, so far.

Covers three connectors from #1916.