### PR TITLE
feat: Split cache name and label

### DIFF
--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -77,13 +77,18 @@ pub fn open_or_create_cache(
     connections: &HashSet<String>,
     write_options: CacheWriteOptions,
 ) -> Result<Box<dyn RwCache>, CacheError> {
-    match cache_manager.open_rw_cache(labels.clone(), write_options)? {
+    match cache_manager.open_rw_cache(
+        labels.to_non_empty_string().into_owned(),
+        labels.clone(),
+        write_options,
+    )? {
         Some(cache) => {
             debug_assert!(cache.get_schema() == &schema);
             Ok(cache)
         }
         None => {
             let cache = cache_manager.create_cache(
+                labels.to_non_empty_string().into_owned(),
                 labels,
                 schema.0,
                 schema.1,

--- a/dozer-api/src/lib.rs
+++ b/dozer-api/src/lib.rs
@@ -136,7 +136,7 @@ fn open_cache_reader(
     labels: Labels,
 ) -> Result<Option<CacheReader>, ApiInitError> {
     let cache = cache_manager
-        .open_ro_cache(labels)
+        .open_ro_cache(labels.to_non_empty_string().into_owned(), labels)
         .map_err(ApiInitError::OpenOrCreateCache)?;
     Ok(cache.map(CacheReader::new))
 }

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -110,6 +110,7 @@ pub fn initialize_cache(
     let (schema, secondary_indexes) = schema.unwrap_or_else(get_schema);
     let mut cache = cache_manager
         .create_cache(
+            labels.to_non_empty_string().into_owned(),
             labels,
             schema,
             secondary_indexes,

--- a/dozer-cache/benches/cache.rs
+++ b/dozer-cache/benches/cache.rs
@@ -58,6 +58,7 @@ fn cache(c: &mut Criterion) {
     let cache = Mutex::new(
         cache_manager
             .create_cache(
+                "temp".to_string(),
                 Default::default(),
                 schema,
                 secondary_indexes,

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
@@ -18,7 +18,7 @@ fn init_env(conflict_resolution: ConflictResolution) -> (RwMainEnvironment, Sche
         ..Default::default()
     };
     let main_env =
-        RwMainEnvironment::new(Some(&schema), None, &Default::default(), write_options).unwrap();
+        RwMainEnvironment::new(Some(&schema), None, Default::default(), write_options).unwrap();
     (main_env, schema.0)
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/hash_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/hash_tests.rs
@@ -10,7 +10,7 @@ fn test_hash_insert_delete_insert() {
     let mut env = RwMainEnvironment::new(
         Some(&(schema, vec![])),
         None,
-        &Default::default(),
+        Default::default(),
         Default::default(),
     )
     .unwrap();

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/tests.rs
@@ -53,7 +53,7 @@ pub fn assert_operation_log_equal<T1: Transaction, T2: Transaction>(
 #[test]
 fn test_operation_log_append_only() {
     let mut env = create_env(&Default::default()).unwrap().0;
-    let log = OperationLog::create(&mut env, Default::default()).unwrap();
+    let log = OperationLog::create(&mut env, "temp".to_string(), Default::default()).unwrap();
     let txn = env.txn_mut().unwrap();
     let append_only = true;
 
@@ -96,7 +96,7 @@ fn test_operation_log_append_only() {
 #[test]
 fn test_operation_log_with_primary_key() {
     let mut env = create_env(&Default::default()).unwrap().0;
-    let log = OperationLog::create(&mut env, Default::default()).unwrap();
+    let log = OperationLog::create(&mut env, "temp".to_string(), Default::default()).unwrap();
     let txn = env.txn_mut().unwrap();
     let append_only = false;
 
@@ -219,7 +219,7 @@ fn test_operation_log_with_primary_key() {
 #[test]
 fn test_operation_log_without_primary_key() {
     let mut env = create_env(&Default::default()).unwrap().0;
-    let log = OperationLog::create(&mut env, Default::default()).unwrap();
+    let log = OperationLog::create(&mut env, "temp".to_string(), Default::default()).unwrap();
     let txn = env.txn_mut().unwrap();
     let append_only = false;
 

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/dump_restore.rs
@@ -43,7 +43,7 @@ pub async fn dump<'txn, E: SecondaryEnvironment, T: Transaction>(
 
 pub async fn restore(
     name: String,
-    options: &CacheOptions,
+    options: CacheOptions,
     reader: &mut (impl AsyncRead + Unpin),
 ) -> Result<RwSecondaryEnvironment, CacheError> {
     info!("Restoring secondary environment {name} with options {options:?}");
@@ -139,7 +139,7 @@ pub mod tests {
         let mut main_env = RwMainEnvironment::new(
             Some(&(schema, vec![])),
             None,
-            &Default::default(),
+            Default::default(),
             Default::default(),
         )
         .unwrap();
@@ -160,7 +160,7 @@ pub mod tests {
         let mut env = RwSecondaryEnvironment::new(
             &IndexDefinition::SortedInverted(vec![0]),
             "0".to_string(),
-            &Default::default(),
+            Default::default(),
         )
         .unwrap();
         {
@@ -186,7 +186,7 @@ pub mod tests {
             }
         }
 
-        let restored_env = restore("0".to_string(), &Default::default(), &mut data.as_slice())
+        let restored_env = restore("0".to_string(), Default::default(), &mut data.as_slice())
             .await
             .unwrap();
         assert_secondary_env_equal(&env, &restored_env);

--- a/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/secondary_environment/mod.rs
@@ -80,7 +80,7 @@ impl RwSecondaryEnvironment {
     pub fn new(
         index_definition: &IndexDefinition,
         name: String,
-        options: &CacheOptions,
+        options: CacheOptions,
     ) -> Result<Self, CacheError> {
         let mut env = create_env(&get_cache_options(name.clone(), options))?.0;
 
@@ -212,7 +212,7 @@ impl SecondaryEnvironment for RoSecondaryEnvironment {
 }
 
 impl RoSecondaryEnvironment {
-    pub fn new(name: String, options: &CacheOptions) -> Result<Self, CacheError> {
+    pub fn new(name: String, options: CacheOptions) -> Result<Self, CacheError> {
         let env = open_env(&get_cache_options(name.clone(), options))?.0;
 
         let database = LmdbMultimap::open(&env, Some(DATABASE_DB_NAME))?;
@@ -239,14 +239,12 @@ impl RoSecondaryEnvironment {
 
 pub mod dump_restore;
 
-fn get_cache_options(name: String, options: &CacheOptions) -> CacheOptions {
-    let path = options.path.as_ref().map(|(main_base_path, main_labels)| {
-        let base_path = main_base_path.join(format!("{}_index", main_labels));
-        let mut labels = Labels::empty();
-        labels.push("secondary_index", name);
-        (base_path, labels)
+fn get_cache_options(name: String, options: CacheOptions) -> CacheOptions {
+    let path = options.path.as_ref().map(|(main_base_path, main_name)| {
+        let base_path = main_base_path.join(format!("{}_index", main_name));
+        (base_path, format!("secondary_index_{name}"))
     });
-    CacheOptions { path, ..*options }
+    CacheOptions { path, ..options }
 }
 
 fn set_comparator<E: LmdbEnvironment>(

--- a/dozer-cache/src/cache/lmdb/indexing.rs
+++ b/dozer-cache/src/cache/lmdb/indexing.rs
@@ -63,9 +63,9 @@ impl IndexingThreadPool {
         }
     }
 
-    pub fn find_cache(&self, labels: &Labels) -> Option<LmdbRoCache> {
+    pub fn find_cache(&self, name: &str) -> Option<LmdbRoCache> {
         for cache in self.caches.iter() {
-            if cache.main_env.labels() == labels {
+            if cache.main_env.name() == name {
                 let secondary_envs = cache
                     .secondary_envs
                     .iter()

--- a/dozer-cache/src/cache/lmdb/tests/read_write.rs
+++ b/dozer-cache/src/cache/lmdb/tests/read_write.rs
@@ -12,7 +12,7 @@ use tempdir::TempDir;
 #[test]
 fn read_and_write() {
     let path = TempDir::new("dozer").unwrap();
-    let path = (path.path().to_path_buf(), Default::default());
+    let path = (path.path().to_path_buf(), "temp".to_string());
 
     // write and read from cache from two different threads.
 
@@ -21,12 +21,13 @@ fn read_and_write() {
     let mut cache_writer = LmdbRwCache::new(
         Some(&schema),
         None,
-        &CacheOptions {
+        CacheOptions {
             max_readers: 2,
             max_db_size: 100,
             max_size: 1024 * 1024,
             path: Some(path.clone()),
             intersection_chunk_size: 1,
+            labels: Default::default(),
         },
         Default::default(),
         indexing_thread_pool.clone(),
@@ -51,7 +52,7 @@ fn read_and_write() {
         path: Some(path),
         ..Default::default()
     };
-    let cache_reader = LmdbRoCache::new(&read_options).unwrap();
+    let cache_reader = LmdbRoCache::new(read_options).unwrap();
     for (a, b, c) in items {
         let rec = cache_reader.get(&Field::Int(a).encode()).unwrap();
         let values = vec![

--- a/dozer-cache/src/cache/lmdb/tests/utils.rs
+++ b/dozer-cache/src/cache/lmdb/tests/utils.rs
@@ -24,7 +24,7 @@ pub fn create_cache(
     let cache = LmdbRwCache::new(
         Some(&schema),
         None,
-        &Default::default(),
+        Default::default(),
         Default::default(),
         indexing_thread_pool.clone(),
     )

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -40,8 +40,12 @@ impl CacheRecord {
 }
 
 pub trait RoCacheManager: Send + Sync + Debug {
-    /// Opens a cache in read-only mode with given labels.
-    fn open_ro_cache(&self, labels: Labels) -> Result<Option<Box<dyn RoCache>>, CacheError>;
+    /// Opens a cache in read-only mode, and attach given labels.
+    fn open_ro_cache(
+        &self,
+        name_or_alias: String,
+        labels: Labels,
+    ) -> Result<Option<Box<dyn RoCache>>, CacheError>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -53,9 +57,10 @@ pub struct CacheWriteOptions {
 }
 
 pub trait RwCacheManager: RoCacheManager {
-    /// Opens a cache in read-write mode with given labels.
+    /// Opens a cache in read-write mode, and attach given labels.
     fn open_rw_cache(
         &self,
+        name_or_alias: String,
         labels: Labels,
         write_options: CacheWriteOptions,
     ) -> Result<Option<Box<dyn RwCache>>, CacheError>;
@@ -64,9 +69,10 @@ pub trait RwCacheManager: RoCacheManager {
     ///
     /// Schemas cannot be changed after the cache is created.
     ///
-    /// The labels must be unique.
+    /// The name must be unique and non-empty.
     fn create_cache(
         &self,
+        name: String,
         labels: Labels,
         schema: Schema,
         indexes: Vec<IndexDefinition>,
@@ -81,6 +87,8 @@ pub trait RwCacheManager: RoCacheManager {
 }
 
 pub trait RoCache: Send + Sync + Debug {
+    /// Returns the name of the cache.
+    fn name(&self) -> &str;
     /// Returns the labels of the cache.
     fn labels(&self) -> &Labels;
 

--- a/dozer-cache/src/errors.rs
+++ b/dozer-cache/src/errors.rs
@@ -39,6 +39,8 @@ pub enum CacheError {
 
     #[error("Storage error: {0}")]
     Storage(#[from] dozer_storage::errors::StorageError),
+    #[error("Cache name is empty")]
+    EmptyName,
     #[error("Schema is not found")]
     SchemaNotFound,
     #[error("Schema for {name} mismatch: given {given:?}, stored {stored:?}")]

--- a/dozer-cache/src/main.rs
+++ b/dozer-cache/src/main.rs
@@ -51,7 +51,10 @@ async fn main() {
                 ..Default::default()
             })
             .unwrap();
-            let cache = cache_manager.open_lmdb_cache(labels).unwrap().unwrap();
+            let cache = cache_manager
+                .open_lmdb_cache(labels.to_non_empty_string().into_owned(), labels)
+                .unwrap()
+                .unwrap();
             let count = cache.count(&QueryExpression::with_no_limit()).unwrap();
             println!("Count: {}", count);
         }
@@ -61,7 +64,10 @@ async fn main() {
                 ..Default::default()
             })
             .unwrap();
-            let cache = &cache_manager.open_lmdb_cache(labels).unwrap().unwrap();
+            let cache = &cache_manager
+                .open_lmdb_cache(labels.to_non_empty_string().into_owned(), labels)
+                .unwrap()
+                .unwrap();
             let file = tokio::fs::File::create(path).await.unwrap();
             let mut writer = tokio::io::BufWriter::new(file);
 
@@ -84,7 +90,12 @@ async fn main() {
             let file = tokio::fs::File::open(path).await.unwrap();
             let mut reader = tokio::io::BufReader::new(file);
             cache_manager
-                .restore_cache(labels, Default::default(), &mut reader)
+                .restore_cache(
+                    labels.to_non_empty_string().into_owned(),
+                    labels,
+                    Default::default(),
+                    &mut reader,
+                )
                 .await
                 .unwrap();
         }

--- a/dozer-tests/src/cache_tests/film/load_database.rs
+++ b/dozer-tests/src/cache_tests/film/load_database.rs
@@ -21,6 +21,7 @@ pub async fn load_database(
     let labels = Labels::default();
     let mut cache = cache_manager
         .create_cache(
+            labels.to_non_empty_string().into_owned(),
             labels.clone(),
             schema.clone(),
             secondary_indexes,
@@ -70,7 +71,10 @@ pub async fn load_database(
 
     drop(cache);
     (
-        cache_manager.open_ro_cache(labels).unwrap().unwrap(),
+        cache_manager
+            .open_ro_cache(labels.to_non_empty_string().into_owned(), labels)
+            .unwrap()
+            .unwrap(),
         mongo_collection,
     )
 }


### PR DESCRIPTION
Every cache is a file under the `cache_dir`. Previously we're using the metrics labels as the cache file name. This works when there's a unique cache for each endpoint.

However, as we're going to introduce blue green cache again, this naming convention can not be used anymore.
Here we add a `name` parameter to `RwCacheManager::create_cache`, to allow the user to use a different name from the labels. The labels only affects the metrics labels now. And we can open the same cache while attaching different labels.

The plan is to use the labels as cache alias to enable switching between blue green cache.