### PR TITLE
fix: Include `-p` parameter in cross build to avoid building web3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
           cache-key: '${{ env.CARGO_TARGET }}'
 
       - name: Build dozer
-        run: cross build --profile=release --target ${{ env.CARGO_TARGET }} --bin dozer
+        run: cross build --package=dozer-cli --profile=release --target ${{ env.CARGO_TARGET }} --bin dozer
 
       - name: Install cargo-deb
         uses: baptiste0928/cargo-install@v1


### PR DESCRIPTION
Problem was introduced in #2189. 

After this fix, the action runs successfully https://github.com/getdozer/dozer/actions/runs/6708158427/job/18228317195