### PR TITLE
chore: Remove source state merging from `ReceiverLoop` to `EpochManager`

### DIFF
--- a/dozer-core/src/epoch/mod.rs
+++ b/dozer-core/src/epoch/mod.rs
@@ -4,25 +4,25 @@ use std::{
     time::SystemTime,
 };
 
-use dozer_types::node::{NodeHandle, OpIdentifier, SourceStates};
+use dozer_types::node::SourceStates;
 
 #[derive(Clone, Debug)]
 pub struct EpochCommonInfo {
     pub id: u64,
     pub checkpoint_writer: Option<Arc<CheckpointWriter>>,
+    pub source_states: Arc<SourceStates>,
 }
 
 #[derive(Clone, Debug)]
 pub struct Epoch {
     pub common_info: EpochCommonInfo,
-    pub details: SourceStates,
     pub decision_instant: SystemTime,
 }
 
 impl Epoch {
     pub fn new(
         id: u64,
-        details: SourceStates,
+        source_states: Arc<SourceStates>,
         checkpoint_writer: Option<Arc<CheckpointWriter>>,
         decision_instant: SystemTime,
     ) -> Self {
@@ -30,24 +30,15 @@ impl Epoch {
             common_info: EpochCommonInfo {
                 id,
                 checkpoint_writer,
+                source_states,
             },
-            details,
             decision_instant,
         }
     }
 
-    pub fn from(
-        common_info: EpochCommonInfo,
-        node_handle: NodeHandle,
-        txid: u64,
-        seq_in_tx: u64,
-        decision_instant: SystemTime,
-    ) -> Self {
+    pub fn from(common_info: EpochCommonInfo, decision_instant: SystemTime) -> Self {
         Self {
             common_info,
-            details: [(node_handle, OpIdentifier::new(txid, seq_in_tx))]
-                .into_iter()
-                .collect(),
             decision_instant,
         }
     }
@@ -55,12 +46,13 @@ impl Epoch {
 
 impl Display for Epoch {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let details_str = self
-            .details
+        let source_states = self
+            .common_info
+            .source_states
             .iter()
             .map(|e| format!("{} -> {}:{}", e.0, e.1.txid, e.1.seq_in_tx))
             .fold(String::new(), |a, b| a + ", " + b.as_str());
-        f.write_str(format!("epoch: {}, details: {}", self.common_info.id, details_str).as_str())
+        f.write_str(format!("epoch: {}, details: {}", self.common_info.id, source_states).as_str())
     }
 }
 

--- a/dozer-core/src/executor/receiver_loop.rs
+++ b/dozer-core/src/executor/receiver_loop.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::time::SystemTime;
 
 use crossbeam::channel::{Receiver, Select};
 use dozer_types::log::debug;
@@ -39,7 +38,7 @@ pub trait ReceiverLoop: Name {
         let mut port_states = vec![InputPortState::Open; receivers.len()];
 
         let mut commits_received: usize = 0;
-        let mut common_epoch = Epoch::new(0, Default::default(), None, SystemTime::now());
+        let mut epoch_id = 0;
 
         let mut sel = init_select(&receivers);
         loop {
@@ -53,25 +52,13 @@ pub trait ReceiverLoop: Name {
                     self.on_op(index, op)?;
                 }
                 ExecutorOperation::Commit { epoch } => {
-                    assert_eq!(epoch.common_info.id, common_epoch.common_info.id);
+                    assert_eq!(epoch.common_info.id, epoch_id);
                     commits_received += 1;
                     sel.remove(index);
-                    // Commits from all inputs ports must have the same decision instant.
-                    if commits_received > 1 {
-                        assert_eq!(common_epoch.decision_instant, epoch.decision_instant);
-                    }
-                    common_epoch.common_info = epoch.common_info;
-                    common_epoch.decision_instant = epoch.decision_instant;
-                    common_epoch.details.extend(epoch.details);
 
                     if commits_received == receivers.len() {
-                        self.on_commit(&common_epoch)?;
-                        common_epoch = Epoch::new(
-                            common_epoch.common_info.id + 1,
-                            Default::default(),
-                            None,
-                            SystemTime::now(),
-                        );
+                        self.on_commit(&epoch)?;
+                        epoch_id += 1;
                         commits_received = 0;
                         sel = init_select(&receivers);
                     }
@@ -108,7 +95,7 @@ fn init_select(receivers: &Vec<Receiver<ExecutorOperation>>) -> Select {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::swap;
+    use std::{mem::swap, sync::Arc, time::SystemTime};
 
     use crossbeam::channel::{unbounded, Sender};
     use dozer_types::{
@@ -230,21 +217,21 @@ mod tests {
     }
 
     #[test]
-    fn receiver_loop_merges_commit_epoch_and_increases_epoch_id() {
+    fn receiver_loop_increases_epoch_id() {
         let (mut test_loop, senders) = TestReceiverLoop::new(2);
-        let mut details = SourceStates::default();
-        details.insert(
+        let mut source_states = SourceStates::default();
+        source_states.insert(
             NodeHandle::new(None, "0".to_string()),
             OpIdentifier::new(0, 0),
         );
-        let decision_instant = SystemTime::now();
-        let mut epoch0 = Epoch::new(0, details, None, decision_instant);
-        let mut details = SourceStates::default();
-        details.insert(
+        source_states.insert(
             NodeHandle::new(None, "1".to_string()),
             OpIdentifier::new(0, 0),
         );
-        let mut epoch1 = Epoch::new(0, details, None, decision_instant);
+        let source_states = Arc::new(source_states);
+        let decision_instant = SystemTime::now();
+        let mut epoch0 = Epoch::new(0, source_states.clone(), None, decision_instant);
+        let mut epoch1 = Epoch::new(0, source_states, None, decision_instant);
         senders[0]
             .send(ExecutorOperation::Commit {
                 epoch: epoch0.clone(),
@@ -271,14 +258,9 @@ mod tests {
         senders[1].send(ExecutorOperation::Terminate).unwrap();
         test_loop.receiver_loop().unwrap();
 
-        let mut details = SourceStates::new();
-        details.extend(epoch0.details);
-        details.extend(epoch1.details);
         assert_eq!(test_loop.commits[0].common_info.id, 0);
-        assert_eq!(test_loop.commits[0].details, details);
         assert_eq!(test_loop.commits[0].decision_instant, decision_instant);
         assert_eq!(test_loop.commits[1].common_info.id, 1);
-        assert_eq!(test_loop.commits[1].details, details);
         assert_eq!(test_loop.commits[1].decision_instant, decision_instant);
     }
 
@@ -286,19 +268,19 @@ mod tests {
     #[should_panic]
     fn receiver_loop_panics_on_inconsistent_commit_epoch() {
         let (mut test_loop, senders) = TestReceiverLoop::new(2);
-        let mut details = SourceStates::new();
-        details.insert(
+        let mut source_states = SourceStates::new();
+        source_states.insert(
             NodeHandle::new(None, "0".to_string()),
             OpIdentifier::new(0, 0),
         );
-        let decision_instant = SystemTime::now();
-        let epoch0 = Epoch::new(0, details, None, decision_instant);
-        let mut details = SourceStates::new();
-        details.insert(
+        source_states.insert(
             NodeHandle::new(None, "1".to_string()),
             OpIdentifier::new(0, 0),
         );
-        let epoch1 = Epoch::new(1, details, None, decision_instant);
+        let source_states = Arc::new(source_states);
+        let decision_instant = SystemTime::now();
+        let epoch0 = Epoch::new(0, source_states.clone(), None, decision_instant);
+        let epoch1 = Epoch::new(1, source_states, None, decision_instant);
         senders[0]
             .send(ExecutorOperation::Commit { epoch: epoch0 })
             .unwrap();


### PR DESCRIPTION
I believe the merging was in `ReceiverLoop` because the `SourceStates` was introduced before `EpochManager`, and every source sent commit messages independently. In that case, `ReceiverLoop`s (processors and sinks) are the only place to merge source states.

Now that we have `EpochManager`, it makes more sense to merge once only in it.