### PR TITLE
fix: Stop lexically compare secondary index key

### DIFF
--- a/dozer-cache/src/cache/index/mod.rs
+++ b/dozer-cache/src/cache/index/mod.rs
@@ -47,6 +47,12 @@ pub fn get_secondary_index(fields: &[&Field], is_single_field_index: bool) -> Ve
     }
 }
 
+pub fn compare_single_secondary_index(a: &[u8], b: &[u8]) -> Result<Ordering, CompareError> {
+    let a = Field::decode(a)?;
+    let b = Field::decode(b)?;
+    Ok(a.cmp(&b))
+}
+
 pub fn compare_composite_secondary_index(a: &[u8], b: &[u8]) -> Result<Ordering, CompareError> {
     let mut a = CompositeSecondaryIndexKey::new(a);
     let mut b = CompositeSecondaryIndexKey::new(b);


### PR DESCRIPTION
Note that this comparator will be much slower than before because it involves allocation for `string` and `json` types.

Fixes #1979 