### PR TITLE
fix: Bump `dozer-log-js` version. Remove release workflow timeout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -261,7 +261,6 @@ jobs:
     runs-on:
       labels: ${{ matrix.os }}
     needs: prepare
-    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-20-16-cores]

--- a/dozer-log-js/package-lock.json
+++ b/dozer-log-js/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "@dozer-js/log",
-  "version": "0.1.39",
+  "name": "@dozerjs/log",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@dozer-js/log",
-      "version": "0.1.39",
-      "hasInstallScript": true,
+      "name": "@dozerjs/log",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.10"

--- a/dozer-log-js/package.json
+++ b/dozer-log-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dozerjs/log",
-  "version": "0.1.39",
+  "version": "0.2.0",
   "description": "Node.js binding for reading Dozer logs",
   "main": "build/log.node",
   "scripts": {


### PR DESCRIPTION
The macos x64 release workflow fails because of timeout. If removing timeout works, we'll release `0.2.1`.

`dozer-log-js` `0.2.0` was not released because of the missing version bump. We'll skip it.