### PR TITLE
fix: Use `rust-cache` and fix `.deb` release

### DIFF
--- a/.github/workflows/dozer.yaml
+++ b/.github/workflows/dozer.yaml
@@ -33,21 +33,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: ⚡ Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/.package-cache
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-            target/
-          key: clippy-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            clippy-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-            clippy-${{ runner.os }}-cargo-
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
 
       - name: Clippy
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,9 +114,9 @@ jobs:
 
           tar -czvf ${{ env.DEB_NAME }}.tar.gz ${{ env.DEB_NAME }}/
 
-          cp deb/${{ env.DEB_NAME }}.deb ${{ env.DEB_NAME }}/
+          cp deb/${{ env.DEB_NAME }}.deb ./
 
-          ls -l ${{ env.DEB_NAME }}
+          ls -l ${{ env.DEB_NAME }}*
 
       - name: Upload the release
         uses: svenstaro/upload-release-action@v2
@@ -306,9 +306,9 @@ jobs:
           tar -czvf ${{matrix.asset_name}}.tar.gz \
               ${{matrix.asset_name}}/
 
-          cp deb/${{matrix.asset_name}}.deb ${{matrix.asset_name}}/ 2>/dev/null || :
+          cp deb/${{matrix.asset_name}}.deb ./ 2>/dev/null || :
 
-          ls -l ${{matrix.asset_name}}
+          ls -l ${{matrix.asset_name}}*
 
       - name: Upload the release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,21 +187,9 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: ⚡ Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/.package-cache
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-            ${{ runner.os }}-cargo-release-
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
 
       - name: Cargo build
         uses: actions-rs/cargo@v1
@@ -286,21 +274,9 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: ⚡ Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/.package-cache
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-            ${{ runner.os }}-cargo-release-
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
 
       - name: Install cargo-deb
         if: matrix.os == 'ubuntu-20-16-cores'


### PR DESCRIPTION
`hashFile (Cargo.lock)` was not a good cache key. We replace them with `rust-cache`.

We're not sure what happened to the `.deb` release. Looks like the depended action has behaviour changes. After this fix, it works again. A successful run: https://github.com/getdozer/dozer/actions/runs/6735239232/job/18307959724. The artifacts: https://github.com/getdozer/dozer/releases/tag/dev