### PR TITLE
chore: Make clippy happy

### DIFF
--- a/dozer-log/src/replication/tests.rs
+++ b/dozer-log/src/replication/tests.rs
@@ -24,6 +24,7 @@ fn create_runtime() -> Arc<Runtime> {
         .into()
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn write_read() {
     let (_temp_dir, log, _) = create_test_log().await;
@@ -52,6 +53,7 @@ async fn write_read() {
     assert_eq!(ops_read, LogResponse::Operations(ops[range].to_vec()));
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn watch_write() {
     let (_temp_dir, log, _) = create_test_log().await;
@@ -80,6 +82,7 @@ async fn watch_write() {
     assert_eq!(ops_read, LogResponse::Operations(ops[range].to_vec()));
 }
 
+#[allow(clippy::async_yields_async)]
 #[test]
 fn watch_partial() {
     let runtime = create_runtime();
@@ -117,6 +120,7 @@ fn watch_partial() {
     assert_eq!(ops_read, LogResponse::Operations(ops[1..].to_vec()));
 }
 
+#[allow(clippy::async_yields_async)]
 #[test]
 fn watch_out_of_range() {
     let runtime = create_runtime();
@@ -205,6 +209,7 @@ fn in_memory_log_should_shrink_after_persist() {
     ));
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn watch_partial_timeout() {
     let (_temp_dir, log, _) = create_test_log().await;
@@ -222,6 +227,7 @@ async fn watch_partial_timeout() {
     assert_eq!(ops_read, LogResponse::Operations(vec![op]));
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn write_watch_partial_timeout() {
     let (_temp_dir, log, _) = create_test_log().await;

--- a/dozer-sql/src/pipeline/expression/tests/expression_builder_test.rs
+++ b/dozer-sql/src/pipeline/expression/tests/expression_builder_test.rs
@@ -34,7 +34,7 @@ fn test_simple_function() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -74,7 +74,7 @@ fn test_simple_aggr_function() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -117,7 +117,7 @@ fn test_2_nested_aggr_function() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -166,7 +166,7 @@ fn test_3_nested_aggr_function() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -221,7 +221,7 @@ fn test_3_nested_aggr_function_dup() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -279,7 +279,7 @@ fn test_3_nested_aggr_function_and_sum() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -344,7 +344,7 @@ fn test_3_nested_aggr_function_and_sum_3() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -406,7 +406,7 @@ fn test_wrong_nested_aggregations() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let _e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 }
@@ -443,7 +443,7 @@ fn test_name_resolution() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 
@@ -486,7 +486,7 @@ fn test_alias_resolution() {
 
     let mut builder = ExpressionBuilder::new(schema.fields.len());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &vec![]).unwrap(),
+        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
         _ => panic!("Invalid expr"),
     };
 

--- a/dozer-tests/src/cache_tests/film/load_database.rs
+++ b/dozer-tests/src/cache_tests/film/load_database.rs
@@ -57,7 +57,7 @@ pub async fn load_database(
         let record = record.unwrap();
 
         cache
-            .insert(&mut string_record_to_record(&record, &schema))
+            .insert(&string_record_to_record(&record, &schema))
             .unwrap();
 
         mongo_collection


### PR DESCRIPTION
Fix clippy issues in tests, or ignore them, to make running
`cargo clippy --workspace --all-targets -- -D warning` possible
