### PR TITLE
chore: Bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,7 +3543,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dozer-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "Inflector",
  "actix-cors",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-cache"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash 0.8.3",
  "clap 4.4.1",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-files",
  "atty",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossbeam",
  "daggy",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-connector"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-types",
  "futures",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-deltalake"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "deltalake",
  "dozer-ingestion-connector",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-dozer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-ingestion-connector",
  "dozer-log",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-ethereum"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-ingestion-connector",
  "dozer-tracing",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-grpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-ingestion-connector",
  "tonic-reflection",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-javascript"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "deno_ast",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-kafka"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.21.0",
  "dozer-ingestion-connector",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-mongodb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bson",
  "dozer-ingestion-connector",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-mysql"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-ingestion-connector",
  "geozero",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-object-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "deltalake",
  "dozer-ingestion-connector",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-postgres"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-ingestion-connector",
  "postgres-protocol",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-ingestion-snowflake"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-ingestion-connector",
  "genawaiter",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-log"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-log-js"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-log",
  "dozer-types",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-log-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-log",
  "dozer-types",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-recordstore"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-storage",
  "dozer-types",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-sql"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash 0.8.3",
  "dozer-core",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-sql-expression"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bigdecimal",
  "dozer-types",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-storage"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-types",
  "lmdb-rkv",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-tests"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash 0.8.3",
  "async-trait",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-tracing"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "atty",
  "console-subscriber",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash 0.8.3",
  "arbitrary",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "dozer-utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dozer-types",
 ]

--- a/dozer-api/Cargo.toml
+++ b/dozer-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-api"
-version = "0.2.0"
+version = "0.2.1"
 
 edition = "2021"
 authors = ["getdozer/dozer-dev"]

--- a/dozer-cache/Cargo.toml
+++ b/dozer-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-cache"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-cli/Cargo.toml
+++ b/dozer-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 default-run = "dozer"
 authors = ["getdozer/dozer-dev"]

--- a/dozer-core/Cargo.toml
+++ b/dozer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-ingestion/Cargo.toml
+++ b/dozer-ingestion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-ingestion/connector/Cargo.toml
+++ b/dozer-ingestion/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-connector"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/deltalake/Cargo.toml
+++ b/dozer-ingestion/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-deltalake"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/dozer/Cargo.toml
+++ b/dozer-ingestion/dozer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-dozer"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/ethereum/Cargo.toml
+++ b/dozer-ingestion/ethereum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-ethereum"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/grpc/Cargo.toml
+++ b/dozer-ingestion/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-grpc"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/javascript/Cargo.toml
+++ b/dozer-ingestion/javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-javascript"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/kafka/Cargo.toml
+++ b/dozer-ingestion/kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-kafka"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/mongodb/Cargo.toml
+++ b/dozer-ingestion/mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-mongodb"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/mysql/Cargo.toml
+++ b/dozer-ingestion/mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-mysql"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/object-store/Cargo.toml
+++ b/dozer-ingestion/object-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-object-store"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/postgres/Cargo.toml
+++ b/dozer-ingestion/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-postgres"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-ingestion/snowflake/Cargo.toml
+++ b/dozer-ingestion/snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-ingestion-snowflake"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-log-js/Cargo.toml
+++ b/dozer-log-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-log-js"
-version = "0.2.0"
+version = "0.2.1"
 description = "Node.js binding for reading Dozer logs"
 authors = ["getdozer/dozer-dev"]
 license = "Apache-2.0"

--- a/dozer-log-js/package-lock.json
+++ b/dozer-log-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dozerjs/log",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dozerjs/log",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.10"

--- a/dozer-log-js/package.json
+++ b/dozer-log-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dozerjs/log",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node.js binding for reading Dozer logs",
   "main": "build/log.node",
   "scripts": {

--- a/dozer-log-python/Cargo.toml
+++ b/dozer-log-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-log-python"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-log/Cargo.toml
+++ b/dozer-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-log"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-recordstore/Cargo.toml
+++ b/dozer-recordstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-recordstore"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-sql"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-sql/expression/Cargo.toml
+++ b/dozer-sql/expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-sql-expression"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-storage/Cargo.toml
+++ b/dozer-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-storage"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-tests/Cargo.toml
+++ b/dozer-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-tests"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-tracing/Cargo.toml
+++ b/dozer-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-tracing"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["getdozer/dozer-dev"]
 

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-types"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["getdozer/dozer-dev"]
 edition = "2021"
 

--- a/dozer-utils/Cargo.toml
+++ b/dozer-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dozer-utils"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
https://github.com/getdozer/dozer/releases/tag/dev has all the artifacts. We should be able to release now.