### PR TITLE
fix: Remove redundant `idx` in `ProcessorRecordStore`

### DIFF
--- a/dozer-core/src/checkpoint/mod.rs
+++ b/dozer-core/src/checkpoint/mod.rs
@@ -355,6 +355,10 @@ async fn read_record_store_slices(
             let record_store_slice = bincode::deserialize::<RecordStoreSlice>(&data)
                 .map_err(ExecutionError::CorruptedCheckpoint)?;
             let processor_prefix = processor_prefix(factory_prefix, object_name.as_str());
+            info!(
+                "Current source states are {:?}",
+                record_store_slice.source_states
+            );
 
             if let Some(last_checkpoint) = last_checkpoint.as_mut() {
                 last_checkpoint.num_slices = last_checkpoint
@@ -365,10 +369,6 @@ async fn read_record_store_slices(
                 last_checkpoint.source_states = record_store_slice.source_states;
                 last_checkpoint.processor_prefix = processor_prefix;
             } else {
-                info!(
-                    "Current source states are {:?}",
-                    record_store_slice.source_states
-                );
                 last_checkpoint = Some(Checkpoint {
                     num_slices: NonZeroUsize::new(objects.objects.len())
                         .expect("have at least one element"),

--- a/dozer-core/src/epoch/manager.rs
+++ b/dozer-core/src/epoch/manager.rs
@@ -1,4 +1,5 @@
 use dozer_recordstore::ProcessorRecordStore;
+use dozer_types::log::info;
 use dozer_types::node::{NodeHandle, SourceStates, TableState};
 use dozer_types::parking_lot::Mutex;
 use std::collections::HashMap;
@@ -217,6 +218,10 @@ impl EpochManager {
                     self.record_store().compact(); // Compact the record store to prepare for persisting.
                     state.next_record_index_to_persist = num_records;
                     state.last_persisted_epoch_decision_instant = instant;
+                    info!(
+                        "Persisting epoch {}, source states: {:?}",
+                        epoch_id, source_states
+                    );
                     Action::CommitAndPersist
                 } else {
                     Action::Commit

--- a/dozer-recordstore/src/in_memory/store.rs
+++ b/dozer-recordstore/src/in_memory/store.rs
@@ -109,7 +109,6 @@ pub struct ProcessorRecordStoreDeserializer {
 struct ProcessorRecordStoreDeserializerInner {
     records: BTreeMap<usize, RecordRef>,
     record_pointer_to_index: HashMap<usize, usize>,
-    idx: usize,
 }
 
 impl ProcessorRecordStoreDeserializer {
@@ -118,7 +117,6 @@ impl ProcessorRecordStoreDeserializer {
             inner: RwLock::new(ProcessorRecordStoreDeserializerInner {
                 records: BTreeMap::new(),
                 record_pointer_to_index: HashMap::new(),
-                idx: 0,
             }),
         })
     }
@@ -176,8 +174,11 @@ impl StoreRecord for ProcessorRecordStoreDeserializer {
     fn store_record(&self, record: &RecordRef) -> Result<(), RecordStoreError> {
         let mut inner = self.inner.write();
 
-        inner.idx += 1;
-        let idx = inner.idx;
+        let idx = inner
+            .records
+            .last_key_value()
+            .map(|(index, _)| index + 1)
+            .unwrap_or(0);
         insert_record_pointer_to_index(&mut inner.record_pointer_to_index, record, idx);
         inner.records.insert(idx, record.clone());
 


### PR DESCRIPTION
This field is not necessary and was not correctly maintained in `deserialize_and_extend`