### PR TITLE
feat: Add a config to disable pipeline checkpointing by default

### DIFF
--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -420,11 +420,9 @@ fn get_dozer_run_instance(
         None => {}
     };
 
-    let app = &mut dozer.config.app;
-    app.max_num_records_before_persist = Some(usize::MAX as u64);
-    app.max_interval_before_persist_in_seconds = Some(u64::MAX);
-
     override_api_config(&mut dozer.config.api);
+
+    dozer.config.flags.enable_app_checkpoints = Some(false);
 
     dozer.config.home_dir = Some(temp_dir.to_string());
     dozer.config.cache_dir = Some(AsRef::<Utf8Path>::as_ref(temp_dir).join("cache").into());

--- a/dozer-cli/src/utils.rs
+++ b/dozer-cli/src/utils.rs
@@ -13,6 +13,7 @@ use dozer_types::{
             default_max_num_records_before_persist, default_persist_queue_capacity,
         },
         config::{default_cache_dir, default_cache_max_map_size, Config},
+        flags::default_enable_app_checkpoints,
     },
 };
 use std::time::Duration;
@@ -93,6 +94,10 @@ pub fn get_executor_options(config: &Config) -> ExecutorOptions {
             max_interval_before_persist_in_seconds: get_max_interval_before_persist_in_seconds(
                 config,
             ),
+            enable_app_checkpoints: config
+                .flags
+                .enable_app_checkpoints
+                .unwrap_or_else(default_enable_app_checkpoints),
         },
         checkpoint_factory_options: get_checkpoint_factory_options(config),
     }

--- a/dozer-core/src/checkpoint/mod.rs
+++ b/dozer-core/src/checkpoint/mod.rs
@@ -180,6 +180,10 @@ impl CheckpointFactory {
         ))
     }
 
+    pub fn queue(&self) -> &Queue {
+        &self.queue
+    }
+
     pub fn record_store(&self) -> &Arc<ProcessorRecordStore> {
         &self.record_store
     }

--- a/dozer-core/src/epoch/manager.rs
+++ b/dozer-core/src/epoch/manager.rs
@@ -83,6 +83,7 @@ impl EpochManagerStateKind {
 pub struct EpochManagerOptions {
     pub max_num_records_before_persist: usize,
     pub max_interval_before_persist_in_seconds: u64,
+    pub enable_app_checkpoints: bool,
 }
 
 impl Default for EpochManagerOptions {
@@ -90,6 +91,7 @@ impl Default for EpochManagerOptions {
         Self {
             max_num_records_before_persist: 100_000,
             max_interval_before_persist_in_seconds: 60,
+            enable_app_checkpoints: false,
         }
     }
 }
@@ -229,16 +231,22 @@ impl EpochManager {
                 num_source_confirmations,
             } => {
                 let common_info = action.should_commit().then(|| {
-                    let checkpoint_writer = action.should_persist().then(|| {
-                        Arc::new(CheckpointWriter::new(
-                            self.checkpoint_factory.clone(),
-                            *epoch_id,
-                            source_states.clone(),
-                        ))
-                    });
+                    let checkpoint_writer = (action.should_persist()
+                        && self.options.enable_app_checkpoints)
+                        .then(|| {
+                            Arc::new(CheckpointWriter::new(
+                                self.checkpoint_factory.clone(),
+                                *epoch_id,
+                                source_states.clone(),
+                            ))
+                        });
+                    let sink_persist_queue = action
+                        .should_persist()
+                        .then(|| self.checkpoint_factory.queue().clone());
                     EpochCommonInfo {
                         id: *epoch_id,
                         checkpoint_writer,
+                        sink_persist_queue,
                         source_states: source_states.clone(),
                     }
                 });
@@ -399,6 +407,7 @@ mod tests {
             EpochManagerOptions {
                 max_num_records_before_persist: 1,
                 max_interval_before_persist_in_seconds: 1,
+                enable_app_checkpoints: true,
             },
         )
         .await;
@@ -408,17 +417,59 @@ mod tests {
         std::thread::spawn(move || {
             // No record, no persist.
             let epoch = epoch_manager.wait_for_epoch_close(source_state.clone(), false, true);
-            assert!(epoch.common_info.unwrap().checkpoint_writer.is_none());
+            let common_info = epoch.common_info.unwrap();
+            assert!(common_info.checkpoint_writer.is_none());
+            assert!(common_info.sink_persist_queue.is_none());
 
             // One record, persist.
             epoch_manager.record_store().create_ref(&[]).unwrap();
             let epoch = epoch_manager.wait_for_epoch_close(source_state.clone(), false, true);
-            assert!(epoch.common_info.unwrap().checkpoint_writer.is_some());
+            let common_info = epoch.common_info.unwrap();
+            assert!(common_info.checkpoint_writer.is_some());
+            assert!(common_info.sink_persist_queue.is_some());
 
             // Time passes, persist.
             std::thread::sleep(Duration::from_secs(1));
             let epoch = epoch_manager.wait_for_epoch_close(source_state.clone(), false, true);
-            assert!(epoch.common_info.unwrap().checkpoint_writer.is_some());
+            let common_info = epoch.common_info.unwrap();
+            assert!(common_info.checkpoint_writer.is_some());
+            assert!(common_info.sink_persist_queue.is_some());
+        })
+        .join()
+        .unwrap();
+
+        // Also test the case where checkpoints are disabled.
+        let (_temp_dir, epoch_manager) = create_epoch_manager(
+            1,
+            EpochManagerOptions {
+                max_num_records_before_persist: 1,
+                max_interval_before_persist_in_seconds: 1,
+                enable_app_checkpoints: false,
+            },
+        )
+        .await;
+
+        let source_state = generate_source_state(0);
+        std::thread::spawn(move || {
+            // No record, no persist.
+            let epoch = epoch_manager.wait_for_epoch_close(source_state.clone(), false, true);
+            let common_info = epoch.common_info.unwrap();
+            assert!(common_info.checkpoint_writer.is_none());
+            assert!(common_info.sink_persist_queue.is_none());
+
+            // One record, persist.
+            epoch_manager.record_store().create_ref(&[]).unwrap();
+            let epoch = epoch_manager.wait_for_epoch_close(source_state.clone(), false, true);
+            let common_info = epoch.common_info.unwrap();
+            assert!(common_info.checkpoint_writer.is_none());
+            assert!(common_info.sink_persist_queue.is_some());
+
+            // Time passes, persist.
+            std::thread::sleep(Duration::from_secs(1));
+            let epoch = epoch_manager.wait_for_epoch_close(source_state.clone(), false, true);
+            let common_info = epoch.common_info.unwrap();
+            assert!(common_info.checkpoint_writer.is_none());
+            assert!(common_info.sink_persist_queue.is_some());
         })
         .join()
         .unwrap();

--- a/dozer-core/src/epoch/manager.rs
+++ b/dozer-core/src/epoch/manager.rs
@@ -201,6 +201,7 @@ impl EpochManager {
                         .unwrap_or(Duration::from_secs(0))
                         >= Duration::from_secs(self.options.max_interval_before_persist_in_seconds)
                 {
+                    self.record_store().compact(); // Compact the record store to prepare for persisting.
                     state.next_record_index_to_persist = num_records;
                     state.last_persisted_epoch_decision_instant = instant;
                     Action::CommitAndPersist

--- a/dozer-core/src/epoch/mod.rs
+++ b/dozer-core/src/epoch/mod.rs
@@ -1,11 +1,13 @@
 use std::{sync::Arc, time::SystemTime};
 
+use dozer_log::storage::Queue;
 use dozer_types::node::SourceStates;
 
 #[derive(Clone, Debug)]
 pub struct EpochCommonInfo {
     pub id: u64,
     pub checkpoint_writer: Option<Arc<CheckpointWriter>>,
+    pub sink_persist_queue: Option<Queue>,
     pub source_states: Arc<SourceStates>,
 }
 
@@ -20,12 +22,14 @@ impl Epoch {
         id: u64,
         source_states: Arc<SourceStates>,
         checkpoint_writer: Option<Arc<CheckpointWriter>>,
+        sink_persist_queue: Option<Queue>,
         decision_instant: SystemTime,
     ) -> Self {
         Self {
             common_info: EpochCommonInfo {
                 id,
                 checkpoint_writer,
+                sink_persist_queue,
                 source_states,
             },
             decision_instant,

--- a/dozer-core/src/executor/receiver_loop.rs
+++ b/dozer-core/src/executor/receiver_loop.rs
@@ -230,8 +230,8 @@ mod tests {
         source_states.insert(NodeHandle::new(None, "1".to_string()), Default::default());
         let source_states = Arc::new(source_states);
         let decision_instant = SystemTime::now();
-        let mut epoch0 = Epoch::new(0, source_states.clone(), None, decision_instant);
-        let mut epoch1 = Epoch::new(0, source_states, None, decision_instant);
+        let mut epoch0 = Epoch::new(0, source_states.clone(), None, None, decision_instant);
+        let mut epoch1 = Epoch::new(0, source_states, None, None, decision_instant);
         senders[0]
             .send(ExecutorOperation::Commit {
                 epoch: epoch0.clone(),
@@ -273,8 +273,8 @@ mod tests {
         source_states.insert(NodeHandle::new(None, "1".to_string()), Default::default());
         let source_states = Arc::new(source_states);
         let decision_instant = SystemTime::now();
-        let epoch0 = Epoch::new(0, source_states.clone(), None, decision_instant);
-        let epoch1 = Epoch::new(1, source_states, None, decision_instant);
+        let epoch0 = Epoch::new(0, source_states.clone(), None, None, decision_instant);
+        let epoch1 = Epoch::new(1, source_states, None, None, decision_instant);
         senders[0]
             .send(ExecutorOperation::Commit { epoch: epoch0 })
             .unwrap();

--- a/dozer-core/src/executor/sink_node.rs
+++ b/dozer-core/src/executor/sink_node.rs
@@ -142,8 +142,8 @@ impl ReceiverLoop for SinkNode {
             histogram!(PIPELINE_LATENCY_HISTOGRAM_NAME, duration, labels);
         }
 
-        if let Some(checkpoint_writer) = epoch.common_info.checkpoint_writer.as_ref() {
-            if let Err(e) = self.sink.persist(checkpoint_writer.queue()) {
+        if let Some(queue) = epoch.common_info.sink_persist_queue.as_ref() {
+            if let Err(e) = self.sink.persist(queue) {
                 self.error_manager.report(e);
             }
         }

--- a/dozer-recordstore/src/lib.rs
+++ b/dozer-recordstore/src/lib.rs
@@ -147,6 +147,12 @@ impl ProcessorRecordStore {
         };
         bincode::serialize(&record)
     }
+
+    pub fn compact(&self) {
+        if let Self::InMemory(store) = self {
+            store.vacuum();
+        }
+    }
 }
 
 impl StoreRecord for ProcessorRecordStore {

--- a/dozer-recordstore/src/rocksdb.rs
+++ b/dozer-recordstore/src/rocksdb.rs
@@ -45,11 +45,11 @@ impl ProcessorRecordStore {
             .ok_or(RecordStoreError::RocksdbRecordNotFound(*record_ref))
     }
 
-    pub fn serialize_slice(&self, start: usize) -> Result<(Vec<u8>, usize), RecordStoreError> {
-        Ok((vec![], self.num_records() - start)) // TODO: implement rocksdb record store checkpointing
+    pub fn serialize_slice(&self, _start: usize) -> Result<(Vec<u8>, usize), RecordStoreError> {
+        todo!("implement rocksdb record store checkpointing")
     }
 
     pub fn deserialize_and_extend(&self, _data: &[u8]) -> Result<(), RecordStoreError> {
-        Ok(()) // TODO: implement rocksdb record store checkpointing
+        todo!("implement rocksdb record store checkpointing")
     }
 }

--- a/dozer-types/src/models/flags.rs
+++ b/dozer-types/src/models/flags.rs
@@ -19,13 +19,15 @@ pub struct Flags {
     pub push_events: Option<bool>,
 
     /// require authentication to access grpc server reflection service if true.; Default: false
-
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authenticate_server_reflection: Option<bool>,
 
     /// probablistic optimizations reduce memory consumption at the expense of accuracy.
     #[serde(default, skip_serializing_if = "equal_default")]
     pub enable_probabilistic_optimizations: EnableProbabilisticOptimizations,
+
+    /// app checkpoints can be used to resume execution of a query.; Default: false
+    pub enable_app_checkpoints: Option<bool>,
 }
 
 pub fn default_dynamic() -> bool {
@@ -50,4 +52,8 @@ pub struct EnableProbabilisticOptimizations {
 
 pub fn default_push_events() -> bool {
     true
+}
+
+pub fn default_enable_app_checkpoints() -> bool {
+    false
 }

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -882,6 +882,13 @@
             "null"
           ]
         },
+        "enable_app_checkpoints": {
+          "description": "app checkpoints can be used to resume execution of a query.; Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "enable_probabilistic_optimizations": {
           "description": "probablistic optimizations reduce memory consumption at the expense of accuracy.",
           "allOf": [


### PR DESCRIPTION
This PR adds a new flag `enable_app_checkpoints`. When disabled, `EpochManager` stops creating `CheckpointWriter`s, effectively avoids persisting the processor record store, all processors and the record writer. A new field `sink_persist_queue` is added to `EpochCommonInfo` to continue persisting the log even if checkpoints are disabled.
This flag defaults to `false`, which means the checkpoints are disabled.

