### PR TITLE
fix: resume a non-SELECT query in snowflake connector

### DIFF
--- a/dozer-ingestion/src/errors.rs
+++ b/dozer-ingestion/src/errors.rs
@@ -354,6 +354,9 @@ pub enum SnowflakeError {
 
     #[error(transparent)]
     SnowflakeStreamError(#[from] SnowflakeStreamError),
+
+    #[error("A network error occurred, but this query is not resumable. query: {0}")]
+    NonResumableQuery(String),
 }
 
 #[cfg(feature = "snowflake")]


### PR DESCRIPTION
There is only one instance where a query which returns multiple rows is not a SELECT query in the snowflake connector. We can restart the query when a network error occurs.