### PR TITLE
fix: `ProcessorRecordStore::serialize_slice` was returning wrong length

### DIFF
--- a/dozer-core/src/checkpoint/mod.rs
+++ b/dozer-core/src/checkpoint/mod.rs
@@ -208,9 +208,9 @@ impl CheckpointFactory {
         source_states: SourceStates,
     ) -> Result<(), ExecutionError> {
         let mut state = self.state.lock();
-        let (data, num_records_serialized) =
+        let (data, next_record_index) =
             self.record_store.serialize_slice(state.next_record_index)?;
-        state.next_record_index += num_records_serialized;
+        state.next_record_index = next_record_index;
         drop(state);
 
         let data = bincode::serialize(&RecordStoreSlice {


### PR DESCRIPTION
`ProcessorRecordStore::serialize_slice` used to return the number of records serialized. The returned value is used to determine the `start` parameter of the next call to `ProcessorRecordStore::serialize_slice`.

However, after we introduce `ProcessorRecordStore::vacuum`, it no longer makes sense and results in duplicated serialization. Here we change the return value to the proper `start` value of next call to `ProcessorRecordStore::serialize_slice`.