### PR TITLE
fix: mysql select query offset syntax is wrong

### DIFF
--- a/dozer-ingestion/src/connectors/mysql/connection.rs
+++ b/dozer-ingestion/src/connectors/mysql/connection.rs
@@ -101,7 +101,7 @@ fn add_query_offset(query: &str, offset: u64) -> String {
     if offset == 0 {
         query.into()
     } else {
-        format!("{query} OFFSET {offset}")
+        format!("{query} LIMIT {offset},18446744073709551615")
     }
 }
 


### PR DESCRIPTION
Reference: https://dev.mysql.com/doc/refman/8.0/en/select.html#:~:text=To%20retrieve%20all,%2C18446744073709551615%3B