### PR TITLE
fix: Cache name is not unique when there are multiple endpoints

### DIFF
--- a/dozer-api/src/cache_builder/builder_impl.rs
+++ b/dozer-api/src/cache_builder/builder_impl.rs
@@ -60,7 +60,7 @@ impl CacheBuilderImpl {
         progress_bar: ProgressBar,
     ) -> Result<(CacheBuilderImpl, u64), CacheError> {
         // Compare cache and log id.
-        let this = if serving.load().cache_name() != endpoint_meta.log_id {
+        let this = if serving.load().cache_name() != endpoint_meta.cache_name() {
             let building = super::create_cache(
                 &*cache_manager,
                 endpoint_meta.clone(),
@@ -358,14 +358,20 @@ mod tests {
     fn test_builder_impl_new() {
         let (builder, start) = create_build_impl(INITIAL_CACHE_NAME.to_string());
         assert_eq!(start, INITIAL_LOG_POSITION + 1);
-        assert_eq!(builder.building.name(), INITIAL_CACHE_NAME);
+        assert_eq!(
+            builder.building.name(),
+            test_endpoint_meta(INITIAL_CACHE_NAME.to_string()).cache_name()
+        );
         assert_eq!(builder.next_log_position, INITIAL_LOG_POSITION + 1);
         assert!(builder.catch_up_info.is_none());
 
         let new_log_id = "new_log_id";
         let (builder, start) = create_build_impl(new_log_id.to_string());
         assert_eq!(start, 0);
-        assert_eq!(builder.building.name(), new_log_id);
+        assert_eq!(
+            builder.building.name(),
+            test_endpoint_meta(new_log_id.to_string()).cache_name()
+        );
         assert_eq!(builder.next_log_position, 0);
         assert_eq!(
             builder.catch_up_info,
@@ -395,7 +401,10 @@ mod tests {
                 )
                 .unwrap();
             assert!(builder.catch_up_info.is_some());
-            assert_eq!(builder.serving.load().cache_name(), INITIAL_CACHE_NAME);
+            assert_eq!(
+                builder.serving.load().cache_name(),
+                test_endpoint_meta(INITIAL_CACHE_NAME.to_string()).cache_name()
+            );
         }
         builder
             .process_op(
@@ -410,6 +419,9 @@ mod tests {
             )
             .unwrap();
         assert!(builder.catch_up_info.is_none());
-        assert_eq!(builder.serving.load().cache_name(), new_log_id);
+        assert_eq!(
+            builder.serving.load().cache_name(),
+            test_endpoint_meta(new_log_id.to_string()).cache_name()
+        );
     }
 }

--- a/dozer-api/src/cache_builder/endpoint_meta.rs
+++ b/dozer-api/src/cache_builder/endpoint_meta.rs
@@ -48,4 +48,8 @@ impl EndpointMeta {
         labels.extend(extra_labels);
         (alias, labels)
     }
+
+    pub fn cache_name(&self) -> String {
+        format!("{}_{}", self.log_id, self.name)
+    }
 }

--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -232,8 +232,9 @@ fn create_cache(
     write_options: CacheWriteOptions,
 ) -> Result<Box<dyn RwCache>, CacheError> {
     let (alias, cache_labels) = endpoint_meta.cache_alias_and_labels(labels);
+    let cache_name = endpoint_meta.cache_name();
     let cache = cache_manager.create_cache(
-        endpoint_meta.log_id.clone(),
+        cache_name.clone(),
         cache_labels,
         (
             endpoint_meta.schema.schema,
@@ -242,7 +243,7 @@ fn create_cache(
         &endpoint_meta.schema.connections,
         write_options,
     )?;
-    cache_manager.create_alias(&endpoint_meta.log_id, &alias)?;
+    cache_manager.create_alias(&cache_name, &alias)?;
     Ok(cache)
 }
 


### PR DESCRIPTION
We used log id as the cache name in https://github.com/getdozer/dozer/pull/2162. When there are multiple endpoints, caches of different endpoints will have the same name, which is just wrong.