### PR TITLE
chore: Remove legacy `build_name` and `descriptor_bytes` from `EndpointMeta`

### DIFF
--- a/dozer-api/Cargo.toml
+++ b/dozer-api/Cargo.toml
@@ -52,6 +52,4 @@ http = "0.2.9"
 pin-project = "1.1.3"
 async-stream = "0.3.5"
 uuid = "1.4.1"
-
-[dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-api/src/cache_builder/builder_impl.rs
+++ b/dozer-api/src/cache_builder/builder_impl.rs
@@ -352,7 +352,6 @@ mod tests {
                 enable_on_event: Default::default(),
                 connections: Default::default(),
             },
-            descriptor_bytes: Default::default(),
         }
     }
 

--- a/dozer-api/src/cache_builder/builder_impl.rs
+++ b/dozer-api/src/cache_builder/builder_impl.rs
@@ -343,7 +343,6 @@ mod tests {
         EndpointMeta {
             name: Default::default(),
             log_id,
-            build_name: Default::default(),
             schema: EndpointSchema {
                 path: Default::default(),
                 schema: Default::default(),

--- a/dozer-api/src/cache_builder/endpoint_meta.rs
+++ b/dozer-api/src/cache_builder/endpoint_meta.rs
@@ -16,7 +16,6 @@ pub struct EndpointMeta {
     pub log_id: String,
     pub build_name: String,
     pub schema: EndpointSchema,
-    pub descriptor_bytes: Vec<u8>,
 }
 
 impl EndpointMeta {
@@ -41,7 +40,6 @@ impl EndpointMeta {
                 log_id,
                 build_name: build.name,
                 schema,
-                descriptor_bytes: build.descriptor_bytes,
             },
             log_client,
         ))

--- a/dozer-api/src/cache_builder/endpoint_meta.rs
+++ b/dozer-api/src/cache_builder/endpoint_meta.rs
@@ -14,7 +14,6 @@ use crate::{cache_alias_and_labels, errors::ApiInitError};
 pub struct EndpointMeta {
     pub name: String,
     pub log_id: String,
-    pub build_name: String,
     pub schema: EndpointSchema,
 }
 
@@ -38,7 +37,6 @@ impl EndpointMeta {
             Self {
                 name: endpoint,
                 log_id,
-                build_name: build.name,
                 schema,
             },
             log_client,
@@ -46,8 +44,7 @@ impl EndpointMeta {
     }
 
     pub fn cache_alias_and_labels(&self, extra_labels: Labels) -> (String, Labels) {
-        let (alias, mut labels) =
-            cache_alias_and_labels(self.name.clone(), self.build_name.clone());
+        let (alias, mut labels) = cache_alias_and_labels(self.name.clone());
         labels.extend(extra_labels);
         (alias, labels)
     }

--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -5,6 +5,7 @@ use crate::errors::ApiInitError;
 use arc_swap::ArcSwap;
 use dozer_cache::cache::{RoCache, RwCache};
 use dozer_cache::dozer_log::reader::{LogClient, LogReader, LogReaderOptions};
+use dozer_cache::dozer_log::schemas::EndpointSchema;
 use dozer_cache::CacheReader;
 use dozer_cache::{
     cache::{CacheWriteOptions, RwCacheManager},
@@ -52,7 +53,7 @@ impl CacheBuilder {
         app_server_url: String,
         endpoint: &ApiEndpoint,
         labels: LabelsAndProgress,
-    ) -> Result<(Self, Vec<u8>), ApiInitError> {
+    ) -> Result<(Self, EndpointSchema), ApiInitError> {
         // Connect to the endpoint's log.
         let mut client = InternalPipelineServiceClient::connect(app_server_url.clone())
             .await
@@ -86,7 +87,7 @@ impl CacheBuilder {
                 progress_bar,
                 log_reader_options,
             },
-            endpoint_meta.descriptor_bytes,
+            endpoint_meta.schema,
         ))
     }
 

--- a/dozer-api/src/errors.rs
+++ b/dozer-api/src/errors.rs
@@ -9,7 +9,7 @@ use dozer_tracing::Labels;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::errors::types::{CannotConvertF64ToJson, TypeError};
 use dozer_types::thiserror::Error;
-use dozer_types::{bincode, serde_json, thiserror, tonic};
+use dozer_types::{serde_json, thiserror, tonic};
 
 use dozer_cache::errors::CacheError;
 use handlebars::{RenderError, TemplateError};
@@ -35,8 +35,8 @@ pub enum ApiInitError {
     GetCacheCommitState(#[source] CacheError),
     #[error("Failed to parse endpoint schema: {0}")]
     ParseEndpointSchema(#[from] serde_json::Error),
-    #[error("Failed to parse checkpoint: {0}")]
-    ParseCheckpoint(#[from] bincode::Error),
+    #[error("Failed to create temp dir: {0}")]
+    CreateTempDir(#[source] std::io::Error),
     #[error("Failed to open or create cache: {0}")]
     OpenOrCreateCache(#[source] CacheError),
     #[error("Failed to find cache: {0}")]

--- a/dozer-api/src/generator/protoc/mod.rs
+++ b/dozer-api/src/generator/protoc/mod.rs
@@ -1,4 +1,39 @@
+use std::path::Path;
+
+use dozer_cache::dozer_log::schemas::EndpointSchema;
+
+use crate::errors::GenerationError;
+
+use self::generator::ProtoGenerator;
+
 pub mod generator;
+
+pub fn generate_all<'a, I: IntoIterator<Item = (&'a str, &'a EndpointSchema)>>(
+    proto_folder_path: &Path,
+    descriptor_path: &Path,
+    endpoints: I,
+) -> Result<Vec<u8>, GenerationError> {
+    let mut resources = Vec::new();
+
+    for (endpoint_name, schema) in endpoints {
+        let resource_name = ProtoGenerator::generate(proto_folder_path, endpoint_name, schema)?;
+        resources.push(resource_name);
+    }
+
+    let common_resources = ProtoGenerator::copy_common(proto_folder_path)?;
+
+    // Copy common service to be included in descriptor.
+    resources.extend(common_resources);
+
+    // Generate a descriptor based on all proto files generated.
+    ProtoGenerator::generate_descriptor(proto_folder_path, descriptor_path, &resources)?;
+
+    // Read descriptor data.
+    let descriptor = std::fs::read(descriptor_path)
+        .map_err(|e| GenerationError::FailedToReadProtoDescriptor(descriptor_path.into(), e))?;
+
+    Ok(descriptor)
+}
 
 #[cfg(test)]
 mod tests;

--- a/dozer-api/src/grpc/internal/internal_pipeline_server.rs
+++ b/dozer-api/src/grpc/internal/internal_pipeline_server.rs
@@ -33,7 +33,6 @@ use crate::shutdown::ShutdownReceiver;
 pub struct LogEndpoint {
     pub build_id: BuildId,
     pub schema_string: String,
-    pub descriptor_bytes: Vec<u8>,
     pub log: Arc<Mutex<Log>>,
 }
 
@@ -152,7 +151,6 @@ fn get_build_response(endpoint: &LogEndpoint) -> BuildResponse {
     BuildResponse {
         name: endpoint.build_id.name().to_owned(),
         schema_string: endpoint.schema_string.clone(),
-        descriptor_bytes: endpoint.descriptor_bytes.clone(),
     }
 }
 

--- a/dozer-api/src/grpc/internal/internal_pipeline_server.rs
+++ b/dozer-api/src/grpc/internal/internal_pipeline_server.rs
@@ -1,5 +1,4 @@
 use async_stream::stream;
-use dozer_cache::dozer_log::home_dir::BuildId;
 use dozer_cache::dozer_log::replication::{Log, LogResponseFuture};
 use dozer_types::bincode;
 use dozer_types::grpc_types::internal::internal_pipeline_service_server::{
@@ -30,7 +29,6 @@ use crate::shutdown::ShutdownReceiver;
 
 #[derive(Debug, Clone)]
 pub struct LogEndpoint {
-    pub build_id: BuildId,
     pub schema_string: String,
     pub log: Arc<Mutex<Log>>,
 }
@@ -134,7 +132,6 @@ impl InternalPipelineService for InternalPipelineServer {
 
 fn get_build_response(endpoint: &LogEndpoint) -> BuildResponse {
     BuildResponse {
-        name: endpoint.build_id.name().to_owned(),
         schema_string: endpoint.schema_string.clone(),
     }
 }

--- a/dozer-api/src/grpc/internal/internal_pipeline_server.rs
+++ b/dozer-api/src/grpc/internal/internal_pipeline_server.rs
@@ -6,9 +6,8 @@ use dozer_types::grpc_types::internal::internal_pipeline_service_server::{
     InternalPipelineService, InternalPipelineServiceServer,
 };
 use dozer_types::grpc_types::internal::{
-    BuildRequest, BuildResponse, DescribeApplicationRequest, DescribeApplicationResponse,
-    EndpointResponse, EndpointsResponse, GetIdResponse, LogRequest, LogResponse, StorageRequest,
-    StorageResponse,
+    BuildRequest, BuildResponse, DescribeApplicationResponse, GetIdResponse, LogRequest,
+    LogResponse, StorageRequest, StorageResponse,
 };
 use dozer_types::log::info;
 use dozer_types::models::api_config::{
@@ -71,23 +70,9 @@ impl InternalPipelineService for InternalPipelineServer {
         }))
     }
 
-    async fn list_endpoints(
-        &self,
-        _request: Request<()>,
-    ) -> Result<Response<EndpointsResponse>, Status> {
-        let endpoints = self
-            .endpoints
-            .iter()
-            .map(|(endpoint, log)| EndpointResponse {
-                endpoint: endpoint.clone(),
-                build_name: log.build_id.name().to_string(),
-            })
-            .collect();
-        Ok(Response::new(EndpointsResponse { endpoints }))
-    }
     async fn describe_application(
         &self,
-        _: Request<DescribeApplicationRequest>,
+        _: Request<()>,
     ) -> Result<Response<DescribeApplicationResponse>, Status> {
         let mut endpoints = HashMap::with_capacity(self.endpoints.len());
 

--- a/dozer-api/src/lib.rs
+++ b/dozer-api/src/lib.rs
@@ -4,7 +4,9 @@ use dozer_cache::{cache::RwCacheManager, errors::CacheError, CacheReader};
 use dozer_tracing::{Labels, LabelsAndProgress};
 use dozer_types::{grpc_types::types::Operation, models::api_endpoint::ApiEndpoint};
 use futures_util::Future;
+use generator::protoc::generate_all;
 use std::{ops::Deref, sync::Arc};
+use tempdir::TempDir;
 
 pub use tonic_reflection;
 pub use tonic_web;
@@ -32,9 +34,20 @@ impl CacheEndpoint {
         operations_sender: Option<Sender<Operation>>,
         labels: LabelsAndProgress,
     ) -> Result<(Self, JoinHandle<Result<(), CacheError>>), ApiInitError> {
-        let (cache_builder, descriptor) =
+        // Create cache builder.
+        let (cache_builder, endpoint_schema) =
             CacheBuilder::new(cache_manager, app_server_url, &endpoint, labels).await?;
         let cache_reader = cache_builder.cache_reader().clone();
+
+        // Generate descriptor.
+        let temp_dir = TempDir::new(&endpoint.name).map_err(ApiInitError::CreateTempDir)?;
+        let proto_folder_path = temp_dir.path();
+        let descriptor_path = proto_folder_path.join("descriptor.bin");
+        let descriptor = generate_all(
+            proto_folder_path,
+            &descriptor_path,
+            [(endpoint.name.as_str(), &endpoint_schema)],
+        )?;
 
         // Start cache builder.
         let handle = {

--- a/dozer-api/src/lib.rs
+++ b/dozer-api/src/lib.rs
@@ -22,7 +22,6 @@ pub struct CacheEndpoint {
 }
 
 const ENDPOINT_LABEL: &str = "endpoint";
-const BUILD_LABEL: &str = "build";
 
 impl CacheEndpoint {
     pub async fn new(
@@ -97,10 +96,9 @@ impl CacheEndpoint {
     }
 }
 
-pub fn cache_alias_and_labels(endpoint: String, build: String) -> (String, Labels) {
+pub fn cache_alias_and_labels(endpoint: String) -> (String, Labels) {
     let mut labels = Labels::new();
     labels.push(ENDPOINT_LABEL, endpoint);
-    labels.push(BUILD_LABEL, build);
     (labels.to_non_empty_string().into_owned(), labels)
 }
 

--- a/dozer-cli/src/simple/build/mod.rs
+++ b/dozer-cli/src/simple/build/mod.rs
@@ -1,5 +1,4 @@
 use dozer_cache::dozer_log::home_dir::{BuildId, HomeDir};
-use dozer_types::log::info;
 
 use crate::errors::BuildError;
 
@@ -7,53 +6,8 @@ mod contract;
 
 pub use contract::{Contract, PipelineContract};
 
-pub async fn build(
-    home_dir: &HomeDir,
-    contract: &Contract,
-    existing_contract: Option<&Contract>,
-) -> Result<(), BuildError> {
-    if let Some(build_id) = new_build_id(home_dir, contract, existing_contract).await? {
-        let build_name = build_id.name().to_string();
-        generate_protos(home_dir, build_id, contract)?;
-        info!("Created new build {build_name}");
-    } else {
-        info!("Building not needed");
-    }
-    Ok(())
-}
-
-async fn new_build_id(
-    home_dir: &HomeDir,
-    contract: &Contract,
-    existing_contract: Option<&Contract>,
-) -> Result<Option<BuildId>, BuildError> {
-    let build_path = home_dir
-        .find_latest_build_path()
-        .map_err(|(path, error)| BuildError::FileSystem(path.into(), error))?;
-    let Some(build_path) = build_path else {
-        return Ok(Some(BuildId::first()));
-    };
-
-    let Some(existing_contract) = existing_contract else {
-        return Ok(Some(build_path.id.next()));
-    };
-
-    for (endpoint, schema) in &contract.endpoints {
-        if let Some(existing_schema) = existing_contract.endpoints.get(endpoint) {
-            if schema == existing_schema {
-                continue;
-            }
-        }
-        return Ok(Some(build_path.id.next()));
-    }
-    Ok(None)
-}
-
-fn generate_protos(
-    home_dir: &HomeDir,
-    build_id: BuildId,
-    contract: &Contract,
-) -> Result<(), BuildError> {
+pub fn generate_protos(home_dir: &HomeDir, contract: &Contract) -> Result<(), BuildError> {
+    let build_id = BuildId::first();
     let build_path = home_dir
         .create_build_dir_all(build_id)
         .map_err(|(path, error)| BuildError::FileSystem(path.into(), error))?;

--- a/dozer-cli/src/simple/executor.rs
+++ b/dozer-cli/src/simple/executor.rs
@@ -153,9 +153,5 @@ async fn create_log_endpoint(
     .await?;
     let log = Arc::new(Mutex::new(log));
 
-    Ok(LogEndpoint {
-        build_id: build_path.id.clone(),
-        schema_string,
-        log,
-    })
+    Ok(LogEndpoint { schema_string, log })
 }

--- a/dozer-cli/src/simple/executor.rs
+++ b/dozer-cli/src/simple/executor.rs
@@ -143,12 +143,6 @@ async fn create_log_endpoint(
     let schema_string =
         dozer_types::serde_json::to_string(schema).map_err(BuildError::SerdeJson)?;
 
-    let descriptor_bytes = tokio::fs::read(&build_path.descriptor_path)
-        .await
-        .map_err(|e| {
-            OrchestrationError::FileSystem(build_path.descriptor_path.clone().into(), e)
-        })?;
-
     let log_prefix = AsRef::<Utf8Path>::as_ref(checkpoint.prefix())
         .join(&endpoint_path.log_dir_relative_to_data_dir);
     let log = Log::new(
@@ -162,7 +156,6 @@ async fn create_log_endpoint(
     Ok(LogEndpoint {
         build_id: build_path.id.clone(),
         schema_string,
-        descriptor_bytes,
         log,
     })
 }

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -373,8 +373,8 @@ impl SimpleOrchestrator {
         )?;
 
         let contract_path = self.lockfile_path();
-        let existing_contract = Contract::deserialize(contract_path.as_std_path()).ok();
         if locked {
+            let existing_contract = Contract::deserialize(contract_path.as_std_path()).ok();
             let Some(existing_contract) = existing_contract.as_ref() else {
                 return Err(OrchestrationError::LockedNoLockFile);
             };
@@ -385,11 +385,7 @@ impl SimpleOrchestrator {
         }
 
         // Run build
-        self.runtime.block_on(build::build(
-            &home_dir,
-            &contract,
-            existing_contract.as_ref(),
-        ))?;
+        build::generate_protos(&home_dir, &contract)?;
 
         contract.serialize(contract_path.as_std_path())?;
 

--- a/dozer-ingestion/src/connectors/dozer/connector.rs
+++ b/dozer-ingestion/src/connectors/dozer/connector.rs
@@ -8,7 +8,7 @@ use dozer_types::{
     errors::types::DeserializationError,
     grpc_types::internal::{
         internal_pipeline_service_client::InternalPipelineServiceClient,
-        DescribeApplicationRequest, DescribeApplicationResponse,
+        DescribeApplicationResponse,
     },
     models::ingestion_types::{
         default_buffer_size, default_log_batch_size, default_timeout, IngestionMessage,
@@ -176,14 +176,11 @@ impl NestedDozerConnector {
     async fn describe_application(&self) -> Result<DescribeApplicationResponse, ConnectorError> {
         let mut client = self.get_client().await?;
 
-        let response = client
-            .describe_application(DescribeApplicationRequest {})
-            .await
-            .map_err(|e| {
-                ConnectorError::NestedDozerConnectorError(
-                    NestedDozerConnectorError::DescribeEndpointsError(e),
-                )
-            })?;
+        let response = client.describe_application(()).await.map_err(|e| {
+            ConnectorError::NestedDozerConnectorError(
+                NestedDozerConnectorError::DescribeEndpointsError(e),
+            )
+        })?;
 
         Ok(response.into_inner())
     }

--- a/dozer-log/src/home_dir.rs
+++ b/dozer-log/src/home_dir.rs
@@ -47,7 +47,6 @@ impl HomeDir {
         let build_dir = self.home_dir.join(&build_id.name);
 
         let contracts_dir = build_dir.join("contracts");
-        let dag_path = contracts_dir.join("__dozer_pipeline.json");
         let descriptor_path = contracts_dir.join("file_descriptor_set.bin");
 
         let data_dir = build_dir.join("data");
@@ -56,7 +55,6 @@ impl HomeDir {
         BuildPath {
             id: build_id,
             contracts_dir,
-            dag_path,
             descriptor_path,
             data_dir,
             log_dir_relative_to_data_dir,
@@ -168,7 +166,6 @@ fn find_latest_build_id(dir: Utf8PathBuf) -> Result<Option<BuildId>, Error> {
 pub struct BuildPath {
     pub id: BuildId,
     pub contracts_dir: Utf8PathBuf,
-    pub dag_path: Utf8PathBuf,
     pub descriptor_path: Utf8PathBuf,
     pub data_dir: Utf8PathBuf,
     log_dir_relative_to_data_dir: Utf8PathBuf,

--- a/dozer-log/src/reader.rs
+++ b/dozer-log/src/reader.rs
@@ -43,8 +43,6 @@ impl LogReaderOptions {
 
 #[derive(Debug)]
 pub struct LogReaderBuilder {
-    /// Log server runs on a specific build of the endpoint. This is the name of the build.
-    pub build_name: String,
     /// Schema of this endpoint.
     pub schema: EndpointSchema,
     pub options: LogReaderOptions,
@@ -71,13 +69,11 @@ impl LogReaderBuilder {
             })
             .await?
             .into_inner();
-        let build_name = build.name;
         let schema = serde_json::from_str(&build.schema_string)?;
 
         let client = LogClient::new(&mut client, options.endpoint.clone()).await?;
 
         Ok(Self {
-            build_name,
             schema,
             client,
             options,

--- a/dozer-log/src/reader.rs
+++ b/dozer-log/src/reader.rs
@@ -47,8 +47,6 @@ pub struct LogReaderBuilder {
     pub build_name: String,
     /// Schema of this endpoint.
     pub schema: EndpointSchema,
-    /// Protobuf descriptor of this endpoint's API.
-    pub descriptor: Vec<u8>,
     pub options: LogReaderOptions,
     client: LogClient,
 }
@@ -81,7 +79,6 @@ impl LogReaderBuilder {
         Ok(Self {
             build_name,
             schema,
-            descriptor: build.descriptor_bytes,
             client,
             options,
         })

--- a/dozer-types/protos/internal.proto
+++ b/dozer-types/protos/internal.proto
@@ -64,7 +64,6 @@ message BuildRequest {
 message BuildResponse {
   string name = 1;
   string schema_string = 2;
-  bytes descriptor_bytes = 3;
 }
 
 message LogRequest {

--- a/dozer-types/protos/internal.proto
+++ b/dozer-types/protos/internal.proto
@@ -9,9 +9,8 @@ service InternalPipelineService {
   rpc GetId(google.protobuf.Empty) returns (GetIdResponse);
 
   rpc DescribeStorage(StorageRequest) returns (StorageResponse);
-  rpc ListEndpoints(google.protobuf.Empty) returns (EndpointsResponse);
   rpc DescribeBuild(BuildRequest) returns (BuildResponse);
-  rpc DescribeApplication(DescribeApplicationRequest) returns (DescribeApplicationResponse);
+  rpc DescribeApplication(google.protobuf.Empty) returns (DescribeApplicationResponse);
   /// For every `LogRequest` sent, the server will reply one `LogResponse`.
   rpc GetLog(stream LogRequest) returns (stream LogResponse);
 }
@@ -38,19 +37,6 @@ message StorageResponse {
     LocalStorage local = 1;
     S3Storage s3 = 2;
   };
-}
-
-message EndpointResponse {
-  string endpoint = 1;
-  string build_name = 2;
-}
-
-message EndpointsResponse {
-  repeated EndpointResponse endpoints = 1;
-}
-
-message DescribeApplicationRequest {
-  
 }
 
 message DescribeApplicationResponse {

--- a/dozer-types/protos/internal.proto
+++ b/dozer-types/protos/internal.proto
@@ -48,8 +48,7 @@ message BuildRequest {
 }
 
 message BuildResponse {
-  string name = 1;
-  string schema_string = 2;
+  string schema_string = 1;
 }
 
 message LogRequest {


### PR DESCRIPTION
- `build_name` is not necessary because we always build to `v0001`.
- `descriptor_bytes` is not necessary because it's generated from schema.