### PR TITLE
chore: read env DOZER_MASTER_SECRET for api security

### DIFF
--- a/dozer-api/src/api_helper.rs
+++ b/dozer-api/src/api_helper.rs
@@ -3,6 +3,7 @@ use crate::errors::{ApiError, AuthError};
 use dozer_cache::cache::expression::QueryExpression;
 use dozer_cache::cache::CacheRecord;
 use dozer_cache::{AccessFilter, CacheReader};
+use dozer_types::models::api_security::ApiSecurity;
 
 pub const API_LATENCY_HISTOGRAM_NAME: &str = "api_latency";
 pub const API_REQUEST_COUNTER_NAME: &str = "api_requests";
@@ -17,6 +18,13 @@ pub fn get_record(
         .get(key, &access_filter)
         .map_err(ApiError::NotFound)?;
     Ok(record)
+}
+
+pub fn get_api_security(current_api_security: Option<ApiSecurity>) -> Option<ApiSecurity> {
+    let dozer_master_secret = std::env::var("DOZER_MASTER_SECRET").ok();
+    dozer_master_secret
+        .map(ApiSecurity::Jwt)
+        .or(current_api_security)
 }
 
 pub fn get_records_count(

--- a/dozer-api/src/grpc/client_server.rs
+++ b/dozer-api/src/grpc/client_server.rs
@@ -121,7 +121,8 @@ impl ApiServer {
         let health_service = web_config.enable(health_service);
 
         // Auth middleware.
-        let auth_middleware = AuthMiddlewareLayer::new(self.security.clone());
+        let security = get_api_security(self.security.to_owned());
+        let auth_middleware = AuthMiddlewareLayer::new(security.clone());
 
         // Authenticated services.
         let common_service = auth_middleware.layer(common_service);

--- a/dozer-api/src/grpc/client_server.rs
+++ b/dozer-api/src/grpc/client_server.rs
@@ -57,11 +57,11 @@ impl ApiServer {
         }
         let inflection_service = builder.build().map_err(GrpcError::ServerReflectionError)?;
         let dozer_master_secret = std::env::var("DOZER_MASTER_SECRET").ok();
-        let security = if self.security.is_none() && dozer_master_secret.is_some() {
-            Some(ApiSecurity::Jwt(dozer_master_secret.unwrap()))
-        } else {
-            self.security.clone()
-        };
+        let security = self
+            .security
+            .clone()
+            .or_else(|| dozer_master_secret.map(ApiSecurity::Jwt));
+
         // Service handling dynamic gRPC requests.
         let typed_service = if self.flags.dynamic {
             Some(TypedService::new(

--- a/dozer-api/src/rest/mod.rs
+++ b/dozer-api/src/rest/mod.rs
@@ -176,7 +176,11 @@ impl ApiServer {
                 })
         );
         let cors = self.cors;
-        let security = self.security;
+        let dozer_master_secret = std::env::var("DOZER_MASTER_SECRET").ok();
+        let security = match (dozer_master_secret, self.security) {
+            (Some(master_secret), None) => Some(ApiSecurity::Jwt(master_secret)),
+            (_, security) => security,
+        };
         let address = format!("{}:{}", self.host, self.port);
         let server = HttpServer::new(move || {
             ApiServer::create_app_entry(

--- a/dozer-api/src/rest/mod.rs
+++ b/dozer-api/src/rest/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::api_helper::get_api_security;
 // Exports
 use crate::errors::ApiInitError;
 use crate::rest::api_generator::health_route;
@@ -165,11 +166,7 @@ impl ApiServer {
         shutdown: impl Future<Output = ()> + Send + 'static,
         labels: LabelsAndProgress,
     ) -> Result<Server, ApiInitError> {
-        let dozer_master_secret = std::env::var("DOZER_MASTER_SECRET").ok();
-        let security = match (dozer_master_secret, self.security) {
-            (Some(master_secret), None) => Some(ApiSecurity::Jwt(master_secret)),
-            (_, security) => security,
-        };
+        let security = get_api_security(self.security.to_owned());
         info!(
             "Starting Rest Api Server on http://{}:{} with security: {}",
             self.host,

--- a/dozer-cli/src/live/server.rs
+++ b/dozer-cli/src/live/server.rs
@@ -5,7 +5,8 @@ use dozer_types::{
     grpc_types::{
         contract::{
             contract_service_server::{ContractService, ContractServiceServer},
-            CommonRequest, DotResponse, ProtoResponse, SchemasResponse, SourcesRequest,
+            CommonRequest, DotResponse, GetApiTokenRequest, GetApiTokenResponse, ProtoResponse,
+            SchemasResponse, SourcesRequest,
         },
         live::{
             code_service_server::{CodeService, CodeServiceServer},
@@ -91,6 +92,20 @@ impl ContractService for ContractServer {
 
         match res {
             Ok(res) => Ok(Response::new(res)),
+            Err(e) => Err(Status::internal(e.to_string())),
+        }
+    }
+
+    async fn get_api_token(
+        &self,
+        _request: Request<GetApiTokenRequest>,
+    ) -> Result<Response<GetApiTokenResponse>, Status> {
+        let state = self.state.clone();
+        let res = state.get_api_token().await;
+        match res {
+            Ok(res) => Ok(Response::new(GetApiTokenResponse {
+                token: res
+            })),
             Err(e) => Err(Status::internal(e.to_string())),
         }
     }

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -172,8 +172,8 @@ impl LiveState {
                     .dozer
                     .config
                     .api
-                    .clone()
-                    .and_then(|f| f.api_security)
+                    .as_ref()
+                    .and_then(|f| f.api_security.as_ref())
                     .is_some(),
             }
         });

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -267,7 +267,8 @@ impl LiveState {
         Ok(())
     }
     pub async fn get_api_token(&self, ttl: Option<i32>) -> Result<Option<String>, LiveError> {
-        let dozer: tokio::sync::RwLockReadGuard<'_, Option<DozerAndContract>> = self.dozer.read().await;
+        let dozer: tokio::sync::RwLockReadGuard<'_, Option<DozerAndContract>> =
+            self.dozer.read().await;
         let dozer = &dozer.as_ref().ok_or(LiveError::NotInitialized)?.dozer;
         let generated_token = dozer.generate_token(ttl).ok();
         Ok(generated_token)
@@ -414,7 +415,7 @@ fn get_dozer_run_instance(
             cors: true,
             enabled: true,
         }),
-        ..Default::default()
+        ..dozer.config.api.unwrap_or_default()
     });
 
     let temp_dir = tempdir::TempDir::new("live").unwrap();

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -168,7 +168,14 @@ impl LiveState {
                 app_name: dozer.dozer.config.app_name.clone(),
                 connections,
                 endpoints,
-                enable_api_security: dozer.dozer.config.api.clone().map(|f| f.api_security).flatten().is_some(),
+                enable_api_security: dozer
+                    .dozer
+                    .config
+                    .api
+                    .clone()
+                    .map(|f| f.api_security)
+                    .flatten()
+                    .is_some(),
             }
         });
 

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -266,10 +266,10 @@ impl LiveState {
         *lock = None;
         Ok(())
     }
-    pub async fn get_api_token(&self) -> Result<Option<String>, LiveError> {
-        let dozer = self.dozer.read().await;
+    pub async fn get_api_token(&self, ttl: Option<i32>) -> Result<Option<String>, LiveError> {
+        let dozer: tokio::sync::RwLockReadGuard<'_, Option<DozerAndContract>> = self.dozer.read().await;
         let dozer = &dozer.as_ref().ok_or(LiveError::NotInitialized)?.dozer;
-        let generated_token = dozer.generate_token().ok();
+        let generated_token = dozer.generate_token(ttl).ok();
         Ok(generated_token)
     }
 }

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -183,7 +183,6 @@ impl LiveState {
         self.create_contract_if_missing().await?;
         let dozer = self.dozer.read().await;
         let contract = get_contract(&dozer)?;
-
         Ok(SchemasResponse {
             schemas: contract.get_endpoints_schemas(),
         })
@@ -267,6 +266,12 @@ impl LiveState {
         *lock = None;
         Ok(())
     }
+    pub async fn get_api_token(&self) -> Result<Option<String>, LiveError> {
+        let dozer = self.dozer.read().await;
+        let dozer = &dozer.as_ref().ok_or(LiveError::NotInitialized)?.dozer;
+        let generated_token = dozer.generate_token().ok();
+        Ok(generated_token)
+    }
 }
 
 fn get_contract(dozer_and_contract: &Option<DozerAndContract>) -> Result<&Contract, LiveError> {
@@ -324,7 +329,6 @@ fn run(
     let mut dozer = get_dozer_run_instance(dozer, labels, request)?;
 
     validate_config(&dozer.config)?;
-
     let runtime = dozer.runtime.clone();
     let run_thread = std::thread::spawn(move || dozer.run_all(shutdown_receiver, false));
 

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -173,8 +173,7 @@ impl LiveState {
                     .config
                     .api
                     .clone()
-                    .map(|f| f.api_security)
-                    .flatten()
+                    .and_then(|f| f.api_security)
                     .is_some(),
             }
         });

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -168,6 +168,7 @@ impl LiveState {
                 app_name: dozer.dozer.config.app_name.clone(),
                 connections,
                 endpoints,
+                enable_api_security: dozer.dozer.config.api.clone().map(|f| f.api_security).flatten().is_some(),
             }
         });
 

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -15,6 +15,7 @@ use dozer_types::{
     models::{
         api_config::{ApiConfig, AppGrpcOptions, GrpcApiOptions, RestApiOptions},
         api_endpoint::ApiEndpoint,
+        api_security::ApiSecurity,
         app_config::AppConfig,
         flags::Flags,
     },
@@ -164,17 +165,23 @@ impl LiveState {
                 .iter()
                 .map(|c| c.name.clone())
                 .collect();
-            LiveApp {
-                app_name: dozer.dozer.config.app_name.clone(),
-                connections,
-                endpoints,
-                enable_api_security: dozer
+
+            let enable_api_security = std::env::var("DOZER_MASTER_SECRET")
+                .ok()
+                .map(ApiSecurity::Jwt)
+                .as_ref()
+                .or(dozer
                     .dozer
                     .config
                     .api
                     .as_ref()
-                    .and_then(|f| f.api_security.as_ref())
-                    .is_some(),
+                    .and_then(|f| f.api_security.as_ref()))
+                .is_some();
+            LiveApp {
+                app_name: dozer.dozer.config.app_name.clone(),
+                connections,
+                endpoints,
+                enable_api_security,
             }
         });
 

--- a/dozer-cli/src/main.rs
+++ b/dozer-cli/src/main.rs
@@ -174,7 +174,7 @@ fn run() -> Result<(), OrchestrationError> {
         },
         Commands::Security(security) => match security.command {
             SecurityCommands::GenerateToken => {
-                let token = dozer.generate_token()?;
+                let token = dozer.generate_token(None)?;
                 info!("token: {:?} ", token);
                 Ok(())
             }

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -272,14 +272,15 @@ impl SimpleOrchestrator {
         })
     }
 
-    pub fn generate_token(&self) -> Result<String, OrchestrationError> {
+    pub fn generate_token(&self, ttl_in_secs: Option<i32>) -> Result<String, OrchestrationError> {
         if let Some(api_config) = &self.config.api {
             if let Some(api_security) = &api_config.api_security {
                 match api_security {
                     dozer_types::models::api_security::ApiSecurity::Jwt(secret) => {
                         let auth = Authorizer::new(secret, None, None);
+                        let duration = ttl_in_secs.map(|f| std::time::Duration::from_secs(f as u64));
                         let token = auth
-                            .generate_token(Access::All, None)
+                            .generate_token(Access::All, duration)
                             .map_err(OrchestrationError::GenerateTokenFailed)?;
                         return Ok(token);
                     }

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -278,7 +278,8 @@ impl SimpleOrchestrator {
                 match api_security {
                     dozer_types::models::api_security::ApiSecurity::Jwt(secret) => {
                         let auth = Authorizer::new(secret, None, None);
-                        let duration = ttl_in_secs.map(|f| std::time::Duration::from_secs(f as u64));
+                        let duration =
+                            ttl_in_secs.map(|f| std::time::Duration::from_secs(f as u64));
                         let token = auth
                             .generate_token(Access::All, duration)
                             .map_err(OrchestrationError::GenerateTokenFailed)?;

--- a/dozer-types/build.rs
+++ b/dozer-types/build.rs
@@ -30,7 +30,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join("live.bin"))
         .compile(&["protos/live.proto"], &["protos"])?;
-
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .file_descriptor_set_path(out_dir.join("api_explorer.bin"))
+        .compile(&["protos/api_explorer.proto"], &["protos"])?;
     // Sample service generated for tests and development
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     tonic_build::configure()

--- a/dozer-types/protos/api_explorer.proto
+++ b/dozer-types/protos/api_explorer.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package dozer.api_explorer;
+service ApiExplorerService {
+    rpc GetApiToken(GetApiTokenRequest) returns (GetApiTokenResponse);
+}
+
+message GetApiTokenRequest {
+  // required if in cloud context.
+  optional string app_id = 1;
+  // ttl in seconds - default 15 minutes (900 seconds)
+  optional int32 ttl = 2;
+}
+message GetApiTokenResponse {
+  optional string token = 1;
+}

--- a/dozer-types/protos/contract.proto
+++ b/dozer-types/protos/contract.proto
@@ -10,8 +10,16 @@ service ContractService {
   rpc GenerateDot(CommonRequest) returns (DotResponse);
   rpc GetGraphSchemas(CommonRequest) returns (SchemasResponse);
   rpc GetProtos(CommonRequest) returns (ProtoResponse);
+  rpc GetApiToken(GetApiTokenRequest) returns (GetApiTokenResponse);
 }
 
+message GetApiTokenRequest {
+  // required if in cloud context.
+  optional string app_id = 1;
+}
+message GetApiTokenResponse {
+  optional string token = 1;
+}
 message CloudDeploymentId {
   string app_id = 1;
   uint32 deployment = 2;

--- a/dozer-types/protos/contract.proto
+++ b/dozer-types/protos/contract.proto
@@ -10,16 +10,8 @@ service ContractService {
   rpc GenerateDot(CommonRequest) returns (DotResponse);
   rpc GetGraphSchemas(CommonRequest) returns (SchemasResponse);
   rpc GetProtos(CommonRequest) returns (ProtoResponse);
-  rpc GetApiToken(GetApiTokenRequest) returns (GetApiTokenResponse);
 }
 
-message GetApiTokenRequest {
-  // required if in cloud context.
-  optional string app_id = 1;
-}
-message GetApiTokenResponse {
-  optional string token = 1;
-}
 message CloudDeploymentId {
   string app_id = 1;
   uint32 deployment = 2;

--- a/dozer-types/protos/live.proto
+++ b/dozer-types/protos/live.proto
@@ -21,7 +21,8 @@ message Label {
 message LiveApp {
   string app_name = 1;
   repeated string connections = 2;  
-  repeated string endpoints = 3;  
+  repeated string endpoints = 3;
+  bool enable_api_security = 4;
 }
 
 message LiveResponse {

--- a/dozer-types/src/grpc_types.rs
+++ b/dozer-types/src/grpc_types.rs
@@ -55,6 +55,12 @@ pub mod live {
     pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("live");
 }
 
+pub mod api_explorer {
+    #![allow(clippy::derive_partial_eq_without_eq)]
+    tonic::include_proto!("dozer.api_explorer");
+    pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("api_explorer");
+}
+
 // To be used in tests
 pub mod generated {
     pub mod films {


### PR DESCRIPTION
- [x] preserve Api Security config in live exeperience
- [x]  add `enable_api_security` indicatior in live state to know wherether API explorer should fetch token  before hand
- [x]  Include ApiExplorerService for both `live` and `cloud` experience => this one providing endpoint in order to fetch the short live token on Api Explorer
- [x] using DOZER_MASTER_SECRET variable as default api security config on cloud