### PR TITLE
feat: Store `SourceStates` in log and cache

### DIFF
--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -35,7 +35,7 @@ pub async fn build_cache(
     labels: LabelsAndProgress,
 ) -> Result<(), CacheError> {
     // Create log reader.
-    let starting_pos = cache.get_metadata()?.map(|pos| pos + 1).unwrap_or(0);
+    let starting_pos = cache.get_log_position()?.map(|pos| pos + 1).unwrap_or(0);
     debug!(
         "Starting log reader {} from position {starting_pos}",
         log_reader_builder.options.endpoint
@@ -207,9 +207,11 @@ fn build_cache_task(
                     }
                 }
             },
-            LogOperation::Commit { decision_instant } => {
-                cache.set_metadata(op_and_pos.pos)?;
-                cache.commit()?;
+            LogOperation::Commit {
+                source_states,
+                decision_instant,
+            } => {
+                cache.commit(&source_states, op_and_pos.pos)?;
                 if let Ok(duration) = decision_instant.elapsed() {
                     histogram!(
                         DATA_LATENCY_HISTOGRAM_NAME,
@@ -219,9 +221,7 @@ fn build_cache_task(
                 }
             }
             LogOperation::SnapshottingDone { connection_name } => {
-                cache.set_metadata(op_and_pos.pos)?;
                 cache.set_connection_snapshotting_done(&connection_name)?;
-                cache.commit()?;
                 snapshotting = !cache.is_snapshotting_done()?;
             }
         }

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -121,7 +121,7 @@ pub fn initialize_cache(
     for record in records {
         cache.insert(&record.record).unwrap();
     }
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     cache_manager.wait_until_indexing_catchup();
 
     Box::new(cache_manager)

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -18,7 +18,7 @@ fn insert(cache: &Mutex<Box<dyn RwCache>>, n: usize, commit_size: usize) {
     cache.insert(&record).unwrap();
 
     if n % commit_size == 0 {
-        cache.commit().unwrap();
+        cache.commit(&Default::default(), 0).unwrap();
     }
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
@@ -41,7 +41,7 @@ pub fn begin_dump_txn<C: LmdbCache>(
 ) -> Result<DumpTransaction<RoTransaction>, CacheError> {
     let main_env = cache.main_env();
     let main_txn = main_env.begin_txn()?;
-    let main_env_metadata = main_env.metadata_with_txn(&main_txn)?;
+    let main_env_metadata = main_env.log_positions_with_txn(&main_txn)?;
 
     let mut secondary_txns = vec![];
     let mut secondary_metadata = vec![];
@@ -139,7 +139,7 @@ mod tests {
         insert_rec_1(&mut cache, (0, Some("a".to_string()), None));
         insert_rec_1(&mut cache, (1, None, Some(2)));
         insert_rec_1(&mut cache, (2, Some("b".to_string()), Some(3)));
-        cache.commit().unwrap();
+        cache.commit(&Default::default(), 0).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         let mut data = vec![];

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
@@ -36,7 +36,7 @@ fn ignore_insert_error_when_type_nothing() {
         lifetime: None,
     };
     env.insert(&record).unwrap();
-    env.commit().unwrap();
+    env.commit(&Default::default(), 0).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -67,7 +67,7 @@ fn update_after_insert_error_when_type_update() {
         lifetime: None,
     };
     env.insert(&record).unwrap();
-    env.commit().unwrap();
+    env.commit(&Default::default(), 0).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -85,7 +85,7 @@ fn update_after_insert_error_when_type_update() {
     };
 
     env.insert(&second_record).unwrap();
-    env.commit().unwrap();
+    env.commit(&Default::default(), 0).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -113,7 +113,7 @@ fn return_insert_error_when_type_panic() {
         lifetime: None,
     };
     env.insert(&record).unwrap();
-    env.commit().unwrap();
+    env.commit(&Default::default(), 0).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -179,7 +179,7 @@ fn update_after_update_error_when_type_upsert() {
         lifetime: None,
     };
     env.update(&initial_record, &update_record).unwrap();
-    env.commit().unwrap();
+    env.commit(&Default::default(), 0).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();

--- a/dozer-cache/src/cache/lmdb/cache/query/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/query/tests.rs
@@ -20,7 +20,7 @@ fn query_secondary_sorted_inverted() {
     ]);
 
     cache.insert(&record).unwrap();
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     let filter = FilterExpression::And(vec![
@@ -51,7 +51,7 @@ fn query_secondary_full_text() {
     ]);
 
     cache.insert(&record).unwrap();
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     let filter = FilterExpression::Simple("foo".into(), Operator::Contains, "good".into());
@@ -89,7 +89,7 @@ fn query_secondary_vars() {
     for val in items {
         insert_rec_1(&mut cache, val);
     }
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     test_query(json!({}), 8, &cache);
@@ -198,7 +198,7 @@ fn query_secondary_multi_indices() {
         };
         cache.insert(&record).unwrap();
     }
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     let query = query_from_filter(FilterExpression::And(vec![

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
@@ -155,7 +155,7 @@ pub mod tests {
         main_env.insert(&record_a).unwrap();
         main_env.insert(&record_b).unwrap();
         main_env.delete(&record_a).unwrap();
-        main_env.commit().unwrap();
+        main_env.commit(&Default::default(), 0).unwrap();
 
         let mut env = RwSecondaryEnvironment::new(
             &IndexDefinition::SortedInverted(vec![0]),

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
@@ -116,7 +116,7 @@ mod tests {
         for val in items.clone() {
             lmdb_utils::insert_rec_1(&mut cache, val);
         }
-        cache.commit().unwrap();
+        cache.commit(&Default::default(), 0).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         // No of index dbs
@@ -137,7 +137,7 @@ mod tests {
             };
             cache.delete(&record).unwrap();
         }
-        cache.commit().unwrap();
+        cache.commit(&Default::default(), 0).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         assert_eq!(
@@ -187,7 +187,7 @@ mod tests {
             cache.delete(&record).unwrap();
         }
 
-        cache.commit().unwrap();
+        cache.commit(&Default::default(), 0).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         assert_eq!(

--- a/dozer-cache/src/cache/lmdb/tests/basic.rs
+++ b/dozer-cache/src/cache/lmdb/tests/basic.rs
@@ -50,7 +50,7 @@ fn insert_get_and_delete_record() {
     let UpsertResult::Inserted { meta } = cache.insert(&record).unwrap() else {
         panic!("Must be inserted")
     };
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 1);
@@ -70,7 +70,7 @@ fn insert_get_and_delete_record() {
             .unwrap(),
         meta
     );
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 0);
@@ -106,7 +106,7 @@ fn insert_and_query_record_impl(
     let record = Record::new(vec![Field::String(val)]);
 
     cache.insert(&record).unwrap();
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     // Query with an expression
@@ -152,7 +152,7 @@ fn update_record_when_primary_changes() {
     };
 
     cache.insert(&initial_record).unwrap();
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = cache.get(&key).unwrap().record;
@@ -160,7 +160,7 @@ fn update_record_when_primary_changes() {
     assert_eq!(initial_values, record.values);
 
     cache.update(&initial_record, &updated_record).unwrap();
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
 
     // Primary key with old values
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
@@ -177,10 +177,20 @@ fn update_record_when_primary_changes() {
 }
 
 #[test]
-fn test_cache_metadata() {
+fn test_cache_source_states() {
     let (mut cache, _, _) = _setup();
-    assert!(cache.get_metadata().unwrap().is_none());
-    cache.set_metadata(32).unwrap();
-    cache.commit().unwrap();
-    assert_eq!(cache.get_metadata().unwrap().unwrap(), 32);
+    assert!(cache.get_source_states().unwrap().is_none());
+    cache.commit(&Default::default(), 0).unwrap();
+    assert_eq!(
+        cache.get_source_states().unwrap().unwrap(),
+        Default::default()
+    );
+}
+
+#[test]
+fn test_cache_log_position() {
+    let (mut cache, _, _) = _setup();
+    assert!(cache.get_log_position().unwrap().is_none());
+    cache.commit(&Default::default(), 32).unwrap();
+    assert_eq!(cache.get_log_position().unwrap().unwrap(), 32);
 }

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -43,7 +43,7 @@ fn read_and_write() {
     for val in items.clone() {
         lmdb_utils::insert_rec_1(&mut cache_writer, val.clone());
     }
-    cache_writer.commit().unwrap();
+    cache_writer.commit(&Default::default(), 0).unwrap();
 
     indexing_thread_pool.lock().wait_until_catchup();
 

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -8,6 +8,7 @@ use dozer_tracing::Labels;
 use dozer_types::models::api_endpoint::{
     OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes,
 };
+use dozer_types::node::SourceStates;
 use dozer_types::{
     serde::{Deserialize, Serialize},
     types::{IndexDefinition, Record, Schema, SchemaWithIndex},
@@ -92,7 +93,8 @@ pub trait RoCache: Send + Sync + Debug {
     fn query(&self, query: &QueryExpression) -> Result<Vec<CacheRecord>, CacheError>;
 
     // Cache metadata
-    fn get_metadata(&self) -> Result<Option<u64>, CacheError>;
+    fn get_source_states(&self) -> Result<Option<SourceStates>, CacheError>;
+    fn get_log_position(&self) -> Result<Option<u64>, CacheError>;
     fn is_snapshotting_done(&self) -> Result<bool, CacheError>;
 }
 
@@ -141,11 +143,11 @@ pub trait RwCache: RoCache {
     /// If the schema has primary index, only fields that are part of the primary index are used to identify the old record.
     fn update(&mut self, old: &Record, record: &Record) -> Result<UpsertResult, CacheError>;
 
-    /// Sets the metadata of the cache. Implicitly starts a transaction if there's no active transaction.
-    fn set_metadata(&mut self, metadata: u64) -> Result<(), CacheError>;
+    /// Marks a connection as snapshotting done. Implicitly starts a transaction if there's no active transaction.
     fn set_connection_snapshotting_done(&mut self, connection_name: &str)
         -> Result<(), CacheError>;
 
     /// Commits the current transaction.
-    fn commit(&mut self) -> Result<(), CacheError>;
+    fn commit(&mut self, source_states: &SourceStates, log_position: u64)
+        -> Result<(), CacheError>;
 }

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, ops::Deref, sync::Arc};
 
 use dozer_cache::dozer_log::{
     replication::{Log, LogOperation},
@@ -104,6 +104,7 @@ impl Sink for LogSink {
             .runtime
             .block_on(self.log.lock())
             .write(LogOperation::Commit {
+                source_states: epoch_details.common_info.source_states.deref().clone(),
                 decision_instant: epoch_details.decision_instant,
             });
         self.pb.set_position(end as u64);

--- a/dozer-log/src/errors.rs
+++ b/dozer-log/src/errors.rs
@@ -1,6 +1,8 @@
 use dozer_types::thiserror::Error;
 use dozer_types::{bincode, serde_json, thiserror, tonic};
 
+use crate::replication::LoadPersistedLogEntryError;
+
 #[derive(Error, Debug)]
 pub enum ReaderBuilderError {
     #[error("Tonic transport error: {0:?}")]
@@ -17,10 +19,8 @@ pub enum ReaderBuilderError {
 pub enum ReaderError {
     #[error("Failed to deserialize log response: {0}")]
     DeserializeLogResponse(#[source] bincode::Error),
-    #[error("Failed to deserialize log entry: {0}")]
-    DeserializeLogEntry(#[source] bincode::Error),
-    #[error("Storage error: {0}")]
-    Storage(#[from] crate::storage::Error),
+    #[error("Failed to load persisted log entry: {0}")]
+    LoadPersistedLogEntry(#[from] LoadPersistedLogEntryError),
     #[error("Reader thread has quit: {0:?}")]
     ReaderThreadQuit(#[source] Option<tokio::task::JoinError>),
 }

--- a/dozer-log/src/reader.rs
+++ b/dozer-log/src/reader.rs
@@ -1,5 +1,5 @@
 use crate::errors::ReaderBuilderError;
-use crate::replication::LogOperation;
+use crate::replication::{load_persisted_log_entry, LogOperation};
 use crate::schemas::EndpointSchema;
 use crate::storage::{LocalStorage, S3Storage, Storage};
 
@@ -222,9 +222,7 @@ impl LogClient {
                     persisted.key, persisted.range, request_range
                 );
                 // Load the persisted log entry.
-                let data = self.storage.download_object(persisted.key).await?;
-                let mut ops: Vec<LogOperation> =
-                    bincode::deserialize(&data).map_err(ReaderError::DeserializeLogEntry)?;
+                let mut ops = load_persisted_log_entry(&*self.storage, &persisted).await?;
                 // Discard the ops that are before the requested range.
                 ops.drain(..request_range.start as usize - persisted.range.start);
                 Ok(ops)

--- a/dozer-log/src/replication/tests.rs
+++ b/dozer-log/src/replication/tests.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use tempdir::TempDir;
 use tokio::{runtime::Runtime, sync::Mutex};
@@ -98,8 +101,9 @@ fn watch_partial() {
         LogOperation::SnapshottingDone {
             connection_name: "0".to_string(),
         },
-        LogOperation::SnapshottingDone {
-            connection_name: "1".to_string(),
+        LogOperation::Commit {
+            source_states: Default::default(),
+            decision_instant: SystemTime::now(),
         },
     ];
     for op in &ops {
@@ -136,8 +140,9 @@ fn watch_out_of_range() {
         LogOperation::SnapshottingDone {
             connection_name: "0".to_string(),
         },
-        LogOperation::SnapshottingDone {
-            connection_name: "1".to_string(),
+        LogOperation::Commit {
+            source_states: Default::default(),
+            decision_instant: SystemTime::now(),
         },
         LogOperation::SnapshottingDone {
             connection_name: "2".to_string(),
@@ -176,8 +181,9 @@ fn in_memory_log_should_shrink_after_persist() {
         LogOperation::SnapshottingDone {
             connection_name: "0".to_string(),
         },
-        LogOperation::SnapshottingDone {
-            connection_name: "1".to_string(),
+        LogOperation::Commit {
+            source_states: Default::default(),
+            decision_instant: SystemTime::now(),
         },
         LogOperation::SnapshottingDone {
             connection_name: "2".to_string(),

--- a/dozer-tests/src/cache_tests/film/load_database.rs
+++ b/dozer-tests/src/cache_tests/film/load_database.rs
@@ -65,7 +65,7 @@ pub async fn load_database(
             .await
             .unwrap();
     }
-    cache.commit().unwrap();
+    cache.commit(&Default::default(), 0).unwrap();
     cache_manager.wait_until_indexing_catchup();
 
     drop(cache);


### PR DESCRIPTION
This PR is a preparation for solving the log data loss problem.

- We store `SourceStates` in cache, so when cache reconnects to a log, it knows whether it needs to roll back.
- We keep track of the `SourceStates` that was persisted when a `Log` is restored from checkpoint, so a reconnecting client knows where to roll back to if necessary.