### PR TITLE
Increase OnEvent operation channel size

### DIFF
--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -87,7 +87,7 @@ impl SimpleOrchestrator {
             let flags = self.config.flags.clone();
             let (operations_sender, operations_receiver) =
                 if flags.dynamic.unwrap_or_else(default_dynamic) {
-                    let (sender, receiver) = broadcast::channel(16);
+                    let (sender, receiver) = broadcast::channel(1024);
                     (Some(sender), Some(receiver))
                 } else {
                     (None, None)


### PR DESCRIPTION
We'll only have one instance of this channel, so a (semi-)large size should be okay.
The smaller size caused some messages to be dropped in the case of joins
with a large fan-out.

We could eventually expose OnEvent using log readers instead, which means we 
would not have to keep any messages in memory for OnEvent at all.
