### PR TITLE
chore: Refactor `QueryExpression` extractor implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "jsonwebtoken",
  "metrics",
  "openapiv3",
+ "pin-project",
  "prost",
  "prost-build",
  "prost-reflect",
@@ -2586,7 +2587,6 @@ dependencies = [
 name = "dozer-cache"
 version = "0.1.35"
 dependencies = [
- "actix-web",
  "ahash 0.8.3",
  "clap 4.4.1",
  "criterion",
@@ -5690,18 +5690,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dozer-api/Cargo.toml
+++ b/dozer-api/Cargo.toml
@@ -43,6 +43,7 @@ gethostname = "0.4.3"
 http-body = "0.4.5"
 bytes = "1.4.0"
 http = "0.2.9"
+pin-project = "1.1.3"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-cache/Cargo.toml
+++ b/dozer-cache/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["getdozer/dozer-dev"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dozer-types = {path = "../dozer-types"}
+dozer-types = { path = "../dozer-types" }
 dozer-storage = { path = "../dozer-storage" }
 dozer-log = { path = "../dozer-log" }
 dozer-tracing = { path = "../dozer-tracing" }
@@ -24,7 +24,6 @@ ahash = "0.8.3"
 metrics = "0.21.0"
 clap = { version = "4.4.1", features = ["derive"] }
 env_logger = "0.10.0"
-actix-web = "4.3.1"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/dozer-cache/src/cache/expression/mod.rs
+++ b/dozer-cache/src/cache/expression/mod.rs
@@ -1,11 +1,7 @@
 use dozer_types::serde::{Deserialize, Serialize};
-use dozer_types::serde_json;
 use dozer_types::serde_json::Value;
 mod query_helper;
 mod query_serde;
-use actix_web::{dev::Payload, Error, FromRequest, HttpMessage, HttpRequest};
-use futures::future::err;
-use futures::future::LocalBoxFuture;
 #[cfg(test)]
 mod tests;
 
@@ -72,32 +68,6 @@ impl QueryExpression {
             limit,
             skip,
         }
-    }
-}
-
-impl FromRequest for QueryExpression {
-    type Error = Error;
-    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
-
-    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
-        let req = req.clone();
-        let mut pl = _payload.take();
-        let content_type = req.content_type();
-        if !content_type.is_empty() && content_type != "application/json" {
-            return Box::pin(err(actix_web::error::UrlencodedError::ContentType.into()));
-        }
-        //execute query
-        Box::pin(async move {
-            let req_body = String::from_request(&req, &mut pl).await?;
-            if req_body.is_empty() {
-                return Ok(QueryExpression::with_no_limit());
-            }
-            let deserialized = serde_json::from_str::<QueryExpression>(&req_body);
-            match deserialized {
-                Ok(x) => Ok(x),
-                Err(x) => Err(actix_web::error::JsonPayloadError::Deserialize(x).into()),
-            }
-        })
     }
 }
 


### PR DESCRIPTION
Two changes:

- Implement `FromRequest` for a newtype `QueryExpressionExtractor` to avoid make `dozer-cache` depend on `actix-web`
- Use `Either` instead of `LocalBoxFuture` to avoid allocation