### PR TITLE
Reduce json memory

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+[profile.test]
+lto = "off"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,6 +2525,16 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
+name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
@@ -2563,7 +2573,7 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "dashmap",
+ "dashmap 5.4.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -2628,7 +2638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4973610d680bdc38f409a678c838d3873356cc6c29a543d1f56d7b4801e8d0a4"
 dependencies = [
  "arrow",
- "dashmap",
+ "dashmap 5.4.0",
  "datafusion-common",
  "datafusion-expr",
  "futures",
@@ -2766,7 +2776,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "chrono",
- "dashmap",
+ "dashmap 5.4.0",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
@@ -3989,9 +3999,11 @@ dependencies = [
  "arrow",
  "arrow-schema",
  "bincode",
+ "bson",
  "bytes",
  "chrono",
  "geo",
+ "ijson",
  "indexmap 2.0.0",
  "indicatif",
  "log",
@@ -5434,6 +5446,18 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "ijson"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96214564d1f12875bd9661b183d8494dd10e373cb693629536fe2f3125e254b"
+dependencies = [
+ "dashmap 4.0.2",
+ "lazy_static",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "impl-codec"
@@ -9196,7 +9220,7 @@ checksum = "5ea1c251bea837ece3126074d9e01c5868e5ae6135946404ceb20b5b2e264f7c"
 dependencies = [
  "apache-avro",
  "byteorder",
- "dashmap",
+ "dashmap 5.4.0",
  "futures",
  "reqwest",
  "serde",
@@ -9535,7 +9559,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "538c30747ae860d6fb88330addbbd3e0ddbe46d662d032855596d8a8ca260611"
 dependencies = [
- "dashmap",
+ "dashmap 5.4.0",
  "futures",
  "lazy_static",
  "log",
@@ -10293,7 +10317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675b5c755b0448268830e85e59429095d3423c0ce4a850b209c6f0eeab069f63"
 dependencies = [
  "base64 0.13.1",
- "dashmap",
+ "dashmap 5.4.0",
  "indexmap 1.9.3",
  "once_cell",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,11 +1414,21 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
 dependencies = [
+ "bincode_derive",
  "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -3597,6 +3607,7 @@ name = "dozer-cache"
 version = "0.3.0"
 dependencies = [
  "ahash 0.8.3",
+ "bincode",
  "clap 4.4.1",
  "criterion",
  "dozer-log",
@@ -3659,6 +3670,7 @@ dependencies = [
 name = "dozer-core"
 version = "0.3.0"
 dependencies = [
+ "bincode",
  "crossbeam",
  "daggy",
  "dozer-log",
@@ -3847,6 +3859,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http",
  "aws-smithy-types",
+ "bincode",
  "camino",
  "clap 4.4.1",
  "dozer-types",
@@ -3883,6 +3896,7 @@ dependencies = [
 name = "dozer-recordstore"
 version = "0.3.0"
 dependencies = [
+ "bincode",
  "dozer-storage",
  "dozer-types",
  "tempdir",
@@ -3893,6 +3907,7 @@ name = "dozer-sql"
 version = "0.3.0"
 dependencies = [
  "ahash 0.8.3",
+ "bincode",
  "dozer-core",
  "dozer-recordstore",
  "dozer-sql-expression",
@@ -3914,6 +3929,7 @@ name = "dozer-sql-expression"
 version = "0.3.0"
 dependencies = [
  "bigdecimal",
+ "bincode",
  "dozer-types",
  "half 2.3.1",
  "jsonpath",
@@ -3999,7 +4015,6 @@ dependencies = [
  "arrow",
  "arrow-schema",
  "bincode",
- "bson",
  "bytes",
  "chrono",
  "geo",
@@ -4013,6 +4028,7 @@ dependencies = [
  "prost 0.12.0",
  "prost-types 0.12.0",
  "pyo3",
+ "rmp-serde",
  "rust_decimal",
  "schemars",
  "serde",
@@ -8761,6 +8777,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "roaring"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11562,6 +11600,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "vsimd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,13 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+bincode = { version = "2.0.0-rc.3", features = ["derive"]}
+
 [patch.crates-io]
 postgres = { git = "https://github.com/getdozer/rust-postgres" }
 postgres-protocol = { git = "https://github.com/getdozer/rust-postgres" }
 postgres-types = { git = "https://github.com/getdozer/rust-postgres" }
 tokio-postgres = { git = "https://github.com/getdozer/rust-postgres" }
+
+

--- a/dozer-api/src/grpc/internal/internal_pipeline_server.rs
+++ b/dozer-api/src/grpc/internal/internal_pipeline_server.rs
@@ -152,7 +152,7 @@ async fn serialize_log_response(response: LogResponseFuture) -> Result<LogRespon
     let response = response
         .await
         .map_err(|e| Status::new(tonic::Code::Internal, e.to_string()))?;
-    let data = bincode::serialize(&response).map_err(|e| {
+    let data = bincode::encode_to_vec(&response, bincode::config::legacy()).map_err(|e| {
         Status::new(
             tonic::Code::Internal,
             format!("Failed to serialize response: {}", e),

--- a/dozer-api/src/rest/api_generator.rs
+++ b/dozer-api/src/rest/api_generator.rs
@@ -155,7 +155,7 @@ fn record_to_map(
     let mut map = IndexMap::new();
 
     for (field_def, field) in schema.fields.iter().zip(record.record.values) {
-        let val = field_to_json_value(field)?;
+        let val = field_to_json_value(field);
         map.insert(field_def.name.clone(), val);
     }
 

--- a/dozer-cache/Cargo.toml
+++ b/dozer-cache/Cargo.toml
@@ -24,6 +24,7 @@ ahash = "0.8.3"
 metrics = "0.21.0"
 clap = { version = "4.4.1", features = ["derive"] }
 env_logger = "0.10.0"
+bincode = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
@@ -106,7 +106,8 @@ pub trait MainEnvironment: LmdbEnvironment {
             .commit_state
             .load(txn)?
             .map(|commit_state| {
-                bincode::deserialize(commit_state.borrow())
+                bincode::decode_from_slice(commit_state.borrow(), bincode::config::legacy())
+                    .map(|v| v.0)
                     .map_err(CacheError::map_deserialization_error)
             })
             .transpose()
@@ -416,7 +417,7 @@ impl RwMainEnvironment {
         let txn = self.env.txn_mut()?;
         self.common.commit_state.store(
             txn,
-            bincode::serialize(state)
+            bincode::encode_to_vec(state, bincode::config::legacy())
                 .map_err(CacheError::map_serialization_error)?
                 .as_slice(),
         )?;

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/lmdb_val_impl.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/lmdb_val_impl.rs
@@ -56,23 +56,25 @@ impl BorrowEncode for Operation {
 
 impl<'a> Encode<'a> for OperationBorrow<'a> {
     fn encode(self) -> Result<Encoded<'a>, StorageError> {
-        dozer_types::bincode::serialize(&self)
-            .map(Encoded::Vec)
-            .map_err(|e| StorageError::SerializationError {
+        let encoded = bincode::encode_to_vec(self, bincode::config::legacy()).map_err(|e| {
+            StorageError::SerializationError {
                 typ: "Operation",
                 reason: Box::new(e),
-            })
+            }
+        })?;
+        Ok(Encoded::Vec(encoded))
     }
 }
 
 impl Decode for Operation {
     fn decode(bytes: &[u8]) -> Result<Cow<Self>, StorageError> {
-        dozer_types::bincode::deserialize(bytes)
-            .map(Cow::Owned)
+        let decoded = dozer_types::bincode::decode_from_slice(bytes, bincode::config::legacy())
             .map_err(|e| StorageError::DeserializationError {
                 typ: "Operation",
                 reason: Box::new(e),
-            })
+            })?
+            .0;
+        Ok(Cow::Owned(decoded))
     }
 }
 

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/operation_log/mod.rs
@@ -7,34 +7,33 @@ use dozer_tracing::Labels;
 use dozer_types::{
     borrow::{Borrow, Cow, IntoOwned},
     log::info,
-    serde::{Deserialize, Serialize},
     types::Record,
 };
 use metrics::{describe_counter, increment_counter};
 
 use crate::cache::{CacheRecord, RecordMeta};
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, Clone, PartialEq, bincode::Decode)]
 pub enum Operation {
     Delete {
         /// The operation id of an `Insert` operation, which must exist.
         operation_id: u64,
     },
     Insert {
+        #[bincode(with_serde)]
         record_meta: RecordMeta,
         record: Record,
     },
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, Clone, Copy, bincode::Encode)]
 pub enum OperationBorrow<'a> {
     Delete {
         /// The operation id of an `Insert` operation, which must exist.
         operation_id: u64,
     },
     Insert {
+        #[bincode(with_serde)]
         record_meta: RecordMeta,
         record: &'a Record,
     },

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -129,8 +129,7 @@ pub enum UpsertResult {
     Ignored,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, Clone, Default, PartialEq, Eq, bincode::Encode, bincode::Decode)]
 pub struct CommitState {
     pub source_states: SourceStates,
     pub log_position: u64,

--- a/dozer-cache/src/errors.rs
+++ b/dozer-cache/src/errors.rs
@@ -76,12 +76,12 @@ pub enum CacheError {
 }
 
 impl CacheError {
-    pub fn map_serialization_error(e: dozer_types::bincode::Error) -> CacheError {
+    pub fn map_serialization_error(e: dozer_types::bincode::error::EncodeError) -> CacheError {
         CacheError::Type(TypeError::SerializationError(SerializationError::Bincode(
             e,
         )))
     }
-    pub fn map_deserialization_error(e: dozer_types::bincode::Error) -> CacheError {
+    pub fn map_deserialization_error(e: dozer_types::bincode::error::DecodeError) -> CacheError {
         CacheError::Type(TypeError::DeserializationError(
             DeserializationError::Bincode(e),
         ))

--- a/dozer-core/Cargo.toml
+++ b/dozer-core/Cargo.toml
@@ -12,6 +12,7 @@ dozer-storage = { path = "../dozer-storage/" }
 dozer-types = { path = "../dozer-types/" }
 dozer-tracing = { path = "../dozer-tracing/" }
 dozer-recordstore = { path = "../dozer-recordstore/" }
+bincode = { workspace = true }
 
 uuid = { version = "1.3.0", features = ["v1", "v4", "fast-rng"] }
 crossbeam = "0.8.2"

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -47,7 +47,7 @@ pub enum ExecutionError {
     #[error("Unrecognized checkpoint: {0}")]
     UnrecognizedCheckpoint(String),
     #[error("Cannot deserialize checkpoint: {0}")]
-    CorruptedCheckpoint(#[source] bincode::Error),
+    CorruptedCheckpoint(#[source] bincode::error::DecodeError),
     #[error("Table {table_name} of source {source_name} cannot restart. You have to clean data from previous runs by running `dozer clean`")]
     SourceCannotRestart {
         source_name: NodeHandle,

--- a/dozer-ingestion/connector/src/ingestor.rs
+++ b/dozer-ingestion/connector/src/ingestor.rs
@@ -61,6 +61,8 @@ impl Ingestor {
         self.sender.send(message).await
     }
 
+    // FIXME: Fix large error variant
+    #[allow(clippy::result_large_err)]
     pub fn blocking_handle_message(
         &self,
         message: IngestionMessage,

--- a/dozer-ingestion/grpc/src/tests.rs
+++ b/dozer-ingestion/grpc/src/tests.rs
@@ -10,10 +10,9 @@ use dozer_ingestion_connector::dozer_types::{
         ingest::{ingest_service_client::IngestServiceClient, IngestArrowRequest, IngestRequest},
         types,
     },
-    json_types::JsonValue as dozer_JsonValue,
+    json_types::json as dozer_json,
     models::ingestion_types::IngestionMessage,
     models::ingestion_types::{GrpcConfig, GrpcConfigSchemas},
-    ordered_float::OrderedFloat,
     serde_json,
     serde_json::json,
     serde_json::Value,
@@ -23,7 +22,7 @@ use dozer_ingestion_connector::dozer_types::{
 };
 use dozer_ingestion_connector::test_util::{create_test_runtime, spawn_connector_all_tables};
 use dozer_ingestion_connector::tokio::runtime::Runtime;
-use dozer_ingestion_connector::{dozer_types, tokio, IngestionIterator};
+use dozer_ingestion_connector::{dozer_types, IngestionIterator};
 
 use crate::{ArrowAdapter, DefaultAdapter};
 
@@ -121,9 +120,9 @@ fn ingest_grpc_default() {
     }
 }
 
-#[tokio::test]
+#[test]
 #[ignore]
-async fn test_serialize_arrow_schema() {
+fn test_serialize_arrow_schema() {
     let schema = arrow_types::Schema::new(vec![
         arrow_types::Field::new("id", arrow_types::DataType::Int32, false),
         arrow_types::Field::new(
@@ -224,7 +223,7 @@ fn ingest_grpc_arrow() {
 
     let a = Int32Array::from_iter([1675, 1676, 1677]);
     let b = StringArray::from_iter_values(vec!["dario", "mario", "vario"]);
-    let c = StringArray::from_iter_values(vec!["[1, 2, 3]", "{'a': 'b'}", "s"]);
+    let c = StringArray::from_iter_values(vec!["[1, 2, 3]", "{\"a\": \"b\"}", "\"s\""]);
 
     let record_batch = RecordBatch::try_new(
         Arc::new(schema),
@@ -249,11 +248,7 @@ fn ingest_grpc_arrow() {
             assert_eq!(record.values[1].as_string(), Some("dario"));
             assert_eq!(
                 record.values[2].as_json(),
-                Some(&dozer_JsonValue::Array(vec![
-                    dozer_JsonValue::Number(OrderedFloat(1_f64)),
-                    dozer_JsonValue::Number(OrderedFloat(2_f64)),
-                    dozer_JsonValue::Number(OrderedFloat(3_f64)),
-                ]))
+                Some(&dozer_json!([1_f64, 2_f64, 3_f64]))
             );
         } else {
             panic!("wrong operation kind");

--- a/dozer-ingestion/mysql/src/connector.rs
+++ b/dozer-ingestion/mysql/src/connector.rs
@@ -415,7 +415,6 @@ mod tests {
     use super::MySQLConnector;
     use dozer_ingestion_connector::{
         dozer_types::{
-            json_types::JsonValue,
             models::ingestion_types::IngestionMessage,
             types::{
                 Field, FieldDefinition, FieldType, Operation::*, Record, Schema, SourceDefinition,
@@ -628,7 +627,7 @@ mod tests {
             IngestionMessage::OperationEvent {
                 table_index: 1,
                 op: Insert {
-                    new: Record::new(vec![Field::Int(1), Field::Json(JsonValue::Bool(true))]),
+                    new: Record::new(vec![Field::Int(1), Field::Json(true.into())]),
                 },
                 id: None,
             },

--- a/dozer-ingestion/mysql/src/conversion.rs
+++ b/dozer-ingestion/mysql/src/conversion.rs
@@ -329,7 +329,7 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(
-            Field::Json(JsonValue::Number(12.0.into())),
+            Field::Json(12.0.into()),
             Value::Bytes(b"12".as_slice().into())
                 .into_field(&FieldType::Json)
                 .unwrap()

--- a/dozer-ingestion/tests/test_suite/connectors/arrow.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/arrow.rs
@@ -9,6 +9,7 @@ use dozer_ingestion_connector::dozer_types::{
         },
     },
     chrono::Datelike,
+    json_types::json_to_string,
     types::{Field, FieldDefinition, FieldType},
 };
 
@@ -431,7 +432,7 @@ fn fields_to_arrow<'a, F: IntoIterator<Item = &'a Field>>(
             let mut builder = arrow::array::StringBuilder::new();
             for field in fields {
                 match field {
-                    Field::Json(value) => builder.append_value(value.to_string()),
+                    Field::Json(value) => builder.append_value(json_to_string(value)),
                     Field::Null => builder.append_null(),
                     _ => panic!("Unexpected field type"),
                 }

--- a/dozer-ingestion/tests/test_suite/connectors/sql.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/sql.rs
@@ -1,4 +1,7 @@
-use dozer_ingestion_connector::dozer_types::types::{Field, FieldDefinition, FieldType};
+use dozer_ingestion_connector::dozer_types::{
+    json_types::json_to_string,
+    types::{Field, FieldDefinition, FieldType},
+};
 
 use crate::test_suite::{records::Operation, FieldsAndPk};
 
@@ -235,7 +238,7 @@ fn field_to_sql(field: &Field) -> String {
         Field::Decimal(d) => d.to_string(),
         Field::Timestamp(t) => format!("'{}'", t),
         Field::Date(d) => format!("'{}'", d),
-        Field::Json(b) => format!("'{b}'::jsonb"),
+        Field::Json(b) => format!("'{}'::jsonb", json_to_string(b)),
         Field::Point(p) => format!("'({},{})'", p.0.x(), p.0.y()),
         Field::Duration(_) => field.to_string(),
         Field::Null => "NULL".to_string(),

--- a/dozer-log-js/src/mapper.rs
+++ b/dozer-log-js/src/mapper.rs
@@ -86,11 +86,7 @@ fn map_record<'a, C: Context<'a>>(
 }
 
 fn map_value<'a, C: Context<'a>>(value: Field, cx: &mut C) -> JsResult<'a, JsValue> {
-    let value = match field_to_json_value(value) {
-        Ok(val) => val,
-        Err(error) => return cx.throw_error(error.to_string()),
-    };
-    map_json_value(value, cx)
+    map_json_value(field_to_json_value(value), cx)
 }
 
 fn map_json_value<'a, C: Context<'a>>(value: Value, cx: &mut C) -> JsResult<'a, JsValue> {

--- a/dozer-log-python/src/mapper.rs
+++ b/dozer-log-python/src/mapper.rs
@@ -1,5 +1,5 @@
 use dozer_log::replication::LogOperation;
-use dozer_types::json_types::JsonValue;
+use dozer_types::json_types::{DestructuredJson, JsonValue};
 use dozer_types::pyo3::types::PyList;
 
 use dozer_types::{
@@ -85,22 +85,22 @@ fn map_value(value: Field, py: Python) -> PyResult<Py<PyAny>> {
 }
 
 fn map_json_py(val: JsonValue, py: Python) -> PyResult<Py<PyAny>> {
-    match val {
-        JsonValue::Null => Ok(py.None()),
-        JsonValue::Bool(b) => Ok(b.to_object(py)),
-        JsonValue::Number(n) => Ok(n.to_object(py)),
-        JsonValue::String(s) => Ok(s.to_object(py)),
-        JsonValue::Array(a) => {
+    match val.destructure() {
+        DestructuredJson::Null => Ok(py.None()),
+        DestructuredJson::Bool(b) => Ok(b.to_object(py)),
+        DestructuredJson::Number(n) => Ok(n.to_f64_lossy().to_object(py)),
+        DestructuredJson::String(s) => Ok(s.to_object(py)),
+        DestructuredJson::Array(a) => {
             let lst: &PyList = PyList::empty(py);
-            for val in a {
+            for val in a.into_iter() {
                 lst.append(map_json_py(val, py)?)?;
             }
             Ok(lst.to_object(py))
         }
-        JsonValue::Object(o) => {
+        DestructuredJson::Object(o) => {
             let obj = PyDict::new(py);
             for (key, val) in o {
-                obj.set_item(key, map_json_py(val, py)?)?;
+                obj.set_item(key.as_str(), map_json_py(val, py)?)?;
             }
             Ok(obj.to_object(py))
         }

--- a/dozer-log/Cargo.toml
+++ b/dozer-log/Cargo.toml
@@ -11,6 +11,7 @@ aws-config = "0.56.1"
 aws-sdk-s3 = "0.31.2"
 aws-smithy-http = "0.56.1"
 aws-smithy-types = "0.56.1"
+bincode = { workspace = true }
 camino = "1.1.6"
 dozer-types = { path = "../dozer-types" }
 dyn-clone = "1.0.14"

--- a/dozer-log/src/errors.rs
+++ b/dozer-log/src/errors.rs
@@ -22,7 +22,7 @@ pub enum ReaderError {
     #[error("Tonic error: {0}")]
     Tonic(#[from] tonic::Status),
     #[error("Failed to deserialize log response: {0}")]
-    DeserializeLogResponse(#[source] bincode::Error),
+    DeserializeLogResponse(#[source] bincode::error::DecodeError),
     #[error("Failed to load persisted log entry: {0}")]
     LoadPersistedLogEntry(#[from] LoadPersistedLogEntryError),
     #[error("Reader thread has quit: {0:?}")]

--- a/dozer-log/src/reader.rs
+++ b/dozer-log/src/reader.rs
@@ -175,7 +175,9 @@ impl LogClient {
         .await?;
         use crate::replication::LogResponse;
         let response: LogResponse =
-            bincode::deserialize(&response.data).map_err(ReaderError::DeserializeLogResponse)?;
+            bincode::decode_from_slice(&response.data, bincode::config::legacy())
+                .map_err(ReaderError::DeserializeLogResponse)?
+                .0;
 
         // Load response.
         let request_range = request.start..request.end;

--- a/dozer-log/src/replication/persist.rs
+++ b/dozer-log/src/replication/persist.rs
@@ -102,7 +102,8 @@ pub fn persist(
 ) -> Result<tokio::sync::oneshot::Receiver<String>, Error> {
     let name = log_entry_name(&range);
     let key = AsRef::<Utf8Path>::as_ref(prefix).join(name).to_string();
-    let data = bincode::serialize(&ops).expect("LogOperation must be serializable");
+    let data = bincode::encode_to_vec(ops, bincode::config::legacy())
+        .expect("LogOperation must be serializable");
     queue
         .upload_object(key, data)
         .map_err(|_| Error::PersistingThreadQuit)

--- a/dozer-recordstore/Cargo.toml
+++ b/dozer-recordstore/Cargo.toml
@@ -12,3 +12,4 @@ fuzz = ["dozer-types/arbitrary"]
 dozer-types = { path = "../dozer-types" }
 dozer-storage = { path = "../dozer-storage" }
 tempdir = "0.3.7"
+bincode = { workspace = true }

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -15,6 +15,7 @@ dozer-sql-expression = { path = "expression" }
 dozer-recordstore = { path = "../dozer-recordstore" }
 
 ahash = "0.8.3"
+bincode = { workspace = true }
 enum_dispatch = "0.3.12"
 linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
 metrics = "0.21.0"

--- a/dozer-sql/expression/Cargo.toml
+++ b/dozer-sql/expression/Cargo.toml
@@ -14,6 +14,7 @@ ndarray = { version = "0.15", optional = true }
 half = { version = "2.3.1", optional = true }
 like = "0.3.1"
 jsonpath = { path = "../jsonpath" }
+bincode = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/dozer-sql/expression/src/aggregate.rs
+++ b/dozer-sql/expression/src/aggregate.rs
@@ -1,9 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use dozer_types::serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, bincode::Encode, bincode::Decode)]
 pub enum AggregateFunctionType {
     Avg,
     Count,

--- a/dozer-sql/jsonpath/src/lib.rs
+++ b/dozer-sql/jsonpath/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::parser::model::JsonPath;
 use crate::path::{json_path_instance, PathInstance};
 use crate::JsonPathValue::{NewValue, NoValue, Slice};
-use dozer_types::json_types::JsonValue;
+use dozer_types::json_types::{parse_json, JsonArray, JsonValue};
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -163,7 +163,7 @@ impl JsonPathFinder {
     }
     /// updates a json from string and therefore can be some parsing errors
     pub fn set_json_str(&mut self, json: &str) -> Result<(), String> {
-        self.json = Box::from(JsonValue::from_str(json).map_err(|e| e.to_string())?);
+        self.json = Box::from(parse_json(json).map_err(|e| e.to_string())?);
         Ok(())
     }
     /// updates a path from string and therefore can be some parsing errors
@@ -174,7 +174,7 @@ impl JsonPathFinder {
 
     /// create a new instance from string and therefore can be some parsing errors
     pub fn from_str(json: &str, path: &str) -> Result<Self, String> {
-        let json = JsonValue::from_str(json).map_err(|e| e.to_string())?;
+        let json = parse_json(json).map_err(|e| e.to_string())?;
         let path = Box::new(JsonPathInst::from_str(path)?);
         Ok(JsonPathFinder::new(Box::from(json), path))
     }
@@ -203,18 +203,17 @@ impl JsonPathFinder {
         let slice = self.find_slice();
         if !slice.is_empty() {
             if JsonPathValue::only_no_value(&slice) {
-                JsonValue::Null
+                JsonValue::NULL
             } else {
-                JsonValue::Array(
-                    self.find_slice()
-                        .into_iter()
-                        .filter(|v| v.has_value())
-                        .map(|v| v.to_data())
-                        .collect(),
-                )
+                self.find_slice()
+                    .into_iter()
+                    .filter(|v| v.has_value())
+                    .map(|v| v.to_data())
+                    .collect::<JsonArray>()
+                    .into()
             }
         } else {
-            JsonValue::Array(vec![])
+            JsonArray::new().into()
         }
     }
 }

--- a/dozer-sql/jsonpath/src/lib.rs
+++ b/dozer-sql/jsonpath/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::parser::model::JsonPath;
 use crate::path::{json_path_instance, PathInstance};
 use crate::JsonPathValue::{NewValue, NoValue, Slice};
-use dozer_types::json_types::{parse_json, JsonArray, JsonValue};
+use dozer_types::json_types::{json_from_str, JsonArray, JsonValue};
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -163,7 +163,7 @@ impl JsonPathFinder {
     }
     /// updates a json from string and therefore can be some parsing errors
     pub fn set_json_str(&mut self, json: &str) -> Result<(), String> {
-        self.json = Box::from(parse_json(json).map_err(|e| e.to_string())?);
+        self.json = Box::from(json_from_str(json).map_err(|e| e.to_string())?);
         Ok(())
     }
     /// updates a path from string and therefore can be some parsing errors
@@ -174,7 +174,7 @@ impl JsonPathFinder {
 
     /// create a new instance from string and therefore can be some parsing errors
     pub fn from_str(json: &str, path: &str) -> Result<Self, String> {
-        let json = parse_json(json).map_err(|e| e.to_string())?;
+        let json = json_from_str(json).map_err(|e| e.to_string())?;
         let path = Box::new(JsonPathInst::from_str(path)?);
         Ok(JsonPathFinder::new(Box::from(json), path))
     }

--- a/dozer-sql/jsonpath/src/parser/parser.rs
+++ b/dozer-sql/jsonpath/src/parser/parser.rs
@@ -109,9 +109,7 @@ fn parse_chain_in_operand(rule: Pair<Rule>) -> Operand {
                     Some(JsonPath::Index(JsonPathIndex::UnionIndex(keys))) => {
                         Operand::val(JsonValue::from(keys.clone()))
                     }
-                    Some(JsonPath::Field(f)) => {
-                        Operand::val(JsonValue::Array(vec![JsonValue::from(f.clone())]))
-                    }
+                    Some(JsonPath::Field(f)) => Operand::val(vec![f].into()),
                     _ => Operand::Dynamic(Box::new(JsonPath::Chain(elems))),
                 }
             } else {
@@ -175,8 +173,8 @@ fn parse_atom(rule: Pair<Rule>) -> Operand {
         Rule::number => Operand::Static(number_to_value(rule.as_str())),
         Rule::string_qt => Operand::Static(JsonValue::from(down(atom).as_str())),
         Rule::chain => parse_chain_in_operand(down(rule)),
-        Rule::boolean => Operand::Static(rule.as_str().parse().unwrap()),
-        _ => Operand::Static(JsonValue::Null),
+        Rule::boolean => Operand::Static(rule.as_str().parse::<bool>().unwrap().into()),
+        _ => Operand::Static(JsonValue::NULL),
     }
 }
 

--- a/dozer-sql/jsonpath/src/path/json.rs
+++ b/dozer-sql/jsonpath/src/path/json.rs
@@ -1,22 +1,19 @@
-use dozer_types::json_types::JsonValue;
+use dozer_types::json_types::{DestructuredJsonRef, JsonValue};
 use regex::Regex;
 
 /// compare sizes of json elements
 /// The method expects to get a number on the right side and array or string or object on the left
 /// where the number of characters, elements or fields will be compared respectively.
 pub fn size(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
-    if let Some(JsonValue::Number(n)) = right.get(0) {
-        for el in left.iter() {
-            match el {
-                JsonValue::String(v) if v.len() == n.0 as usize => true,
-                JsonValue::Array(elems) if elems.len() == n.0 as usize => true,
-                JsonValue::Object(fields) if fields.len() == n.0 as usize => true,
-                _ => return false,
-            };
-        }
-        return true;
-    }
-    false
+    let Some(n) = right.get(0).and_then(|v| v.to_usize()) else {
+        return false;
+    };
+    left.iter().all(|el| match el.destructure_ref() {
+        DestructuredJsonRef::String(v) => v.len() == n,
+        DestructuredJsonRef::Array(elems) => elems.len() == n,
+        DestructuredJsonRef::Object(fields) => fields.len() == n,
+        _ => false,
+    })
 }
 
 /// ensure the array on the left side is a subset of the array on the right side.
@@ -29,7 +26,7 @@ pub fn sub_set_of(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
     }
 
     if let Some(elems) = left.first().and_then(|e| (*e).as_array()) {
-        if let Some(JsonValue::Array(right_elems)) = right.get(0) {
+        if let Some(right_elems) = right.get(0).and_then(|v| v.as_array()) {
             if right_elems.is_empty() {
                 return false;
             }
@@ -61,30 +58,30 @@ pub fn any_of(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
         return false;
     }
 
-    if let Some(JsonValue::Array(elems)) = right.get(0) {
-        if elems.is_empty() {
-            return false;
-        }
+    let Some(elems) = right.get(0).and_then(|v| v.as_array()) else {
+        return false;
+    };
+    if elems.is_empty() {
+        return false;
+    }
 
-        for el in left.iter() {
-            if let Some(left_elems) = el.as_array() {
-                for l in left_elems.iter() {
-                    for r in elems.iter() {
-                        if l.eq(r) {
-                            return true;
-                        }
-                    }
-                }
-            } else {
+    for el in left.iter() {
+        if let Some(left_elems) = el.as_array() {
+            for l in left_elems.iter() {
                 for r in elems.iter() {
-                    if el.eq(&r) {
+                    if l.eq(r) {
                         return true;
                     }
                 }
             }
+        } else {
+            for r in elems.iter() {
+                if el.eq(&r) {
+                    return true;
+                }
+            }
         }
     }
-
     false
 }
 
@@ -94,21 +91,19 @@ pub fn regex(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
         return false;
     }
 
-    match right.get(0) {
-        Some(JsonValue::String(str)) => {
-            if let Ok(regex) = Regex::new(str) {
-                for el in left.iter() {
-                    if let Some(v) = el.as_str() {
-                        if regex.is_match(v) {
-                            return true;
-                        }
-                    }
+    let Some(str) = right.get(0).and_then(|v| v.as_string()) else {
+        return false;
+    };
+    if let Ok(regex) = Regex::new(str) {
+        for el in left.iter() {
+            if let Some(v) = el.as_string() {
+                if regex.is_match(v) {
+                    return true;
                 }
             }
-            false
         }
-        _ => false,
     }
+    false
 }
 
 /// ensure that the element on the left side belongs to the array on the right side.
@@ -117,34 +112,34 @@ pub fn inside(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
         return false;
     }
 
-    match right.get(0) {
-        Some(JsonValue::Array(elems)) => {
-            for el in left.iter() {
-                if elems.contains(el) {
+    let Some(first) = right.get(0) else {
+        return false;
+    };
+    if let Some(elems) = first.as_array() {
+        for el in left.iter() {
+            if elems.contains(el) {
+                return true;
+            }
+        }
+    } else if let Some(elems) = first.as_object() {
+        for el in left.iter() {
+            for r in elems.values() {
+                if el.eq(&r) {
                     return true;
                 }
             }
-            false
         }
-        Some(JsonValue::Object(elems)) => {
-            for el in left.iter() {
-                for r in elems.values() {
-                    if el.eq(&r) {
-                        return true;
-                    }
-                }
-            }
-            false
-        }
-        _ => false,
     }
+    false
 }
 
 /// ensure the number on the left side is less the number on the right side
 pub fn less(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
     if left.len() == 1 && right.len() == 1 {
-        match (left.get(0), right.get(0)) {
-            (Some(JsonValue::Number(l)), Some(JsonValue::Number(r))) => l.0 < r.0,
+        let left_no = left.get(0).and_then(|v| v.as_number());
+        let right_no = right.get(0).and_then(|v| v.as_number());
+        match (left_no, right_no) {
+            (Some(l), Some(r)) => l < r,
             _ => false,
         }
     } else {

--- a/dozer-sql/jsonpath/src/path/mod.rs
+++ b/dozer-sql/jsonpath/src/path/mod.rs
@@ -59,7 +59,10 @@ pub fn json_path_instance<'a>(json_path: &'a JsonPath, root: &'a JsonValue) -> P
 /// The method processes the indexes(all expressions indie [])
 fn process_index<'a>(json_path_index: &'a JsonPathIndex, root: &'a JsonValue) -> PathInstance<'a> {
     match json_path_index {
-        JsonPathIndex::Single(index) => Box::new(ArrayIndex::new(index.as_u64().unwrap() as usize)),
+        // We roundtrip through isize, because of a bug when the f64 representation is used
+        JsonPathIndex::Single(index) => {
+            Box::new(ArrayIndex::new(index.to_isize().unwrap() as usize))
+        }
         JsonPathIndex::Slice(s, e, step) => Box::new(ArraySlice::new(*s, *e, *step)),
         JsonPathIndex::UnionKeys(elems) => Box::new(UnionIndex::from_keys(elems)),
         JsonPathIndex::UnionIndex(elems) => Box::new(UnionIndex::from_indexes(elems)),

--- a/dozer-sql/src/aggregation/avg.rs
+++ b/dozer-sql/src/aggregation/avg.rs
@@ -7,13 +7,12 @@ use dozer_sql_expression::num_traits::FromPrimitive;
 use dozer_types::arrow::datatypes::ArrowNativeTypeOp;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
-use dozer_types::serde::{Deserialize, Serialize};
+
 use dozer_types::types::{DozerDuration, Field, FieldType, TimeUnit};
 
 use std::ops::Div;
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct AvgAggregator {
     current_state: SumState,
     current_count: u64,

--- a/dozer-sql/src/aggregation/count.rs
+++ b/dozer-sql/src/aggregation/count.rs
@@ -5,11 +5,9 @@ use dozer_sql_expression::aggregate::AggregateFunctionType::Count;
 use dozer_sql_expression::num_traits::FromPrimitive;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
-use dozer_types::serde::{Deserialize, Serialize};
 use dozer_types::types::{Field, FieldType};
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct CountAggregator {
     current_state: u64,
     return_type: Option<FieldType>,

--- a/dozer-sql/src/aggregation/max.rs
+++ b/dozer-sql/src/aggregation/max.rs
@@ -1,13 +1,11 @@
 use crate::aggregation::aggregator::Aggregator;
 use crate::errors::PipelineError;
 use dozer_sql_expression::aggregate::AggregateFunctionType::Max;
-use dozer_types::serde::{Deserialize, Serialize};
 use dozer_types::types::{Field, FieldType};
 
 use super::aggregator::OrderedAggregatorState;
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct MaxAggregator {
     current_state: Option<OrderedAggregatorState>,
     return_type: Option<FieldType>,

--- a/dozer-sql/src/aggregation/max_append_only.rs
+++ b/dozer-sql/src/aggregation/max_append_only.rs
@@ -7,11 +7,10 @@ use dozer_sql_expression::aggregate::AggregateFunctionType::MaxAppendOnly;
 use dozer_types::chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
-use dozer_types::serde::{Deserialize, Serialize};
+
 use dozer_types::types::{DozerDuration, Field, FieldType, TimeUnit};
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct MaxAppendOnlyAggregator {
     current_state: Field,
     return_type: Option<FieldType>,

--- a/dozer-sql/src/aggregation/max_value.rs
+++ b/dozer-sql/src/aggregation/max_value.rs
@@ -3,12 +3,11 @@ use crate::calculate_err;
 use crate::errors::PipelineError;
 use crate::errors::PipelineError::InvalidReturnType;
 use dozer_sql_expression::aggregate::AggregateFunctionType::MaxValue;
-use dozer_types::serde::{Deserialize, Serialize};
+
 use dozer_types::types::{Field, FieldType};
 use std::collections::BTreeMap;
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct MaxValueAggregator {
     current_state: BTreeMap<Field, u64>,
     return_state: BTreeMap<Field, Vec<Field>>,

--- a/dozer-sql/src/aggregation/min.rs
+++ b/dozer-sql/src/aggregation/min.rs
@@ -1,13 +1,12 @@
 use crate::aggregation::aggregator::Aggregator;
 use crate::errors::PipelineError;
 use dozer_sql_expression::aggregate::AggregateFunctionType::{self, Min};
-use dozer_types::serde::{Deserialize, Serialize};
+
 use dozer_types::types::{Field, FieldType};
 
 use super::aggregator::OrderedAggregatorState;
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct MinAggregator {
     current_state: Option<OrderedAggregatorState>,
     return_type: Option<FieldType>,

--- a/dozer-sql/src/aggregation/min_append_only.rs
+++ b/dozer-sql/src/aggregation/min_append_only.rs
@@ -7,11 +7,10 @@ use dozer_sql_expression::aggregate::AggregateFunctionType::MinAppendOnly;
 use dozer_types::chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
-use dozer_types::serde::{Deserialize, Serialize};
+
 use dozer_types::types::{DozerDuration, Field, FieldType, TimeUnit};
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct MinAppendOnlyAggregator {
     current_state: Field,
     return_type: Option<FieldType>,

--- a/dozer-sql/src/aggregation/min_value.rs
+++ b/dozer-sql/src/aggregation/min_value.rs
@@ -3,12 +3,11 @@ use crate::calculate_err;
 use crate::errors::PipelineError;
 use crate::errors::PipelineError::InvalidReturnType;
 use dozer_sql_expression::aggregate::AggregateFunctionType::MinValue;
-use dozer_types::serde::{Deserialize, Serialize};
+
 use dozer_types::types::{Field, FieldType};
 use std::collections::BTreeMap;
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct MinValueAggregator {
     current_state: BTreeMap<Field, u64>,
     return_state: BTreeMap<Field, Vec<Field>>,

--- a/dozer-sql/src/aggregation/sum.rs
+++ b/dozer-sql/src/aggregation/sum.rs
@@ -5,24 +5,23 @@ use dozer_sql_expression::aggregate::AggregateFunctionType::Sum;
 use dozer_sql_expression::num_traits::FromPrimitive;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::rust_decimal::Decimal;
-use dozer_types::serde::{Deserialize, Serialize};
+
 use dozer_types::types::{DozerDuration, Field, FieldType, TimeUnit};
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct SumAggregator {
     current_state: SumState,
     return_type: Option<FieldType>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(crate = "dozer_types::serde")]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
 pub struct SumState {
     pub(crate) int_state: i64,
     pub(crate) i128_state: i128,
     pub(crate) uint_state: u64,
     pub(crate) u128_state: u128,
     pub(crate) float_state: f64,
+    #[bincode(with_serde)]
     pub(crate) decimal_state: Decimal,
     pub(crate) duration_state: std::time::Duration,
 }

--- a/dozer-sql/src/expression/tests/json_functions.rs
+++ b/dozer-sql/src/expression/tests/json_functions.rs
@@ -1,13 +1,12 @@
 use crate::expression::tests::test_common::run_fct;
-use dozer_types::json_types::{serde_json_to_json_value, JsonValue};
+use dozer_types::json_types::json;
+use dozer_types::json_types::JsonValue;
 use dozer_types::ordered_float::OrderedFloat;
-use dozer_types::serde_json::json;
 use dozer_types::types::{Field, FieldDefinition, FieldType, Schema, SourceDefinition};
-use std::collections::BTreeMap;
 
 #[test]
 fn test_json_value() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         {
             "info":{
                 "type":1,
@@ -20,8 +19,7 @@ fn test_json_value() {
             },
             "type":"Basic"
         }
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.info.address.town') FROM users",
@@ -39,12 +37,12 @@ fn test_json_value() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::String(String::from("Bristol"))));
+    assert_eq!(f, Field::Json(String::from("Bristol").into()));
 }
 
 #[test]
 fn test_json_value_null() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         {
             "info":{
                 "type":1,
@@ -57,8 +55,7 @@ fn test_json_value_null() {
             },
             "type":"Basic"
         }
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.info.address.tags') FROM users",
@@ -76,12 +73,12 @@ fn test_json_value_null() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Null));
+    assert_eq!(f, Field::Json(JsonValue::NULL));
 }
 
 #[test]
 fn test_json_query() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         {
             "info": {
                 "type": 1,
@@ -94,8 +91,7 @@ fn test_json_query() {
             },
             "type": "Basic"
         }
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.info.address') FROM users",
@@ -115,26 +111,15 @@ fn test_json_query() {
 
     assert_eq!(
         f,
-        Field::Json(JsonValue::Object(BTreeMap::from([
-            (
-                "town".to_string(),
-                JsonValue::String("Cheltenham".to_string())
-            ),
-            (
-                "county".to_string(),
-                JsonValue::String("Gloucestershire".to_string())
-            ),
-            (
-                "country".to_string(),
-                JsonValue::String("England".to_string())
-            ),
-        ])))
+        Field::Json(
+            json!({"town": "Cheltenham", "county": "Gloucestershire", "country": "England"})
+        )
     );
 }
 
 #[test]
 fn test_json_query_null() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         {
             "info": {
                 "type": 1,
@@ -147,8 +132,7 @@ fn test_json_query_null() {
             },
             "type": "Basic"
         }
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.type') FROM users",
@@ -165,12 +149,12 @@ fn test_json_query_null() {
             .clone(),
         vec![Field::Json(json_val)],
     );
-    assert_eq!(f, Field::Json(JsonValue::Null));
+    assert_eq!(f, Field::Json(JsonValue::NULL));
 }
 
 #[test]
 fn test_json_query_len_one_array() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         {
             "info": {
                 "type": 1,
@@ -183,8 +167,7 @@ fn test_json_query_len_one_array() {
             },
             "type": "Basic"
         }
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.info.tags') FROM users",
@@ -201,17 +184,12 @@ fn test_json_query_len_one_array() {
             .clone(),
         vec![Field::Json(json_val)],
     );
-    assert_eq!(
-        f,
-        Field::Json(JsonValue::Array(vec![JsonValue::String(String::from(
-            "Sport"
-        ))]))
-    );
+    assert_eq!(f, Field::Json(json!(["Sport"])));
 }
 
 #[test]
 fn test_json_query_array() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         {
             "info": {
                 "type": 1,
@@ -224,8 +202,7 @@ fn test_json_query_array() {
             },
             "type": "Basic"
         }
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.info.tags') FROM users",
@@ -243,18 +220,12 @@ fn test_json_query_array() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(
-        f,
-        Field::Json(JsonValue::Array(vec![
-            JsonValue::String(String::from("Sport")),
-            JsonValue::String(String::from("Water polo")),
-        ]))
-    );
+    assert_eq!(f, Field::Json(json!(["Sport", "Water polo",])));
 }
 
 #[test]
 fn test_json_query_default_path() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         {
             "Cities": [
                 {
@@ -271,8 +242,7 @@ fn test_json_query_default_path() {
                 }
             ]
         }
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo) FROM users",
@@ -294,13 +264,12 @@ fn test_json_query_default_path() {
 
 #[test]
 fn test_json_query_all() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         [
             {"digit": 30, "letter": "A"},
             {"digit": 31, "letter": "B"}
         ]
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo, '$..*') FROM users",
@@ -320,35 +289,31 @@ fn test_json_query_all() {
 
     assert_eq!(
         f,
-        Field::Json(
-            serde_json_to_json_value(json!([
-                {
-                    "digit": 30,
-                    "letter": "A"
-                },
-                30,
-                "A",
-                {
-                    "digit": 31,
-                    "letter": "B"
-                },
-                31,
-                "B"
-            ]))
-            .unwrap()
-        )
+        Field::Json(json!([
+            {
+                "digit": 30,
+                "letter": "A"
+            },
+            30,
+            "A",
+            {
+                "digit": 31,
+                "letter": "B"
+            },
+            31,
+            "B"
+        ]))
     );
 }
 
 #[test]
 fn test_json_query_iter() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         [
             {"digit": 30, "letter": "A"},
             {"digit": 31, "letter": "B"}
         ]
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_QUERY(jsonInfo, '$[*].digit') FROM users",
@@ -366,10 +331,7 @@ fn test_json_query_iter() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(
-        f,
-        Field::Json(serde_json_to_json_value(json!([30, 31,])).unwrap())
-    );
+    assert_eq!(f, Field::Json(json!([30, 31,])));
 }
 
 #[test]
@@ -390,7 +352,7 @@ fn test_json_cast() {
         vec![Field::UInt(10_u64)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Number(OrderedFloat(10_f64))));
+    assert_eq!(f, Field::Json(10_f64.into()));
 
     let f = run_fct(
         "SELECT CAST(u128 AS JSON) FROM users",
@@ -408,7 +370,7 @@ fn test_json_cast() {
         vec![Field::U128(10_u128)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Number(OrderedFloat(10_f64))));
+    assert_eq!(f, Field::Json(10_f64.into()));
 
     let f = run_fct(
         "SELECT CAST(int AS JSON) FROM users",
@@ -426,7 +388,7 @@ fn test_json_cast() {
         vec![Field::Int(10_i64)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Number(OrderedFloat(10_f64))));
+    assert_eq!(f, Field::Json(10_f64.into()));
 
     let f = run_fct(
         "SELECT CAST(i128 AS JSON) FROM users",
@@ -444,7 +406,7 @@ fn test_json_cast() {
         vec![Field::I128(10_i128)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Number(OrderedFloat(10_f64))));
+    assert_eq!(f, Field::Json(10_f64.into()));
 
     let f = run_fct(
         "SELECT CAST(float AS JSON) FROM users",
@@ -462,7 +424,7 @@ fn test_json_cast() {
         vec![Field::Float(OrderedFloat(10_f64))],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Number(OrderedFloat(10_f64))));
+    assert_eq!(f, Field::Json(10_f64.into()));
 
     let f = run_fct(
         "SELECT CAST(str AS JSON) FROM users",
@@ -480,7 +442,7 @@ fn test_json_cast() {
         vec![Field::String("Dozer".to_string())],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::String("Dozer".to_string())));
+    assert_eq!(f, Field::Json("Dozer".into()));
 
     let f = run_fct(
         "SELECT CAST(str AS JSON) FROM users",
@@ -498,7 +460,7 @@ fn test_json_cast() {
         vec![Field::Text("Dozer".to_string())],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::String("Dozer".to_string())));
+    assert_eq!(f, Field::Json("Dozer".into()));
 
     let f = run_fct(
         "SELECT CAST(bool AS JSON) FROM users",
@@ -516,18 +478,17 @@ fn test_json_cast() {
         vec![Field::Boolean(true)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Bool(true)));
+    assert_eq!(f, Field::Json(true.into()));
 }
 
 #[test]
 fn test_json_value_cast() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         [
             {"digit": 30, "letter": "A"},
             {"digit": 31, "letter": "B"}
         ]
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT JSON_VALUE(jsonInfo, '$[0].digit') FROM users",
@@ -545,7 +506,7 @@ fn test_json_value_cast() {
         vec![Field::Json(json_val.clone())],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Number(OrderedFloat(30_f64))));
+    assert_eq!(f, Field::Json(30.into()));
 
     let f = run_fct(
         "SELECT CAST(JSON_VALUE(jsonInfo, '$[0].digit') AS UINT) FROM users",
@@ -619,13 +580,12 @@ fn test_json_value_cast() {
 
     assert_eq!(f, Field::String("30".to_string()));
 
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         [
             {"bool": true},
             {"digit": 31, "letter": "B"}
         ]
-    ))
-    .unwrap();
+    );
 
     let f = run_fct(
         "SELECT CAST(JSON_VALUE(jsonInfo, '$[0].bool') AS BOOLEAN) FROM users",
@@ -648,10 +608,9 @@ fn test_json_value_cast() {
 
 #[test]
 fn test_json_value_diff_1() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         { "x": [0,1], "y": "[0,1]", "z": "Monty" }
-    ))
-    .unwrap();
+    );
 
     let mut f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$') FROM users",
@@ -687,15 +646,14 @@ fn test_json_value_diff_1() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Null));
+    assert_eq!(f, Field::Json(JsonValue::NULL));
 }
 
 #[test]
 fn test_json_value_diff_2() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         { "x": [0,1], "y": "[0,1]", "z": "Monty" }
-    ))
-    .unwrap();
+    );
 
     let mut f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.x') FROM users",
@@ -713,13 +671,7 @@ fn test_json_value_diff_2() {
         vec![Field::Json(json_val.clone())],
     );
 
-    assert_eq!(
-        f,
-        Field::Json(JsonValue::Array(vec![
-            JsonValue::Number(OrderedFloat(0_f64)),
-            JsonValue::Number(OrderedFloat(1_f64))
-        ]))
-    );
+    assert_eq!(f, Field::Json(json!([0, 1,])));
 
     f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.x') FROM users",
@@ -737,15 +689,14 @@ fn test_json_value_diff_2() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Null));
+    assert_eq!(f, Field::Json(JsonValue::NULL));
 }
 
 #[test]
 fn test_json_value_diff_3() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         { "x": [0,1], "y": "[0,1]", "z": "Monty" }
-    ))
-    .unwrap();
+    );
 
     let mut f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.y') FROM users",
@@ -763,7 +714,7 @@ fn test_json_value_diff_3() {
         vec![Field::Json(json_val.clone())],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Null));
+    assert_eq!(f, Field::Json(JsonValue::NULL));
 
     f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.y') FROM users",
@@ -781,15 +732,14 @@ fn test_json_value_diff_3() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::String("[0,1]".to_string())));
+    assert_eq!(f, Field::Json("[0,1]".into()));
 }
 
 #[test]
 fn test_json_value_diff_4() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         { "x": [0,1], "y": "[0,1]", "z": "Monty" }
-    ))
-    .unwrap();
+    );
 
     let mut f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.z') FROM users",
@@ -807,7 +757,7 @@ fn test_json_value_diff_4() {
         vec![Field::Json(json_val.clone())],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Null));
+    assert_eq!(f, Field::Json(JsonValue::NULL));
 
     f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.z') FROM users",
@@ -825,15 +775,14 @@ fn test_json_value_diff_4() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::String("Monty".to_string())));
+    assert_eq!(f, Field::Json("Monty".into()));
 }
 
 #[test]
 fn test_json_value_diff_5() {
-    let json_val = serde_json_to_json_value(json!(
+    let json_val = json!(
         { "x": [0,1], "y": "[0,1]", "z": "Monty" }
-    ))
-    .unwrap();
+    );
 
     let mut f = run_fct(
         "SELECT JSON_QUERY(jsonInfo,'$.x[0]') FROM users",
@@ -851,7 +800,7 @@ fn test_json_value_diff_5() {
         vec![Field::Json(json_val.clone())],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Null));
+    assert_eq!(f, Field::Json(JsonValue::NULL));
 
     f = run_fct(
         "SELECT JSON_VALUE(jsonInfo,'$.x[0]') FROM users",
@@ -869,5 +818,5 @@ fn test_json_value_diff_5() {
         vec![Field::Json(json_val)],
     );
 
-    assert_eq!(f, Field::Json(JsonValue::Number(OrderedFloat(0_f64))));
+    assert_eq!(f, Field::Json(0.into()));
 }

--- a/dozer-sql/src/product/join/operator/table.rs
+++ b/dozer-sql/src/product/join/operator/table.rs
@@ -58,7 +58,7 @@ impl JoinTable {
             (
                 deserialize_record(cursor, record_store)?,
                 deserialize_join_map(cursor, record_store)?,
-                deserialize_bincode(cursor)?,
+                deserialize_bincode::<bincode::serde::Compat<_>>(cursor)?.0,
             )
         } else {
             (
@@ -171,7 +171,7 @@ impl JoinTable {
     ) -> Result<(), SerializationError> {
         serialize_record(&self.default_record, record_store, object)?;
         serialize_join_map(&self.map, record_store, object)?;
-        serialize_bincode(&self.lifetime_map, object)?;
+        serialize_bincode(&bincode::serde::Compat(&self.lifetime_map), object)?;
         Ok(())
     }
 

--- a/dozer-sql/src/product/set/record_map/mod.rs
+++ b/dozer-sql/src/product/set/record_map/mod.rs
@@ -119,7 +119,7 @@ impl ProbabilisticCountingRecordMap {
     pub fn new(cursor: Option<&mut Cursor>) -> Result<Self, DeserializationError> {
         Ok(if let Some(cursor) = cursor {
             Self {
-                map: deserialize_bincode(cursor)?,
+                map: deserialize_bincode::<bincode::serde::Compat<_>>(cursor)?.0,
             }
         } else {
             Self {
@@ -154,7 +154,7 @@ impl CountingRecordMap for ProbabilisticCountingRecordMap {
         _record_store: &ProcessorRecordStore,
         object: &mut Object,
     ) -> Result<(), SerializationError> {
-        serialize_bincode(&self.map, object)
+        serialize_bincode(&bincode::serde::Compat(&self.map), object)
     }
 }
 

--- a/dozer-sql/src/utils/record_hashtable_key.rs
+++ b/dozer-sql/src/utils/record_hashtable_key.rs
@@ -5,7 +5,9 @@ use dozer_types::{
 };
 use std::hash::{Hash, Hasher};
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Hash, PartialEq, Eq, bincode::Encode, bincode::Decode, Deserialize, Serialize,
+)]
 #[serde(crate = "dozer_types::serde")]
 pub enum RecordKey {
     Accurate(Vec<Field>),

--- a/dozer-storage/src/lmdb_database/lmdb_val.rs
+++ b/dozer-storage/src/lmdb_database/lmdb_val.rs
@@ -1,4 +1,5 @@
 use dozer_types::{
+    bincode,
     borrow::{Borrow, Cow},
     types::{Field, IndexDefinition, Record, SchemaWithIndex},
 };
@@ -225,7 +226,7 @@ unsafe impl LmdbKey for String {
 
 impl<'a> Encode<'a> for &'a [Field] {
     fn encode(self) -> Result<Encoded<'a>, StorageError> {
-        dozer_types::bincode::serialize(self)
+        bincode::encode_to_vec(self, bincode::config::legacy())
             .map(Encoded::Vec)
             .map_err(|e| StorageError::SerializationError {
                 typ: "[Field]",
@@ -240,12 +241,14 @@ impl BorrowEncode for Vec<Field> {
 
 impl Decode for Vec<Field> {
     fn decode(bytes: &[u8]) -> Result<Cow<Self>, StorageError> {
-        dozer_types::bincode::deserialize(bytes)
-            .map(Cow::Owned)
-            .map_err(|e| StorageError::DeserializationError {
-                typ: "Vec<Field>",
-                reason: Box::new(e),
-            })
+        let (value, _): (Self, usize) =
+            dozer_types::bincode::decode_from_slice(bytes, bincode::config::legacy()).map_err(
+                |e| StorageError::DeserializationError {
+                    typ: "Vec<Field>",
+                    reason: Box::new(e),
+                },
+            )?;
+        Ok(Cow::Owned(value))
     }
 }
 
@@ -253,7 +256,7 @@ unsafe impl LmdbVal for Vec<Field> {}
 
 impl<'a> Encode<'a> for &'a Record {
     fn encode(self) -> Result<Encoded<'a>, StorageError> {
-        dozer_types::bincode::serialize(self)
+        dozer_types::bincode::encode_to_vec(self, bincode::config::legacy())
             .map(Encoded::Vec)
             .map_err(|e| StorageError::SerializationError {
                 typ: "Record",
@@ -268,12 +271,14 @@ impl BorrowEncode for Record {
 
 impl Decode for Record {
     fn decode(bytes: &[u8]) -> Result<Cow<Self>, StorageError> {
-        dozer_types::bincode::deserialize(bytes)
-            .map(Cow::Owned)
-            .map_err(|e| StorageError::DeserializationError {
-                typ: "Record",
-                reason: Box::new(e),
-            })
+        let (value, _): (Self, _) =
+            dozer_types::bincode::decode_from_slice(bytes, bincode::config::legacy()).map_err(
+                |e| StorageError::DeserializationError {
+                    typ: "Record",
+                    reason: Box::new(e),
+                },
+            )?;
+        Ok(Cow::Owned(value))
     }
 }
 
@@ -285,7 +290,7 @@ unsafe impl LmdbVal for Record {}
 
 impl<'a> Encode<'a> for &'a IndexDefinition {
     fn encode(self) -> Result<Encoded<'a>, StorageError> {
-        dozer_types::bincode::serialize(self)
+        dozer_types::bincode::encode_to_vec(self, bincode::config::legacy())
             .map(Encoded::Vec)
             .map_err(|e| StorageError::SerializationError {
                 typ: "IndexDefinition",
@@ -300,12 +305,14 @@ impl BorrowEncode for IndexDefinition {
 
 impl Decode for IndexDefinition {
     fn decode(bytes: &[u8]) -> Result<Cow<Self>, StorageError> {
-        dozer_types::bincode::deserialize(bytes)
-            .map(Cow::Owned)
-            .map_err(|e| StorageError::DeserializationError {
-                typ: "IndexDefinition",
-                reason: Box::new(e),
-            })
+        let (value, _): (Self, _) =
+            dozer_types::bincode::decode_from_slice(bytes, bincode::config::legacy()).map_err(
+                |e| StorageError::DeserializationError {
+                    typ: "IndexDefinition",
+                    reason: Box::new(e),
+                },
+            )?;
+        Ok(Cow::Owned(value))
     }
 }
 
@@ -313,7 +320,7 @@ unsafe impl LmdbVal for IndexDefinition {}
 
 impl<'a> Encode<'a> for &'a SchemaWithIndex {
     fn encode(self) -> Result<Encoded<'a>, StorageError> {
-        dozer_types::bincode::serialize(self)
+        dozer_types::bincode::serde::encode_to_vec(self, bincode::config::legacy())
             .map(Encoded::Vec)
             .map_err(|e| StorageError::SerializationError {
                 typ: "SchemaWithIndex",
@@ -328,12 +335,13 @@ impl BorrowEncode for SchemaWithIndex {
 
 impl Decode for SchemaWithIndex {
     fn decode(bytes: &[u8]) -> Result<Cow<Self>, StorageError> {
-        dozer_types::bincode::deserialize(bytes)
-            .map(Cow::Owned)
-            .map_err(|e| StorageError::DeserializationError {
-                typ: "SchemaWithIndex",
-                reason: Box::new(e),
-            })
+        let (value, _) =
+            dozer_types::bincode::serde::decode_from_slice(bytes, bincode::config::legacy())
+                .map_err(|e| StorageError::DeserializationError {
+                    typ: "SchemaWithIndex",
+                    reason: Box::new(e),
+                })?;
+        Ok(Cow::Owned(value))
     }
 }
 

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 chrono = { version = "0.4.23", features = ["serde"] }
 serde = { version = "1.0.189", features = ["derive", "rc"] }
 serde_json = { version = "1.0.93", features = ["std"] }
+ijson = "0.1.3"
 rust_decimal = { version = "1.32", features = ["serde-str", "db-postgres"] }
 bincode = "1.3.3"
 ahash = "0.8.3"
@@ -38,6 +39,7 @@ tokio-postgres = { version = "0.7.7", features = [
 serde_bytes = "0.11.12"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 schemars = "0.8.15"
+bson = "2.7.0"
 
 [build-dependencies]
 tonic-build = "0.10.0"

--- a/dozer-types/Cargo.toml
+++ b/dozer-types/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.189", features = ["derive", "rc"] }
 serde_json = { version = "1.0.93", features = ["std"] }
 ijson = "0.1.3"
 rust_decimal = { version = "1.32", features = ["serde-str", "db-postgres"] }
-bincode = "1.3.3"
+bincode = { workspace = true, features = ["serde"] }
 ahash = "0.8.3"
 thiserror = "1.0.48"
 parking_lot = "0.12"
@@ -39,7 +39,7 @@ tokio-postgres = { version = "0.7.7", features = [
 serde_bytes = "0.11.12"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 schemars = "0.8.15"
-bson = "2.7.0"
+rmp-serde = "1.1.2"
 
 [build-dependencies]
 tonic-build = "0.10.0"

--- a/dozer-types/src/arrow_types/from_arrow.rs
+++ b/dozer-types/src/arrow_types/from_arrow.rs
@@ -6,7 +6,7 @@ use super::errors::FromArrowError::FieldTypeNotSupported;
 use super::errors::FromArrowError::TimeConversionError;
 use super::to_arrow;
 use crate::arrow_types::to_arrow::DOZER_SCHEMA_KEY;
-use crate::json_types::parse_json;
+use crate::json_types::json_from_str;
 use crate::types::{
     Field as DozerField, FieldDefinition, FieldType, Record, Schema as DozerSchema, Schema,
     SourceDefinition,
@@ -154,7 +154,7 @@ fn make_json(column: &ArrayRef, row: usize) -> Result<DozerField, FromArrowError
         let s: DozerField = if r.is_null(row) {
             DozerField::Null
         } else {
-            DozerField::Json(parse_json(r.value(row))?)
+            DozerField::Json(json_from_str(r.value(row))?)
         };
         Ok(s)
     } else {

--- a/dozer-types/src/arrow_types/to_arrow.rs
+++ b/dozer-types/src/arrow_types/to_arrow.rs
@@ -105,9 +105,9 @@ pub fn map_record_to_arrow(
             (Field::Binary(v), FieldType::Binary) => {
                 Arc::new(arrow_array::BinaryArray::from_iter_values([v])) as ArrayRef
             }
-            (Field::Json(v), FieldType::Json) => {
-                Arc::new(arrow_array::StringArray::from_iter_values([v.to_string()])) as ArrayRef
-            }
+            (Field::Json(v), FieldType::Json) => Arc::new(
+                arrow_array::StringArray::from_iter_values([format!("{v:?}")]),
+            ) as ArrayRef,
             (Field::Null, FieldType::Json) => {
                 Arc::new(arrow_array::StringArray::from(vec![None as Option<String>])) as ArrayRef
             }

--- a/dozer-types/src/errors/types.rs
+++ b/dozer-types/src/errors/types.rs
@@ -41,6 +41,8 @@ pub enum DeserializationError {
     Json(#[from] serde_json::Error),
     #[error("bincode: {0}")]
     Bincode(#[from] bincode::Error),
+    #[error("bson: {0}")]
+    Bson(#[from] bson::de::Error),
     #[error("custom: {0}")]
     Custom(#[from] BoxedError),
     #[error("Empty input")]

--- a/dozer-types/src/errors/types.rs
+++ b/dozer-types/src/errors/types.rs
@@ -30,7 +30,7 @@ pub enum SerializationError {
     #[error("json: {0}")]
     Json(#[from] serde_json::Error),
     #[error("bincode: {0}")]
-    Bincode(#[from] bincode::Error),
+    Bincode(#[from] bincode::error::EncodeError),
     #[error("custom: {0}")]
     Custom(#[from] BoxedError),
 }
@@ -40,9 +40,9 @@ pub enum DeserializationError {
     #[error("json: {0}")]
     Json(#[from] serde_json::Error),
     #[error("bincode: {0}")]
-    Bincode(#[from] bincode::Error),
+    Bincode(#[from] bincode::error::DecodeError),
     #[error("bson: {0}")]
-    Bson(#[from] bson::de::Error),
+    Msgpack(#[from] rmp_serde::decode::Error),
     #[error("custom: {0}")]
     Custom(#[from] BoxedError),
     #[error("Empty input")]

--- a/dozer-types/src/helper.rs
+++ b/dozer-types/src/helper.rs
@@ -1,5 +1,5 @@
 use crate::errors::types::{DeserializationError, TypeError};
-use crate::json_types::{parse_json, serde_json_to_json_value};
+use crate::json_types::{json_from_str, serde_json_to_json_value};
 use crate::types::{DozerDuration, DozerPoint, TimeUnit, DATE_FORMAT};
 use crate::types::{Field, FieldType};
 use chrono::{DateTime, NaiveDate};
@@ -278,13 +278,13 @@ impl Field {
                 if nullable && (value.is_empty() || value == "null") {
                     Ok(Field::Null)
                 } else {
-                    parse_json(value)
-                        .map(Field::Json)
-                        .map_err(|_| TypeError::InvalidFieldValue {
+                    json_from_str(value).map(Field::Json).map_err(|_| {
+                        TypeError::InvalidFieldValue {
                             field_type: typ,
                             nullable,
                             value: value.to_string(),
-                        })
+                        }
+                    })
                 }
             }
             FieldType::Point => {

--- a/dozer-types/src/node.rs
+++ b/dozer-types/src/node.rs
@@ -5,7 +5,9 @@ use std::{
     fmt::{Display, Formatter},
     str::from_utf8,
 };
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, bincode::Encode, bincode::Decode,
+)]
 pub struct NodeHandle {
     pub ns: Option<u16>,
     pub id: String,
@@ -61,7 +63,19 @@ impl Display for NodeHandle {
 }
 
 #[derive(
-    Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+    Clone,
+    Debug,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    Serialize,
+    Deserialize,
+    bincode::Encode,
+    bincode::Decode,
 )]
 /// A identifier made of two `u64`s.
 pub struct OpIdentifier {
@@ -90,7 +104,20 @@ impl OpIdentifier {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    bincode::Encode,
+    bincode::Decode,
+)]
 /// A table's ingestion state.
 pub enum TableState {
     /// This table hasn't been ingested.

--- a/dozer-types/src/tests/field_serialize_test.rs
+++ b/dozer-types/src/tests/field_serialize_test.rs
@@ -1,3 +1,5 @@
+use bincode::config;
+
 use crate::types::{field_test_cases, Field};
 
 #[test]
@@ -12,10 +14,11 @@ fn test_field_serialize_roundtrip() {
 #[test]
 fn test_field_bincode_serialize_roundtrip() {
     for field in field_test_cases() {
-        let bytes = bincode::serialize(&field).unwrap();
-        let deserialized = bincode::deserialize::<Field>(&bytes).unwrap_or_else(|_| {
-            panic!("Failed to deserialize field: {field:?} from bytes: {bytes:?}")
-        });
+        let bytes = bincode::encode_to_vec(&field, config::legacy()).unwrap();
+        let (deserialized, _): (Field, _) = bincode::decode_from_slice(&bytes, config::legacy())
+            .unwrap_or_else(|e| {
+                panic!("Failed to deserialize field: {field:?} from bytes: {bytes:?}. {e}")
+            });
         assert_eq!(field, deserialized);
     }
 }

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -1,10 +1,13 @@
 use crate::errors::types::DeserializationError;
-use crate::json_types::JsonValue;
+use crate::json_types::{
+    json_cmp, json_from_bytes, json_to_bytes, json_to_bytes_size, parse_json, JsonValue,
+};
 use crate::types::{
     DozerDuration, DozerPoint, FieldDefinition, Schema, SourceDefinition, TimeUnit,
 };
 #[allow(unused_imports)]
 use chrono::{DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, TimeZone, Utc};
+use ijson::DestructuredRef;
 use ordered_float::OrderedFloat;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal::Decimal;
@@ -15,7 +18,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 pub const DATE_FORMAT: &str = "%Y-%m-%d";
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Field {
     UInt(u64),
@@ -30,10 +33,41 @@ pub enum Field {
     Decimal(Decimal),
     Timestamp(DateTime<FixedOffset>),
     Date(NaiveDate),
-    Json(JsonValue),
+    Json(#[cfg_attr(feature= "arbitrary", arbitrary(with = arb_json::arbitrary_json))] JsonValue),
     Point(DozerPoint),
     Duration(DozerDuration),
     Null,
+}
+
+impl Ord for Field {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (Self::UInt(l), Self::UInt(r)) => l.cmp(r),
+            (Self::U128(l), Self::U128(r)) => l.cmp(r),
+            (Self::Int(l), Self::Int(r)) => l.cmp(r),
+            (Self::I128(l), Self::I128(r)) => l.cmp(r),
+            (Self::Float(l), Self::Float(r)) => l.cmp(r),
+            (Self::Boolean(l), Self::Boolean(r)) => l.cmp(r),
+            (Self::String(l), Self::String(r)) => l.cmp(r),
+            (Self::Text(l), Self::Text(r)) => l.cmp(r),
+            (Self::Binary(l), Self::Binary(r)) => l.cmp(r),
+            (Self::Decimal(l), Self::Decimal(r)) => l.cmp(r),
+            (Self::Timestamp(l), Self::Timestamp(r)) => l.cmp(r),
+            (Self::Date(l), Self::Date(r)) => l.cmp(r),
+            (Self::Json(l), Self::Json(r)) => json_cmp(l, r),
+            (Self::Point(l), Self::Point(r)) => l.cmp(r),
+            (Self::Duration(l), Self::Duration(r)) => l.cmp(r),
+            (Self::Null, Self::Null) => std::cmp::Ordering::Equal,
+            (Self::Null, _) => std::cmp::Ordering::Greater,
+            (_, Self::Null) => std::cmp::Ordering::Less,
+            (l, r) => l.ty().cmp(&r.ty()),
+        }
+    }
+}
+impl PartialOrd for Field {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 #[cfg(feature = "arbitrary")]
@@ -41,6 +75,57 @@ pub(crate) fn arbitrary_float(
     arbitrary: &mut arbitrary::Unstructured,
 ) -> arbitrary::Result<OrderedFloat<f64>> {
     Ok(OrderedFloat(arbitrary.arbitrary()?))
+}
+
+#[cfg(feature = "arbitrary")]
+mod arb_json {
+    use arbitrary::Arbitrary;
+    use ijson::{IArray, IObject};
+
+    use super::JsonValue;
+
+    struct ArbitraryJson(JsonValue);
+
+    impl<'a> arbitrary::Arbitrary<'a> for ArbitraryJson {
+        fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+            use ijson::ValueType;
+
+            let v = match u.choose(&[
+                ValueType::Null,
+                ValueType::Bool,
+                ValueType::Number,
+                ValueType::String,
+                ValueType::Array,
+                ValueType::Object,
+            ])? {
+                ValueType::Null => JsonValue::NULL,
+                ValueType::Bool => bool::arbitrary(u)?.into(),
+                ValueType::Number => f64::arbitrary(u)?.into(),
+                ValueType::String => String::arbitrary(u)?.into(),
+                ValueType::Array => {
+                    let mut values = IArray::new();
+                    for json_value in u.arbitrary_iter::<ArbitraryJson>()? {
+                        values.push(json_value?.0);
+                    }
+                    values.into()
+                }
+                ValueType::Object => {
+                    let mut object = IObject::new();
+                    for result in u.arbitrary_iter::<(String, ArbitraryJson)>()? {
+                        let (key, value) = result?;
+                        object.insert(key, value.0);
+                    }
+                    object.into()
+                }
+            };
+            Ok(ArbitraryJson(v))
+        }
+    }
+    pub(crate) fn arbitrary_json(
+        arbitrary: &mut arbitrary::Unstructured,
+    ) -> arbitrary::Result<JsonValue> {
+        Ok(ArbitraryJson::arbitrary(arbitrary)?.0)
+    }
 }
 
 impl Field {
@@ -59,7 +144,7 @@ impl Field {
             Field::Timestamp(_) => 8,
             Field::Date(_) => 10,
             // todo: should optimize with better serialization method
-            Field::Json(b) => bincode::serialize(b).unwrap().len(),
+            Field::Json(b) => json_to_bytes_size(b),
             Field::Point(_p) => 16,
             Field::Duration(_) => 17,
             Field::Null => 0,
@@ -80,7 +165,7 @@ impl Field {
             Field::Decimal(d) => Cow::Owned(d.serialize().into()),
             Field::Timestamp(t) => Cow::Owned(t.timestamp_millis().to_be_bytes().into()),
             Field::Date(t) => Cow::Owned(t.to_string().into()),
-            Field::Json(b) => Cow::Owned(bincode::serialize(b).unwrap()),
+            Field::Json(b) => Cow::Owned(json_to_bytes(b)),
             Field::Point(p) => Cow::Owned(p.to_bytes().into()),
             Field::Duration(d) => Cow::Owned(d.to_bytes().into()),
             Field::Null => Cow::Owned([].into()),
@@ -156,9 +241,7 @@ impl Field {
                 std::str::from_utf8(val)?,
                 DATE_FORMAT,
             )?)),
-            12 => Ok(Field::Json(
-                bincode::deserialize(val).map_err(DeserializationError::Bincode)?,
-            )),
+            12 => Ok(Field::Json(json_from_bytes(val)?)),
             13 => Ok(Field::Point(
                 DozerPoint::from_bytes(val).map_err(|_| DeserializationError::BadDataLength)?,
             )),
@@ -215,7 +298,7 @@ impl Field {
     pub fn as_uint(&self) -> Option<u64> {
         match self {
             Field::UInt(i) => Some(*i),
-            Field::Json(JsonValue::Number(f)) => Some(f.0 as u64),
+            Field::Json(v) => v.as_number()?.to_u64(),
             _ => None,
         }
     }
@@ -223,7 +306,7 @@ impl Field {
     pub fn as_u128(&self) -> Option<u128> {
         match self {
             Field::U128(i) => Some(*i),
-            Field::Json(j) => j.as_u128(),
+            Field::Json(j) => Some(j.to_f64_lossy()? as u128),
             _ => None,
         }
     }
@@ -235,7 +318,7 @@ impl Field {
     pub fn as_int(&self) -> Option<i64> {
         match self {
             Field::Int(i) => Some(*i),
-            Field::Json(j) => j.as_i64(),
+            Field::Json(j) => j.to_i64(),
             _ => None,
         }
     }
@@ -243,7 +326,7 @@ impl Field {
     pub fn as_i128(&self) -> Option<i128> {
         match self {
             Field::I128(i) => Some(*i),
-            Field::Json(j) => j.as_i128(),
+            Field::Json(j) => Some(j.to_f64_lossy()? as i128),
             _ => None,
         }
     }
@@ -255,7 +338,7 @@ impl Field {
     pub fn as_float(&self) -> Option<f64> {
         match self {
             Field::Float(f) => Some(f.0),
-            Field::Json(j) => j.as_f64(),
+            Field::Json(j) => j.to_f64_lossy(),
             _ => None,
         }
     }
@@ -263,7 +346,7 @@ impl Field {
     pub fn as_boolean(&self) -> Option<bool> {
         match self {
             Field::Boolean(b) => Some(*b),
-            Field::Json(j) => j.as_bool(),
+            Field::Json(j) => j.to_bool(),
             _ => None,
         }
     }
@@ -271,7 +354,7 @@ impl Field {
     pub fn as_string(&self) -> Option<&str> {
         match self {
             Field::String(s) => Some(s),
-            Field::Json(j) => j.as_str(),
+            Field::Json(j) => Some(j.as_string()?.as_str()),
             _ => None,
         }
     }
@@ -279,7 +362,7 @@ impl Field {
     pub fn as_text(&self) -> Option<&str> {
         match self {
             Field::Text(s) => Some(s),
-            Field::Json(j) => j.as_str(),
+            Field::Json(j) => Some(j.as_string()?.as_str()),
             _ => None,
         }
     }
@@ -356,7 +439,13 @@ impl Field {
     pub fn as_null(&self) -> Option<()> {
         match self {
             Field::Null => Some(()),
-            Field::Json(j) => j.as_null(),
+            Field::Json(j) => {
+                if j.is_null() {
+                    Some(())
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }
@@ -371,10 +460,9 @@ impl Field {
             Field::Decimal(d) => d.to_u64(),
             Field::String(s) => s.parse::<u64>().ok(),
             Field::Text(s) => s.parse::<u64>().ok(),
-            Field::Json(j) => match j {
-                &JsonValue::Number(n) => u64::from_f64(*n),
-                JsonValue::String(s) => s.parse::<u64>().ok(),
-                &JsonValue::Null => Some(0_u64),
+            Field::Json(j) => match j.destructure_ref() {
+                DestructuredRef::Number(n) => Some(n.to_f64_lossy() as u64),
+                DestructuredRef::String(s) => s.parse::<u64>().ok(),
                 _ => None,
             },
             Field::Null => Some(0_u64),
@@ -392,13 +480,12 @@ impl Field {
             Field::Decimal(d) => d.to_u128(),
             Field::String(s) => s.parse::<u128>().ok(),
             Field::Text(s) => s.parse::<u128>().ok(),
-            Field::Json(j) => match j {
-                &JsonValue::Number(n) => u128::from_f64(*n),
-                JsonValue::String(s) => s.parse::<u128>().ok(),
-                &JsonValue::Null => Some(0_u128),
+            Field::Json(j) => match j.destructure_ref() {
+                DestructuredRef::Number(n) => Some(n.to_f64_lossy() as u128),
+                DestructuredRef::String(s) => s.parse::<u128>().ok(),
                 _ => None,
             },
-            Field::Null => Some(0_u128),
+            Field::Null => None,
             _ => None,
         }
     }
@@ -413,10 +500,9 @@ impl Field {
             Field::Decimal(d) => d.to_i64(),
             Field::String(s) => s.parse::<i64>().ok(),
             Field::Text(s) => s.parse::<i64>().ok(),
-            Field::Json(j) => match j {
-                &JsonValue::Number(n) => i64::from_f64(*n),
-                JsonValue::String(s) => s.parse::<i64>().ok(),
-                &JsonValue::Null => Some(0_i64),
+            Field::Json(j) => match j.destructure_ref() {
+                DestructuredRef::Number(n) => Some(n.to_f64_lossy() as i64),
+                DestructuredRef::String(s) => s.parse::<i64>().ok(),
                 _ => None,
             },
             Field::Null => Some(0_i64),
@@ -434,10 +520,9 @@ impl Field {
             Field::Decimal(d) => d.to_i128(),
             Field::String(s) => s.parse::<i128>().ok(),
             Field::Text(s) => s.parse::<i128>().ok(),
-            Field::Json(j) => match j {
-                &JsonValue::Number(n) => i128::from_f64(*n),
-                JsonValue::String(s) => s.parse::<i128>().ok(),
-                &JsonValue::Null => Some(0_i128),
+            Field::Json(j) => match j.destructure_ref() {
+                DestructuredRef::Number(n) => Some(n.to_f64_lossy() as i128),
+                DestructuredRef::String(s) => s.parse::<i128>().ok(),
                 _ => None,
             },
             Field::Null => Some(0_i128),
@@ -455,10 +540,9 @@ impl Field {
             Field::Decimal(d) => d.to_f64(),
             Field::String(s) => s.parse::<f64>().ok(),
             Field::Text(s) => s.parse::<f64>().ok(),
-            Field::Json(j) => match j {
-                &JsonValue::Number(n) => Some(*n),
-                JsonValue::String(s) => s.parse::<f64>().ok(),
-                &JsonValue::Null => Some(0_f64),
+            Field::Json(j) => match j.destructure_ref() {
+                DestructuredRef::Number(n) => Some(n.to_f64_lossy()),
+                DestructuredRef::String(s) => s.parse::<f64>().ok(),
                 _ => None,
             },
             Field::Null => Some(0_f64),
@@ -477,11 +561,7 @@ impl Field {
             Field::Boolean(b) => Some(*b),
             Field::String(s) => s.parse::<bool>().ok(),
             Field::Text(s) => s.parse::<bool>().ok(),
-            Field::Json(j) => match j {
-                JsonValue::Bool(b) => Some(*b),
-                JsonValue::Null => Some(false),
-                _ => None,
-            },
+            Field::Json(j) => j.to_bool(),
             Field::Null => Some(false),
             _ => None,
         }
@@ -536,18 +616,15 @@ impl Field {
     pub fn to_json(&self) -> Option<JsonValue> {
         match self {
             Field::Json(b) => Some(b.to_owned()),
-            Field::UInt(u) => Some(JsonValue::Number(OrderedFloat((*u) as f64))),
-            Field::U128(u) => Some(JsonValue::Number(OrderedFloat((*u) as f64))),
-            Field::Int(i) => Some(JsonValue::Number(OrderedFloat((*i) as f64))),
-            Field::I128(i) => Some(JsonValue::Number(OrderedFloat((*i) as f64))),
-            Field::Float(f) => Some(JsonValue::Number(*f)),
-            Field::Boolean(b) => Some(JsonValue::Bool(*b)),
-            Field::String(s) => match JsonValue::from_str(s.as_str()) {
-                Ok(v) => Some(v),
-                _ => None,
-            },
-            Field::Text(t) => Some(JsonValue::String(t.to_owned())),
-            Field::Null => Some(JsonValue::Null),
+            Field::UInt(u) => Some((*u).into()),
+            Field::U128(u) => Some((*u as f64).into()),
+            Field::Int(i) => Some((*i).into()),
+            Field::I128(i) => Some((*i as f64).into()),
+            Field::Float(OrderedFloat(f)) => Some((*f).into()),
+            Field::Boolean(b) => Some((*b).into()),
+            Field::String(s) => parse_json(s.as_str()).ok(),
+            Field::Text(t) => Some(t.into()),
+            Field::Null => Some(JsonValue::NULL),
             _ => None,
         }
     }
@@ -597,34 +674,32 @@ impl Field {
 
 impl Display for Field {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let string = match self {
-            Field::UInt(u) => format!("{u}"),
-            Field::U128(u) => format!("{u}"),
-            Field::Int(i) => format!("{i}"),
-            Field::I128(i) => format!("{i}"),
-            Field::Float(f) => format!("{f}"),
-            Field::Decimal(d) => format!("{d}"),
-            Field::Boolean(i) => {
-                if *i {
-                    "TRUE".to_string()
-                } else {
-                    "FALSE".to_string()
-                }
+        match self {
+            Field::UInt(u) => write!(f, "{u}"),
+            Field::U128(u) => write!(f, "{u}"),
+            Field::Int(i) => write!(f, "{i}"),
+            Field::I128(i) => write!(f, "{i}"),
+            Field::Float(OrderedFloat(fl)) => write!(f, "{fl}"),
+            Field::Decimal(d) => write!(f, "{d}"),
+            Field::Boolean(false) => {
+                write!(f, "FALSE")
             }
-            Field::String(s) => s.to_owned(),
-            Field::Text(t) => t.to_owned(),
-            Field::Date(d) => d.format(DATE_FORMAT).to_string(),
-            Field::Timestamp(t) => t.to_rfc3339(),
-            Field::Binary(b) => format!("{b:X?}"),
-            Field::Json(j) => j.to_string(),
+            Field::Boolean(true) => {
+                write!(f, "TRUE")
+            }
+            Field::String(s) => f.write_str(s),
+            Field::Text(t) => write!(f, "{t}"),
+            Field::Date(d) => write!(f, "{}", d.format(DATE_FORMAT)),
+            Field::Timestamp(t) => write!(f, "{}", t.to_rfc3339()),
+            Field::Binary(b) => write!(f, "{b:X?}"),
+            Field::Json(j) => write!(f, "{j:?}"),
             Field::Point(p) => {
                 let (x, y) = p.0.x_y();
-                format!("POINT({}, {})", x.0, y.0)
+                write!(f, "POINT({}, {})", x.0, y.0)
             }
-            Field::Duration(d) => format!("{:?}", d.0),
-            Field::Null => "".to_string(),
-        };
-        f.write_str(&string)
+            Field::Duration(d) => write!(f, "{:?}", d.0),
+            Field::Null => write!(f, ""),
+        }
     }
 }
 
@@ -746,21 +821,14 @@ pub fn field_test_cases() -> impl Iterator<Item = Field> {
         Field::Timestamp(DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z").unwrap()),
         Field::Date(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()),
         Field::Date(NaiveDate::from_ymd_opt(2020, 1, 1).unwrap()),
-        Field::Json(JsonValue::Array(vec![])),
-        Field::Json(JsonValue::Array(vec![
-            JsonValue::Number(OrderedFloat(123_f64)),
-            JsonValue::Number(OrderedFloat(34_f64)),
-            JsonValue::Number(OrderedFloat(97_f64)),
-            JsonValue::Number(OrderedFloat(98_f64)),
-            JsonValue::Number(OrderedFloat(99_f64)),
-            JsonValue::Number(OrderedFloat(34_f64)),
-            JsonValue::Number(OrderedFloat(58_f64)),
-            JsonValue::Number(OrderedFloat(34_f64)),
-            JsonValue::Number(OrderedFloat(102_f64)),
-            JsonValue::Number(OrderedFloat(111_f64)),
-            JsonValue::Number(OrderedFloat(111_f64)),
-            JsonValue::Number(OrderedFloat(34_f64)),
-        ])),
+        Field::Json(Vec::<String>::new().into()),
+        Field::Json(
+            vec![
+                123_f64, 34_f64, 97_f64, 98_f64, 99_f64, 34_f64, 58_f64, 34_f64, 102_f64, 111_f64,
+                111_f64, 34_f64,
+            ]
+            .into(),
+        ),
         Field::Null,
     ]
     .into_iter()

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -20,7 +20,19 @@ use crate::errors::internal::BoxedError;
 use crate::errors::types::TypeError::InvalidFieldValue;
 pub use field::{field_test_cases, Field, FieldType, DATE_FORMAT};
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(
+    Clone,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    bincode::Encode,
+    bincode::Decode,
+)]
 pub enum SourceDefinition {
     Table {
         connection: String,
@@ -129,7 +141,7 @@ impl Display for Schema {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, bincode::Encode, bincode::Decode)]
 pub enum IndexDefinition {
     /// The sorted inverted index, supporting `Eq` filter on multiple fields and `LT`, `LTE`, `GT`, `GTE` filter on at most one field.
     SortedInverted(Vec<usize>),
@@ -141,13 +153,27 @@ pub type SchemaWithIndex = (Schema, Vec<IndexDefinition>);
 
 pub type Timestamp = DateTime<FixedOffset>;
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
+#[derive(
+    Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash, bincode::Encode, bincode::Decode,
+)]
 pub struct Lifetime {
+    #[bincode(with_serde)]
     pub reference: Timestamp,
     pub duration: std::time::Duration,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Hash,
+    Default,
+    bincode::Encode,
+    bincode::Decode,
+)]
 pub struct Record {
     /// List of values, following the definitions of `fields` of the associated schema
     pub values: Vec<Field>,
@@ -249,7 +275,7 @@ impl Display for Record {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, bincode::Encode, bincode::Decode)]
 /// A CDC event.
 pub enum Operation {
     Delete { old: Record },
@@ -259,7 +285,20 @@ pub enum Operation {
 
 // Helpful in interacting with external systems during ingestion and querying
 // For example, nanoseconds can overflow.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    bincode::Decode,
+    bincode::Encode,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TimeUnit {
     Seconds,
@@ -320,7 +359,18 @@ impl TimeUnit {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Hash,
+    bincode::Encode,
+    bincode::Decode,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DozerDuration(pub std::time::Duration, pub TimeUnit);
 
@@ -370,8 +420,19 @@ impl DozerDuration {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
-pub struct DozerPoint(pub Point<OrderedFloat<f64>>);
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Hash,
+    bincode::Encode,
+    bincode::Decode,
+)]
+pub struct DozerPoint(#[bincode(with_serde)] pub Point<OrderedFloat<f64>>);
 
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for DozerPoint {

--- a/dozer-types/src/types/tests.rs
+++ b/dozer-types/src/types/tests.rs
@@ -3,8 +3,6 @@ use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use ordered_float::OrderedFloat;
 use rust_decimal::Decimal;
 
-use crate::json_types::JsonValue;
-
 #[test]
 fn data_encoding_len_must_agree_with_encode() {
     for field in field_test_cases() {
@@ -231,7 +229,7 @@ fn test_as_conversion() {
     assert!(field.as_duration().is_none());
     assert!(field.as_null().is_none());
 
-    let field = Field::Json(JsonValue::Array(vec![]));
+    let field = Field::Json(Vec::<String>::new().into());
     assert!(field.as_uint().is_none());
     assert!(field.as_int().is_none());
     assert!(field.as_u128().is_none());
@@ -500,7 +498,7 @@ fn test_to_conversion() {
     assert!(field.to_duration().is_none());
     assert!(field.to_null().is_none());
 
-    let field = Field::Json(JsonValue::Array(vec![]));
+    let field = Field::Json(Vec::<String>::new().into());
     assert!(field.to_uint().is_none());
     assert!(field.to_int().is_none());
     assert!(field.to_u128().is_none());


### PR DESCRIPTION
- Use ijson to make json more compact in memory
- Update to bincode@2.0.0-rc.3.

Tested on the [Amazon Berkeley Objects (listings)](https://amazon-berkeley-objects.s3.amazonaws.com/archives/abo-listings.tar) dataset, loaded using mongodb. Memory usage decreased by 75%
