### PR TITLE
refactor: Store source states and log position in one database

### DIFF
--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -121,7 +121,7 @@ pub fn initialize_cache(
     for record in records {
         cache.insert(&record.record).unwrap();
     }
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     cache_manager.wait_until_indexing_catchup();
 
     Box::new(cache_manager)

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -18,7 +18,7 @@ fn insert(cache: &Mutex<Box<dyn RwCache>>, n: usize, commit_size: usize) {
     cache.insert(&record).unwrap();
 
     if n % commit_size == 0 {
-        cache.commit(&Default::default(), 0).unwrap();
+        cache.commit(&Default::default()).unwrap();
     }
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/dump_restore.rs
@@ -41,7 +41,9 @@ pub fn begin_dump_txn<C: LmdbCache>(
 ) -> Result<DumpTransaction<RoTransaction>, CacheError> {
     let main_env = cache.main_env();
     let main_txn = main_env.begin_txn()?;
-    let main_env_metadata = main_env.log_positions_with_txn(&main_txn)?;
+    let main_env_metadata = main_env
+        .commit_state_with_txn(&main_txn)?
+        .map(|commit_state| commit_state.log_position);
 
     let mut secondary_txns = vec![];
     let mut secondary_metadata = vec![];
@@ -139,7 +141,7 @@ mod tests {
         insert_rec_1(&mut cache, (0, Some("a".to_string()), None));
         insert_rec_1(&mut cache, (1, None, Some(2)));
         insert_rec_1(&mut cache, (2, Some("b".to_string()), Some(3)));
-        cache.commit(&Default::default(), 0).unwrap();
+        cache.commit(&Default::default()).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         let mut data = vec![];

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
@@ -36,7 +36,7 @@ fn ignore_insert_error_when_type_nothing() {
         lifetime: None,
     };
     env.insert(&record).unwrap();
-    env.commit(&Default::default(), 0).unwrap();
+    env.commit(&Default::default()).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -67,7 +67,7 @@ fn update_after_insert_error_when_type_update() {
         lifetime: None,
     };
     env.insert(&record).unwrap();
-    env.commit(&Default::default(), 0).unwrap();
+    env.commit(&Default::default()).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -85,7 +85,7 @@ fn update_after_insert_error_when_type_update() {
     };
 
     env.insert(&second_record).unwrap();
-    env.commit(&Default::default(), 0).unwrap();
+    env.commit(&Default::default()).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -113,7 +113,7 @@ fn return_insert_error_when_type_panic() {
         lifetime: None,
     };
     env.insert(&record).unwrap();
-    env.commit(&Default::default(), 0).unwrap();
+    env.commit(&Default::default()).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();
@@ -179,7 +179,7 @@ fn update_after_update_error_when_type_upsert() {
         lifetime: None,
     };
     env.update(&initial_record, &update_record).unwrap();
-    env.commit(&Default::default(), 0).unwrap();
+    env.commit(&Default::default()).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = env.get(&key).unwrap();

--- a/dozer-cache/src/cache/lmdb/cache/query/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/query/tests.rs
@@ -20,7 +20,7 @@ fn query_secondary_sorted_inverted() {
     ]);
 
     cache.insert(&record).unwrap();
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     let filter = FilterExpression::And(vec![
@@ -51,7 +51,7 @@ fn query_secondary_full_text() {
     ]);
 
     cache.insert(&record).unwrap();
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     let filter = FilterExpression::Simple("foo".into(), Operator::Contains, "good".into());
@@ -89,7 +89,7 @@ fn query_secondary_vars() {
     for val in items {
         insert_rec_1(&mut cache, val);
     }
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     test_query(json!({}), 8, &cache);
@@ -198,7 +198,7 @@ fn query_secondary_multi_indices() {
         };
         cache.insert(&record).unwrap();
     }
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     let query = query_from_filter(FilterExpression::And(vec![

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
@@ -155,7 +155,7 @@ pub mod tests {
         main_env.insert(&record_a).unwrap();
         main_env.insert(&record_b).unwrap();
         main_env.delete(&record_a).unwrap();
-        main_env.commit(&Default::default(), 0).unwrap();
+        main_env.commit(&Default::default()).unwrap();
 
         let mut env = RwSecondaryEnvironment::new(
             &IndexDefinition::SortedInverted(vec![0]),

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/indexer.rs
@@ -116,7 +116,7 @@ mod tests {
         for val in items.clone() {
             lmdb_utils::insert_rec_1(&mut cache, val);
         }
-        cache.commit(&Default::default(), 0).unwrap();
+        cache.commit(&Default::default()).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         // No of index dbs
@@ -137,7 +137,7 @@ mod tests {
             };
             cache.delete(&record).unwrap();
         }
-        cache.commit(&Default::default(), 0).unwrap();
+        cache.commit(&Default::default()).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         assert_eq!(
@@ -187,7 +187,7 @@ mod tests {
             cache.delete(&record).unwrap();
         }
 
-        cache.commit(&Default::default(), 0).unwrap();
+        cache.commit(&Default::default()).unwrap();
         indexing_thread_pool.lock().wait_until_catchup();
 
         assert_eq!(

--- a/dozer-cache/src/cache/lmdb/tests/basic.rs
+++ b/dozer-cache/src/cache/lmdb/tests/basic.rs
@@ -50,7 +50,7 @@ fn insert_get_and_delete_record() {
     let UpsertResult::Inserted { meta } = cache.insert(&record).unwrap() else {
         panic!("Must be inserted")
     };
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 1);
@@ -70,7 +70,7 @@ fn insert_get_and_delete_record() {
             .unwrap(),
         meta
     );
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     assert_eq!(cache.count(&QueryExpression::with_no_limit()).unwrap(), 0);
@@ -106,7 +106,7 @@ fn insert_and_query_record_impl(
     let record = Record::new(vec![Field::String(val)]);
 
     cache.insert(&record).unwrap();
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     indexing_thread_pool.lock().wait_until_catchup();
 
     // Query with an expression
@@ -152,7 +152,7 @@ fn update_record_when_primary_changes() {
     };
 
     cache.insert(&initial_record).unwrap();
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
 
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
     let record = cache.get(&key).unwrap().record;
@@ -160,7 +160,7 @@ fn update_record_when_primary_changes() {
     assert_eq!(initial_values, record.values);
 
     cache.update(&initial_record, &updated_record).unwrap();
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
 
     // Primary key with old values
     let key = index::get_primary_key(&schema.primary_index, &initial_values);
@@ -177,20 +177,12 @@ fn update_record_when_primary_changes() {
 }
 
 #[test]
-fn test_cache_source_states() {
+fn test_cache_commit_state() {
     let (mut cache, _, _) = _setup();
-    assert!(cache.get_source_states().unwrap().is_none());
-    cache.commit(&Default::default(), 0).unwrap();
+    assert!(cache.get_commit_state().unwrap().is_none());
+    cache.commit(&Default::default()).unwrap();
     assert_eq!(
-        cache.get_source_states().unwrap().unwrap(),
+        cache.get_commit_state().unwrap().unwrap(),
         Default::default()
     );
-}
-
-#[test]
-fn test_cache_log_position() {
-    let (mut cache, _, _) = _setup();
-    assert!(cache.get_log_position().unwrap().is_none());
-    cache.commit(&Default::default(), 32).unwrap();
-    assert_eq!(cache.get_log_position().unwrap().unwrap(), 32);
 }

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -43,7 +43,7 @@ fn read_and_write() {
     for val in items.clone() {
         lmdb_utils::insert_rec_1(&mut cache_writer, val.clone());
     }
-    cache_writer.commit(&Default::default(), 0).unwrap();
+    cache_writer.commit(&Default::default()).unwrap();
 
     indexing_thread_pool.lock().wait_until_catchup();
 

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -93,8 +93,7 @@ pub trait RoCache: Send + Sync + Debug {
     fn query(&self, query: &QueryExpression) -> Result<Vec<CacheRecord>, CacheError>;
 
     // Cache metadata
-    fn get_source_states(&self) -> Result<Option<SourceStates>, CacheError>;
-    fn get_log_position(&self) -> Result<Option<u64>, CacheError>;
+    fn get_commit_state(&self) -> Result<Option<CommitState>, CacheError>;
     fn is_snapshotting_done(&self) -> Result<bool, CacheError>;
 }
 
@@ -123,6 +122,13 @@ pub enum UpsertResult {
     Ignored,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(crate = "dozer_types::serde")]
+pub struct CommitState {
+    pub source_states: SourceStates,
+    pub log_position: u64,
+}
+
 pub trait RwCache: RoCache {
     /// Inserts a record into the cache. Implicitly starts a transaction if there's no active transaction.
     ///
@@ -148,6 +154,5 @@ pub trait RwCache: RoCache {
         -> Result<(), CacheError>;
 
     /// Commits the current transaction.
-    fn commit(&mut self, source_states: &SourceStates, log_position: u64)
-        -> Result<(), CacheError>;
+    fn commit(&mut self, state: &CommitState) -> Result<(), CacheError>;
 }

--- a/dozer-tests/src/cache_tests/film/load_database.rs
+++ b/dozer-tests/src/cache_tests/film/load_database.rs
@@ -65,7 +65,7 @@ pub async fn load_database(
             .await
             .unwrap();
     }
-    cache.commit(&Default::default(), 0).unwrap();
+    cache.commit(&Default::default()).unwrap();
     cache_manager.wait_until_indexing_catchup();
 
     drop(cache);


### PR DESCRIPTION
This is a follow-up to https://github.com/getdozer/dozer/pull/2158. We shouldn't have used two different databases because the two pieces of information always appear together.