### PR TITLE
fix: mysql use a random server_id if none was specified

### DIFF
--- a/dozer-ingestion/src/connectors/mysql/connector.rs
+++ b/dozer-ingestion/src/connectors/mysql/connector.rs
@@ -20,6 +20,7 @@ use dozer_types::{
 };
 use mysql_async::{Opts, Pool};
 use mysql_common::Row;
+use rand::Rng;
 
 #[derive(Debug)]
 pub struct MySQLConnector {
@@ -378,7 +379,7 @@ impl MySQLConnector {
         start_position: BinlogPosition,
         stop_position: Option<BinlogPosition>,
     ) -> Result<(), ConnectorError> {
-        let server_id = self.server_id.unwrap_or(0xd07e5);
+        let server_id = self.server_id.unwrap_or_else(|| rand::thread_rng().gen());
 
         let mut binlog_ingestor = BinlogIngestor::new(
             ingestor,


### PR DESCRIPTION
MySQL returns an error if two clients are using the same `server_id` concurrently.