### PR TITLE
chore: Make `Expression::evaluate` accept `&mut self`

### DIFF
--- a/dozer-sql/expression/src/case.rs
+++ b/dozer-sql/expression/src/case.rs
@@ -8,9 +8,9 @@ use crate::execution::Expression;
 pub fn evaluate_case(
     schema: &Schema,
     _operand: &Option<Box<Expression>>,
-    conditions: &Vec<Expression>,
-    results: &Vec<Expression>,
-    else_result: &Option<Box<Expression>>,
+    conditions: &mut [Expression],
+    results: &mut [Expression],
+    else_result: &mut Option<Box<Expression>>,
     record: &Record,
 ) -> Result<Field, Error> {
     let iter = zip(conditions, results);

--- a/dozer-sql/expression/src/cast.rs
+++ b/dozer-sql/expression/src/cast.rs
@@ -41,7 +41,7 @@ impl CastOperatorType {
     pub(crate) fn evaluate(
         &self,
         schema: &Schema,
-        arg: &Expression,
+        arg: &mut Expression,
         record: &Record,
     ) -> Result<Field, Error> {
         let field = arg.evaluate(record, schema)?;

--- a/dozer-sql/expression/src/comparison/mod.rs
+++ b/dozer-sql/expression/src/comparison/mod.rs
@@ -13,8 +13,8 @@ macro_rules! define_comparison {
     ($id:ident, $op:expr, $function:expr) => {
         pub fn $id(
             schema: &Schema,
-            left: &Expression,
-            right: &Expression,
+            left: &mut Expression,
+            right: &mut Expression,
             record: &Record,
         ) -> Result<Field, PipelineError> {
             let left_p = left.evaluate(&record, schema)?;
@@ -627,8 +627,8 @@ macro_rules! define_comparison {
 
 pub fn evaluate_lt(
     schema: &Schema,
-    left: &Expression,
-    right: &Expression,
+    left: &mut Expression,
+    right: &mut Expression,
     record: &Record,
 ) -> Result<Field, PipelineError> {
     let left_p = left.evaluate(record, schema)?;
@@ -1164,8 +1164,8 @@ pub fn evaluate_lt(
 
 pub fn evaluate_gt(
     schema: &Schema,
-    left: &Expression,
-    right: &Expression,
+    left: &mut Expression,
+    right: &mut Expression,
     record: &Record,
 ) -> Result<Field, PipelineError> {
     let left_p = left.evaluate(record, schema)?;

--- a/dozer-sql/expression/src/comparison/tests.rs
+++ b/dozer-sql/expression/src/comparison/tests.rs
@@ -13,409 +13,414 @@ fn test_comparison() {
         u_num1: u64, u_num2: u64, i_num1: i64, i_num2: i64, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Literal(Field::UInt(u_num1));
-        let uint2 = Literal(Field::UInt(u_num2));
-        let int1 = Literal(Field::Int(i_num1));
-        let int2 = Literal(Field::Int(i_num2));
-        let float1 = Literal(Field::Float(OrderedFloat(f_num1)));
-        let float2 = Literal(Field::Float(OrderedFloat(f_num2)));
-        let dec1 = Literal(Field::Decimal(d_num1.0));
-        let dec2 = Literal(Field::Decimal(d_num2.0));
-        let null = Literal(Field::Null);
+        let mut uint1 = Literal(Field::UInt(u_num1));
+        let mut uint2 = Literal(Field::UInt(u_num2));
+        let mut int1 = Literal(Field::Int(i_num1));
+        let mut int2 = Literal(Field::Int(i_num2));
+        let mut float1 = Literal(Field::Float(OrderedFloat(f_num1)));
+        let mut float2 = Literal(Field::Float(OrderedFloat(f_num2)));
+        let mut dec1 = Literal(Field::Decimal(d_num1.0));
+        let mut dec2 = Literal(Field::Decimal(d_num2.0));
+        let mut null = Literal(Field::Null);
 
         // eq: UInt
-        test_eq(&uint1, &uint1, &row, None);
+        let mut uint1_clone = uint1.clone();
+        test_eq(&mut uint1, &mut uint1_clone, &row, None);
         if u_num1 == u_num2 && u_num1 as i64 == i_num1 && u_num1 as f64 == f_num1 && Decimal::from(u_num1) == d_num1.0 {
-            test_eq(&uint1, &uint2, &row, None);
-            test_eq(&uint1, &int1, &row, None);
-            test_eq(&uint1, &float1, &row, None);
-            test_eq(&uint1, &dec1, &row, None);
-            test_eq(&uint1, &null, &row, Some(Field::Null));
+            test_eq(&mut uint1, &mut uint2, &row, None);
+            test_eq(&mut uint1, &mut int1, &row, None);
+            test_eq(&mut uint1, &mut float1, &row, None);
+            test_eq(&mut uint1, &mut dec1, &row, None);
+            test_eq(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&uint1, &uint2, &row, None);
-            test_gte(&uint1, &int1, &row, None);
-            test_gte(&uint1, &float1, &row, None);
-            test_gte(&uint1, &dec1, &row, None);
-            test_gte(&uint1, &null, &row, Some(Field::Null));
+            test_gte(&mut uint1, &mut uint2, &row, None);
+            test_gte(&mut uint1, &mut int1, &row, None);
+            test_gte(&mut uint1, &mut float1, &row, None);
+            test_gte(&mut uint1, &mut dec1, &row, None);
+            test_gte(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&uint1, &uint2, &row, None);
-            test_lte(&uint1, &int1, &row, None);
-            test_lte(&uint1, &float1, &row, None);
-            test_lte(&uint1, &dec1, &row, None);
-            test_lte(&uint1, &null, &row, Some(Field::Null));
+            test_lte(&mut uint1, &mut uint2, &row, None);
+            test_lte(&mut uint1, &mut int1, &row, None);
+            test_lte(&mut uint1, &mut float1, &row, None);
+            test_lte(&mut uint1, &mut dec1, &row, None);
+            test_lte(&mut uint1, &mut null, &row, Some(Field::Null));
         }
 
         // eq: Int
-        test_eq(&int1, &int1, &row, None);
+        let mut int1_clone = int1.clone();
+        test_eq(&mut int1, &mut int1_clone, &row, None);
         if i_num1 == u_num1 as i64 && i_num1 == i_num2 && i_num1 as f64 == f_num1 && Decimal::from(i_num1) == d_num1.0 {
-            test_eq(&int1, &uint1, &row, None);
-            test_eq(&int1, &int2, &row, None);
-            test_eq(&int1, &float1, &row, None);
-            test_eq(&int1, &dec1, &row, None);
-            test_eq(&int1, &null, &row, Some(Field::Null));
+            test_eq(&mut int1, &mut uint1, &row, None);
+            test_eq(&mut int1, &mut int2, &row, None);
+            test_eq(&mut int1, &mut float1, &row, None);
+            test_eq(&mut int1, &mut dec1, &row, None);
+            test_eq(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&int1, &uint1, &row, None);
-            test_gte(&int1, &int2, &row, None);
-            test_gte(&int1, &float1, &row, None);
-            test_gte(&int1, &dec1, &row, None);
-            test_gte(&int1, &null, &row, Some(Field::Null));
+            test_gte(&mut int1, &mut uint1, &row, None);
+            test_gte(&mut int1, &mut int2, &row, None);
+            test_gte(&mut int1, &mut float1, &row, None);
+            test_gte(&mut int1, &mut dec1, &row, None);
+            test_gte(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&int1, &uint1, &row, None);
-            test_lte(&int1, &int2, &row, None);
-            test_lte(&int1, &float1, &row, None);
-            test_lte(&int1, &dec1, &row, None);
-            test_lte(&int1, &null, &row, Some(Field::Null));
+            test_lte(&mut int1, &mut uint1, &row, None);
+            test_lte(&mut int1, &mut int2, &row, None);
+            test_lte(&mut int1, &mut float1, &row, None);
+            test_lte(&mut int1, &mut dec1, &row, None);
+            test_lte(&mut int1, &mut null, &row, Some(Field::Null));
         }
 
         // eq: Float
-        test_eq(&float1, &float1, &row, None);
+        let mut float1_clone = float1.clone();
+        test_eq(&mut float1, &mut float1_clone, &row, None);
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && f_num1 == u_num1 as f64 && f_num1 == i_num1 as f64 && f_num1 == f_num2 && d_val.unwrap() == d_num1.0 {
-            test_eq(&float1, &uint1, &row, None);
-            test_eq(&float1, &int1, &row, None);
-            test_eq(&float1, &float2, &row, None);
-            test_eq(&float1, &dec1, &row, None);
-            test_eq(&float1, &null, &row, Some(Field::Null));
+            test_eq(&mut float1, &mut uint1, &row, None);
+            test_eq(&mut float1, &mut int1, &row, None);
+            test_eq(&mut float1, &mut float2, &row, None);
+            test_eq(&mut float1, &mut dec1, &row, None);
+            test_eq(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&float1, &uint1, &row, None);
-            test_gte(&float1, &int1, &row, None);
-            test_gte(&float1, &float2, &row, None);
-            test_gte(&float1, &dec1, &row, None);
-            test_gte(&float1, &null, &row, Some(Field::Null));
+            test_gte(&mut float1, &mut uint1, &row, None);
+            test_gte(&mut float1, &mut int1, &row, None);
+            test_gte(&mut float1, &mut float2, &row, None);
+            test_gte(&mut float1, &mut dec1, &row, None);
+            test_gte(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&float1, &uint1, &row, None);
-            test_lte(&float1, &int1, &row, None);
-            test_lte(&float1, &float2, &row, None);
-            test_lte(&float1, &dec1, &row, None);
-            test_lte(&float1, &null, &row, Some(Field::Null));
+            test_lte(&mut float1, &mut uint1, &row, None);
+            test_lte(&mut float1, &mut int1, &row, None);
+            test_lte(&mut float1, &mut float2, &row, None);
+            test_lte(&mut float1, &mut dec1, &row, None);
+            test_lte(&mut float1, &mut null, &row, Some(Field::Null));
         }
 
         // eq: Decimal
-        test_eq(&dec1, &dec1, &row, None);
+        let mut dec1_clone = dec1.clone();
+        test_eq(&mut dec1, &mut dec1_clone, &row, None);
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && d_num1.0 == Decimal::from(u_num1) && d_num1.0 == Decimal::from(i_num1) && d_num1.0 == d_val.unwrap() && d_num1.0 == d_num2.0 {
-            test_eq(&dec1, &uint1, &row, None);
-            test_eq(&dec1, &int1, &row, None);
-            test_eq(&dec1, &float1, &row, None);
-            test_eq(&dec1, &dec2, &row, None);
-            test_eq(&dec1, &null, &row, Some(Field::Null));
+            test_eq(&mut dec1, &mut uint1, &row, None);
+            test_eq(&mut dec1, &mut int1, &row, None);
+            test_eq(&mut dec1, &mut float1, &row, None);
+            test_eq(&mut dec1, &mut dec2, &row, None);
+            test_eq(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&dec1, &uint1, &row, None);
-            test_gte(&dec1, &int1, &row, None);
-            test_gte(&dec1, &float1, &row, None);
-            test_gte(&dec1, &dec2, &row, None);
-            test_gte(&dec1, &null, &row, Some(Field::Null));
+            test_gte(&mut dec1, &mut uint1, &row, None);
+            test_gte(&mut dec1, &mut int1, &row, None);
+            test_gte(&mut dec1, &mut float1, &row, None);
+            test_gte(&mut dec1, &mut dec2, &row, None);
+            test_gte(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&dec1, &uint1, &row, None);
-            test_lte(&dec1, &int1, &row, None);
-            test_lte(&dec1, &float1, &row, None);
-            test_lte(&dec1, &dec2, &row, None);
-            test_lte(&dec1, &null, &row, Some(Field::Null));
+            test_lte(&mut dec1, &mut uint1, &row, None);
+            test_lte(&mut dec1, &mut int1, &row, None);
+            test_lte(&mut dec1, &mut float1, &row, None);
+            test_lte(&mut dec1, &mut dec2, &row, None);
+            test_lte(&mut dec1, &mut null, &row, Some(Field::Null));
         }
 
         // eq: Null
-        test_eq(&null, &uint2, &row, Some(Field::Null));
-        test_eq(&null, &int2, &row, Some(Field::Null));
-        test_eq(&null, &float2, &row, Some(Field::Null));
-        test_eq(&null, &dec2, &row, Some(Field::Null));
-        test_eq(&null, &null, &row, Some(Field::Null));
+        test_eq(&mut null, &mut uint2, &row, Some(Field::Null));
+        test_eq(&mut null, &mut int2, &row, Some(Field::Null));
+        test_eq(&mut null, &mut float2, &row, Some(Field::Null));
+        test_eq(&mut null, &mut dec2, &row, Some(Field::Null));
+        let mut null_clone = null.clone();
+        test_eq(&mut null, &mut null_clone, &row, Some(Field::Null));
 
         // not eq: UInt
         if u_num1 != u_num2 && u_num1 as i64 != i_num1 && u_num1 as f64 != f_num1 && Decimal::from(u_num1) != d_num1.0 {
-            test_eq(&uint1, &uint2, &row, Some(Field::Boolean(false)));
-            test_eq(&uint1, &int1, &row, Some(Field::Boolean(false)));
-            test_eq(&uint1, &float1, &row, Some(Field::Boolean(false)));
-            test_eq(&uint1, &dec1, &row, Some(Field::Boolean(false)));
-            test_eq(&uint1, &null, &row, Some(Field::Null));
+            test_eq(&mut uint1, &mut uint2, &row, Some(Field::Boolean(false)));
+            test_eq(&mut uint1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut uint1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut uint1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_ne(&uint1, &uint2, &row, None);
-            test_ne(&uint1, &int1, &row, None);
-            test_ne(&uint1, &float1, &row, None);
-            test_ne(&uint1, &dec1, &row, None);
-            test_ne(&uint1, &null, &row, Some(Field::Null));
+            test_ne(&mut uint1, &mut uint2, &row, None);
+            test_ne(&mut uint1, &mut int1, &row, None);
+            test_ne(&mut uint1, &mut float1, &row, None);
+            test_ne(&mut uint1, &mut dec1, &row, None);
+            test_ne(&mut uint1, &mut null, &row, Some(Field::Null));
         }
 
         // not eq: Int
         if i_num1 != u_num1 as i64 && i_num1 != i_num2 && i_num1 as f64 != f_num1 && Decimal::from(i_num1) != d_num1.0 {
-            test_eq(&int1, &uint1, &row, Some(Field::Boolean(false)));
-            test_eq(&int1, &int2, &row, Some(Field::Boolean(false)));
-            test_eq(&int1, &float1, &row, Some(Field::Boolean(false)));
-            test_eq(&int1, &dec1, &row, Some(Field::Boolean(false)));
-            test_eq(&int1, &null, &row, Some(Field::Null));
+            test_eq(&mut int1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut int1, &mut int2, &row, Some(Field::Boolean(false)));
+            test_eq(&mut int1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut int1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_ne(&int1, &uint1, &row, None);
-            test_ne(&int1, &int2, &row, None);
-            test_ne(&int1, &float1, &row, None);
-            test_ne(&int1, &dec1, &row, None);
-            test_ne(&int1, &null, &row, Some(Field::Null));
+            test_ne(&mut int1, &mut uint1, &row, None);
+            test_ne(&mut int1, &mut int2, &row, None);
+            test_ne(&mut int1, &mut float1, &row, None);
+            test_ne(&mut int1, &mut dec1, &row, None);
+            test_ne(&mut int1, &mut null, &row, Some(Field::Null));
         }
 
         // not eq: Float
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && f_num1 != u_num1 as f64 && f_num1 != i_num1 as f64 && f_num1 != f_num2 && d_val.unwrap() != d_num1.0 {
-            test_eq(&float1, &uint1, &row, Some(Field::Boolean(false)));
-            test_eq(&float1, &int1, &row, Some(Field::Boolean(false)));
-            test_eq(&float1, &float2, &row, Some(Field::Boolean(false)));
-            test_eq(&float1, &dec1, &row, Some(Field::Boolean(false)));
-            test_eq(&float1, &null, &row, Some(Field::Null));
+            test_eq(&mut float1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut float1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut float1, &mut float2, &row, Some(Field::Boolean(false)));
+            test_eq(&mut float1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_ne(&float1, &uint1, &row, None);
-            test_ne(&float1, &int1, &row, None);
-            test_ne(&float1, &float2, &row, None);
-            test_ne(&float1, &dec1, &row, None);
-            test_ne(&float1, &null, &row, Some(Field::Null));
+            test_ne(&mut float1, &mut uint1, &row, None);
+            test_ne(&mut float1, &mut int1, &row, None);
+            test_ne(&mut float1, &mut float2, &row, None);
+            test_ne(&mut float1, &mut dec1, &row, None);
+            test_ne(&mut float1, &mut null, &row, Some(Field::Null));
         }
 
         // not eq: Decimal
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && d_num1.0 != Decimal::from(u_num1) && d_num1.0 != Decimal::from(i_num1) && d_num1.0 != d_val.unwrap() && d_num1.0 != d_num2.0 {
-            test_eq(&dec1, &uint1, &row, Some(Field::Boolean(false)));
-            test_eq(&dec1, &int1, &row, Some(Field::Boolean(false)));
-            test_eq(&dec1, &float1, &row, Some(Field::Boolean(false)));
-            test_eq(&dec1, &dec2, &row, Some(Field::Boolean(false)));
-            test_eq(&dec1, &null, &row, Some(Field::Null));
+            test_eq(&mut dec1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut dec1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut dec1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_eq(&mut dec1, &mut dec2, &row, Some(Field::Boolean(false)));
+            test_eq(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_ne(&dec1, &uint1, &row, None);
-            test_ne(&dec1, &int1, &row, None);
-            test_ne(&dec1, &float1, &row, None);
-            test_ne(&dec1, &dec2, &row, None);
-            test_ne(&dec1, &null, &row, Some(Field::Null));
+            test_ne(&mut dec1, &mut uint1, &row, None);
+            test_ne(&mut dec1, &mut int1, &row, None);
+            test_ne(&mut dec1, &mut float1, &row, None);
+            test_ne(&mut dec1, &mut dec2, &row, None);
+            test_ne(&mut dec1, &mut null, &row, Some(Field::Null));
         }
 
         // not eq: Null
-        test_eq(&null, &uint2, &row, Some(Field::Null));
-        test_eq(&null, &int2, &row, Some(Field::Null));
-        test_eq(&null, &float2, &row, Some(Field::Null));
-        test_eq(&null, &dec2, &row, Some(Field::Null));
+        test_eq(&mut null, &mut uint2, &row, Some(Field::Null));
+        test_eq(&mut null, &mut int2, &row, Some(Field::Null));
+        test_eq(&mut null, &mut float2, &row, Some(Field::Null));
+        test_eq(&mut null, &mut dec2, &row, Some(Field::Null));
 
-        test_ne(&null, &uint2, &row, Some(Field::Null));
-        test_ne(&null, &int2, &row, Some(Field::Null));
-        test_ne(&null, &float2, &row, Some(Field::Null));
-        test_ne(&null, &dec2, &row, Some(Field::Null));
+        test_ne(&mut null, &mut uint2, &row, Some(Field::Null));
+        test_ne(&mut null, &mut int2, &row, Some(Field::Null));
+        test_ne(&mut null, &mut float2, &row, Some(Field::Null));
+        test_ne(&mut null, &mut dec2, &row, Some(Field::Null));
 
         // gt: UInt
         if u_num1 > u_num2 && u_num1 as i64 > i_num1 && u_num1 as f64 > f_num1 && Decimal::from(u_num1) > d_num1.0 {
-            test_gt(&uint1, &uint2, &row, None);
-            test_gt(&uint1, &int1, &row, None);
-            test_gt(&uint1, &float1, &row, None);
-            test_gt(&uint1, &dec1, &row, None);
-            test_gt(&uint1, &null, &row, Some(Field::Null));
+            test_gt(&mut uint1, &mut uint2, &row, None);
+            test_gt(&mut uint1, &mut int1, &row, None);
+            test_gt(&mut uint1, &mut float1, &row, None);
+            test_gt(&mut uint1, &mut dec1, &row, None);
+            test_gt(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&uint1, &uint2, &row, None);
-            test_gte(&uint1, &int1, &row, None);
-            test_gte(&uint1, &float1, &row, None);
-            test_gte(&uint1, &dec1, &row, None);
-            test_gte(&uint1, &null, &row, Some(Field::Null));
+            test_gte(&mut uint1, &mut uint2, &row, None);
+            test_gte(&mut uint1, &mut int1, &row, None);
+            test_gte(&mut uint1, &mut float1, &row, None);
+            test_gte(&mut uint1, &mut dec1, &row, None);
+            test_gte(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_lt(&uint1, &uint2, &row, Some(Field::Boolean(false)));
-            test_lt(&uint1, &int1, &row, Some(Field::Boolean(false)));
-            test_lt(&uint1, &float1, &row, Some(Field::Boolean(false)));
-            test_lt(&uint1, &dec1, &row, Some(Field::Boolean(false)));
-            test_lt(&uint1, &null, &row, Some(Field::Null));
+            test_lt(&mut uint1, &mut uint2, &row, Some(Field::Boolean(false)));
+            test_lt(&mut uint1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut uint1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut uint1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&uint1, &uint2, &row, Some(Field::Boolean(false)));
-            test_lte(&uint1, &int1, &row, Some(Field::Boolean(false)));
-            test_lte(&uint1, &float1, &row, Some(Field::Boolean(false)));
-            test_lte(&uint1, &dec1, &row, Some(Field::Boolean(false)));
-            test_lte(&uint1, &null, &row, Some(Field::Null));
+            test_lte(&mut uint1, &mut uint2, &row, Some(Field::Boolean(false)));
+            test_lte(&mut uint1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut uint1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut uint1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut uint1, &mut null, &row, Some(Field::Null));
         }
 
         // gt: Int
         if i_num1 > u_num1 as i64 && i_num1 > i_num2 && i_num1 as f64 > f_num1 && Decimal::from(i_num1) > d_num1.0 {
-            test_gt(&int1, &uint1, &row, None);
-            test_gt(&int1, &int2, &row, None);
-            test_gt(&int1, &float1, &row, None);
-            test_gt(&int1, &dec1, &row, None);
-            test_gt(&int1, &null, &row, Some(Field::Null));
+            test_gt(&mut int1, &mut uint1, &row, None);
+            test_gt(&mut int1, &mut int2, &row, None);
+            test_gt(&mut int1, &mut float1, &row, None);
+            test_gt(&mut int1, &mut dec1, &row, None);
+            test_gt(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&int1, &uint1, &row, None);
-            test_gte(&int1, &int2, &row, None);
-            test_gte(&int1, &float1, &row, None);
-            test_gte(&int1, &dec1, &row, None);
-            test_gte(&int1, &null, &row, Some(Field::Null));
+            test_gte(&mut int1, &mut uint1, &row, None);
+            test_gte(&mut int1, &mut int2, &row, None);
+            test_gte(&mut int1, &mut float1, &row, None);
+            test_gte(&mut int1, &mut dec1, &row, None);
+            test_gte(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_lt(&int1, &uint1, &row, Some(Field::Boolean(false)));
-            test_lt(&int1, &int2, &row, Some(Field::Boolean(false)));
-            test_lt(&int1, &float1, &row, Some(Field::Boolean(false)));
-            test_lt(&int1, &dec1, &row, Some(Field::Boolean(false)));
-            test_lt(&int1, &null, &row, Some(Field::Null));
+            test_lt(&mut int1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut int1, &mut int2, &row, Some(Field::Boolean(false)));
+            test_lt(&mut int1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut int1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&int1, &uint1, &row, Some(Field::Boolean(false)));
-            test_lte(&int1, &int2, &row, Some(Field::Boolean(false)));
-            test_lte(&int1, &float1, &row, Some(Field::Boolean(false)));
-            test_lte(&int1, &dec1, &row, Some(Field::Boolean(false)));
-            test_lte(&int1, &null, &row, Some(Field::Null));
+            test_lte(&mut int1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut int1, &mut int2, &row, Some(Field::Boolean(false)));
+            test_lte(&mut int1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut int1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut int1, &mut null, &row, Some(Field::Null));
         }
 
         // gt: Float
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && f_num1 > u_num1 as f64 && f_num1 > i_num1 as f64 && f_num1 > f_num2 && d_val.unwrap() > d_num1.0 {
-            test_gt(&float1, &uint1, &row, None);
-            test_gt(&float1, &int1, &row, None);
-            test_gt(&float1, &float2, &row, None);
-            test_gt(&float1, &dec1, &row, None);
-            test_gt(&float1, &null, &row, Some(Field::Null));
+            test_gt(&mut float1, &mut uint1, &row, None);
+            test_gt(&mut float1, &mut int1, &row, None);
+            test_gt(&mut float1, &mut float2, &row, None);
+            test_gt(&mut float1, &mut dec1, &row, None);
+            test_gt(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&float1, &uint1, &row, None);
-            test_gte(&float1, &int1, &row, None);
-            test_gte(&float1, &float2, &row, None);
-            test_gte(&float1, &dec1, &row, None);
-            test_gte(&float1, &null, &row, Some(Field::Null));
+            test_gte(&mut float1, &mut uint1, &row, None);
+            test_gte(&mut float1, &mut int1, &row, None);
+            test_gte(&mut float1, &mut float2, &row, None);
+            test_gte(&mut float1, &mut dec1, &row, None);
+            test_gte(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_lt(&float1, &uint1, &row, Some(Field::Boolean(false)));
-            test_lt(&float1, &int1, &row, Some(Field::Boolean(false)));
-            test_lt(&float1, &float2, &row, Some(Field::Boolean(false)));
-            test_lt(&float1, &dec1, &row, Some(Field::Boolean(false)));
-            test_lt(&float1, &null, &row, Some(Field::Null));
+            test_lt(&mut float1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut float1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut float1, &mut float2, &row, Some(Field::Boolean(false)));
+            test_lt(&mut float1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&float1, &uint1, &row, Some(Field::Boolean(false)));
-            test_lte(&float1, &int1, &row, Some(Field::Boolean(false)));
-            test_lte(&float1, &float2, &row, Some(Field::Boolean(false)));
-            test_lte(&float1, &dec1, &row, Some(Field::Boolean(false)));
-            test_lte(&float1, &null, &row, Some(Field::Null));
+            test_lte(&mut float1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut float1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut float1, &mut float2, &row, Some(Field::Boolean(false)));
+            test_lte(&mut float1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut float1, &mut null, &row, Some(Field::Null));
         }
 
         // gt: Decimal
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && d_num1.0 > Decimal::from(u_num1) && d_num1.0 > Decimal::from(i_num1) && d_num1.0 > d_val.unwrap() && d_num1.0 > d_num2.0 {
-            test_gt(&dec1, &uint1, &row, None);
-            test_gt(&dec1, &int1, &row, None);
-            test_gt(&dec1, &float1, &row, None);
-            test_gt(&dec1, &dec2, &row, None);
-            test_gt(&dec1, &null, &row, Some(Field::Null));
+            test_gt(&mut dec1, &mut uint1, &row, None);
+            test_gt(&mut dec1, &mut int1, &row, None);
+            test_gt(&mut dec1, &mut float1, &row, None);
+            test_gt(&mut dec1, &mut dec2, &row, None);
+            test_gt(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&dec1, &uint1, &row, None);
-            test_gte(&dec1, &int1, &row, None);
-            test_gte(&dec1, &float1, &row, None);
-            test_gte(&dec1, &dec2, &row, None);
-            test_gte(&dec1, &null, &row, Some(Field::Null));
+            test_gte(&mut dec1, &mut uint1, &row, None);
+            test_gte(&mut dec1, &mut int1, &row, None);
+            test_gte(&mut dec1, &mut float1, &row, None);
+            test_gte(&mut dec1, &mut dec2, &row, None);
+            test_gte(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_lt(&dec1, &uint1, &row, Some(Field::Boolean(false)));
-            test_lt(&dec1, &int1, &row, Some(Field::Boolean(false)));
-            test_lt(&dec1, &float1, &row, Some(Field::Boolean(false)));
-            test_lt(&dec1, &dec2, &row, Some(Field::Boolean(false)));
-            test_lt(&dec1, &null, &row, Some(Field::Null));
+            test_lt(&mut dec1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut dec1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut dec1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut dec1, &mut dec2, &row, Some(Field::Boolean(false)));
+            test_lt(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&dec1, &uint1, &row, Some(Field::Boolean(false)));
-            test_lte(&dec1, &int1, &row, Some(Field::Boolean(false)));
-            test_lt(&dec1, &float1, &row, Some(Field::Boolean(false)));
-            test_lte(&dec1, &dec2, &row, Some(Field::Boolean(false)));
-            test_lte(&dec1, &null, &row, Some(Field::Null));
+            test_lte(&mut dec1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut dec1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_lt(&mut dec1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_lte(&mut dec1, &mut dec2, &row, Some(Field::Boolean(false)));
+            test_lte(&mut dec1, &mut null, &row, Some(Field::Null));
         }
 
         // lt: UInt
         if u_num1 < u_num2 && (u_num1 as i64) < i_num1 && (u_num1 as f64) < f_num1 && Decimal::from(u_num1) < d_num1.0 {
-            test_lt(&uint1, &uint2, &row, None);
-            test_lt(&uint1, &int1, &row, None);
-            test_lt(&uint1, &float1, &row, None);
-            test_lt(&uint1, &dec1, &row, None);
-            test_lt(&uint1, &null, &row, Some(Field::Null));
+            test_lt(&mut uint1, &mut uint2, &row, None);
+            test_lt(&mut uint1, &mut int1, &row, None);
+            test_lt(&mut uint1, &mut float1, &row, None);
+            test_lt(&mut uint1, &mut dec1, &row, None);
+            test_lt(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&uint1, &uint2, &row, None);
-            test_lte(&uint1, &int1, &row, None);
-            test_lte(&uint1, &float1, &row, None);
-            test_lte(&uint1, &dec1, &row, None);
-            test_lte(&uint1, &null, &row, Some(Field::Null));
+            test_lte(&mut uint1, &mut uint2, &row, None);
+            test_lte(&mut uint1, &mut int1, &row, None);
+            test_lte(&mut uint1, &mut float1, &row, None);
+            test_lte(&mut uint1, &mut dec1, &row, None);
+            test_lte(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_gt(&uint1, &uint2, &row, Some(Field::Boolean(false)));
-            test_gt(&uint1, &int1, &row, Some(Field::Boolean(false)));
-            test_gt(&uint1, &float1, &row, Some(Field::Boolean(false)));
-            test_gt(&uint1, &dec1, &row, Some(Field::Boolean(false)));
-            test_gt(&uint1, &null, &row, Some(Field::Null));
+            test_gt(&mut uint1, &mut uint2, &row, Some(Field::Boolean(false)));
+            test_gt(&mut uint1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut uint1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut uint1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut uint1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&uint1, &uint2, &row, Some(Field::Boolean(false)));
-            test_gte(&uint1, &int1, &row, Some(Field::Boolean(false)));
-            test_gte(&uint1, &float1, &row, Some(Field::Boolean(false)));
-            test_gte(&uint1, &dec1, &row, Some(Field::Boolean(false)));
-            test_gte(&uint1, &null, &row, Some(Field::Null));
+            test_gte(&mut uint1, &mut uint2, &row, Some(Field::Boolean(false)));
+            test_gte(&mut uint1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut uint1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut uint1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut uint1, &mut null, &row, Some(Field::Null));
         }
 
         // gt: Int
         if i_num1 < (u_num1 as i64) && i_num1 < i_num2 && (i_num1 as f64) < f_num1 && Decimal::from(i_num1) < d_num1.0 {
-            test_lt(&int1, &uint1, &row, None);
-            test_lt(&int1, &int2, &row, None);
-            test_lt(&int1, &float1, &row, None);
-            test_lt(&int1, &dec1, &row, None);
-            test_lt(&int1, &null, &row, Some(Field::Null));
+            test_lt(&mut int1, &mut uint1, &row, None);
+            test_lt(&mut int1, &mut int2, &row, None);
+            test_lt(&mut int1, &mut float1, &row, None);
+            test_lt(&mut int1, &mut dec1, &row, None);
+            test_lt(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&int1, &uint1, &row, None);
-            test_lte(&int1, &int2, &row, None);
-            test_lte(&int1, &float1, &row, None);
-            test_lte(&int1, &dec1, &row, None);
-            test_lte(&int1, &null, &row, Some(Field::Null));
+            test_lte(&mut int1, &mut uint1, &row, None);
+            test_lte(&mut int1, &mut int2, &row, None);
+            test_lte(&mut int1, &mut float1, &row, None);
+            test_lte(&mut int1, &mut dec1, &row, None);
+            test_lte(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_gt(&int1, &uint1, &row, Some(Field::Boolean(false)));
-            test_gt(&int1, &int2, &row, Some(Field::Boolean(false)));
-            test_gt(&int1, &float1, &row, Some(Field::Boolean(false)));
-            test_gt(&int1, &dec1, &row, Some(Field::Boolean(false)));
-            test_gt(&int1, &null, &row, Some(Field::Null));
+            test_gt(&mut int1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut int1, &mut int2, &row, Some(Field::Boolean(false)));
+            test_gt(&mut int1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut int1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut int1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&int1, &uint1, &row, Some(Field::Boolean(false)));
-            test_gte(&int1, &int2, &row, Some(Field::Boolean(false)));
-            test_gte(&int1, &float1, &row, Some(Field::Boolean(false)));
-            test_gte(&int1, &dec1, &row, Some(Field::Boolean(false)));
-            test_gte(&int1, &null, &row, Some(Field::Null));
+            test_gte(&mut int1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut int1, &mut int2, &row, Some(Field::Boolean(false)));
+            test_gte(&mut int1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut int1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut int1, &mut null, &row, Some(Field::Null));
         }
 
         // gt: Float
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && f_num1 < u_num1 as f64 && f_num1 < i_num1 as f64 && f_num1 < f_num2 && d_val.unwrap() < d_num1.0 {
-            test_lt(&float1, &uint1, &row, None);
-            test_lt(&float1, &int1, &row, None);
-            test_lt(&float1, &float2, &row, None);
-            test_lt(&float1, &dec1, &row, None);
-            test_lt(&float1, &null, &row, Some(Field::Null));
+            test_lt(&mut float1, &mut uint1, &row, None);
+            test_lt(&mut float1, &mut int1, &row, None);
+            test_lt(&mut float1, &mut float2, &row, None);
+            test_lt(&mut float1, &mut dec1, &row, None);
+            test_lt(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&float1, &uint1, &row, None);
-            test_lte(&float1, &int1, &row, None);
-            test_lte(&float1, &float2, &row, None);
-            test_lte(&float1, &dec1, &row, None);
-            test_lte(&float1, &null, &row, Some(Field::Null));
+            test_lte(&mut float1, &mut uint1, &row, None);
+            test_lte(&mut float1, &mut int1, &row, None);
+            test_lte(&mut float1, &mut float2, &row, None);
+            test_lte(&mut float1, &mut dec1, &row, None);
+            test_lte(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_gt(&float1, &uint1, &row, Some(Field::Boolean(false)));
-            test_gt(&float1, &int1, &row, Some(Field::Boolean(false)));
-            test_gt(&float1, &float2, &row, Some(Field::Boolean(false)));
-            test_gt(&float1, &dec1, &row, Some(Field::Boolean(false)));
-            test_gt(&float1, &null, &row, Some(Field::Null));
+            test_gt(&mut float1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut float1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut float1, &mut float2, &row, Some(Field::Boolean(false)));
+            test_gt(&mut float1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut float1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&float1, &uint1, &row, Some(Field::Boolean(false)));
-            test_gte(&float1, &int1, &row, Some(Field::Boolean(false)));
-            test_gte(&float1, &float2, &row, Some(Field::Boolean(false)));
-            test_gte(&float1, &dec1, &row, Some(Field::Boolean(false)));
-            test_gte(&float1, &null, &row, Some(Field::Null));
+            test_gte(&mut float1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut float1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut float1, &mut float2, &row, Some(Field::Boolean(false)));
+            test_gte(&mut float1, &mut dec1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut float1, &mut null, &row, Some(Field::Null));
         }
 
         // gt: Decimal
         let d_val = Decimal::from_f64(f_num1);
         if d_val.is_some() && d_num1.0 < Decimal::from(u_num1) && d_num1.0 < Decimal::from(i_num1) && d_num1.0 < d_val.unwrap() && d_num1.0 < d_num2.0 {
-            test_lt(&dec1, &uint1, &row, None);
-            test_lt(&dec1, &int1, &row, None);
-            test_lt(&dec1, &float1, &row, None);
-            test_lt(&dec1, &dec2, &row, None);
-            test_lt(&dec1, &null, &row, Some(Field::Null));
+            test_lt(&mut dec1, &mut uint1, &row, None);
+            test_lt(&mut dec1, &mut int1, &row, None);
+            test_lt(&mut dec1, &mut float1, &row, None);
+            test_lt(&mut dec1, &mut dec2, &row, None);
+            test_lt(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_lte(&dec1, &uint1, &row, None);
-            test_lte(&dec1, &int1, &row, None);
-            test_lte(&dec1, &float1, &row, None);
-            test_lte(&dec1, &dec2, &row, None);
-            test_lte(&dec1, &null, &row, Some(Field::Null));
+            test_lte(&mut dec1, &mut uint1, &row, None);
+            test_lte(&mut dec1, &mut int1, &row, None);
+            test_lte(&mut dec1, &mut float1, &row, None);
+            test_lte(&mut dec1, &mut dec2, &row, None);
+            test_lte(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_gt(&dec1, &uint1, &row, Some(Field::Boolean(false)));
-            test_gt(&dec1, &int1, &row, Some(Field::Boolean(false)));
-            test_gt(&dec1, &float1, &row, Some(Field::Boolean(false)));
-            test_gt(&dec1, &dec2, &row, Some(Field::Boolean(false)));
-            test_gt(&dec1, &null, &row, Some(Field::Null));
+            test_gt(&mut dec1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut dec1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut dec1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_gt(&mut dec1, &mut dec2, &row, Some(Field::Boolean(false)));
+            test_gt(&mut dec1, &mut null, &row, Some(Field::Null));
 
-            test_gte(&dec1, &uint1, &row, Some(Field::Boolean(false)));
-            test_gte(&dec1, &int1, &row, Some(Field::Boolean(false)));
-            test_gte(&dec1, &float1, &row, Some(Field::Boolean(false)));
-            test_gte(&dec1, &dec2, &row, Some(Field::Boolean(false)));
-            test_gte(&dec1, &null, &row, Some(Field::Null));
+            test_gte(&mut dec1, &mut uint1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut dec1, &mut int1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut dec1, &mut float1, &row, Some(Field::Boolean(false)));
+            test_gte(&mut dec1, &mut dec2, &row, Some(Field::Boolean(false)));
+            test_gte(&mut dec1, &mut null, &row, Some(Field::Null));
         }
     });
 }
 
-fn test_eq(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Field>) {
+fn test_eq(exp1: &mut Expression, exp2: &mut Expression, row: &Record, result: Option<Field>) {
     match result {
         None => {
             assert!(matches!(
@@ -432,7 +437,7 @@ fn test_eq(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     }
 }
 
-fn test_ne(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Field>) {
+fn test_ne(exp1: &mut Expression, exp2: &mut Expression, row: &Record, result: Option<Field>) {
     match result {
         None => {
             assert!(matches!(
@@ -449,7 +454,7 @@ fn test_ne(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     }
 }
 
-fn test_gt(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Field>) {
+fn test_gt(exp1: &mut Expression, exp2: &mut Expression, row: &Record, result: Option<Field>) {
     match result {
         None => {
             assert!(matches!(
@@ -466,7 +471,7 @@ fn test_gt(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     }
 }
 
-fn test_lt(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Field>) {
+fn test_lt(exp1: &mut Expression, exp2: &mut Expression, row: &Record, result: Option<Field>) {
     match result {
         None => {
             assert!(matches!(
@@ -483,7 +488,7 @@ fn test_lt(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Fi
     }
 }
 
-fn test_gte(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Field>) {
+fn test_gte(exp1: &mut Expression, exp2: &mut Expression, row: &Record, result: Option<Field>) {
     match result {
         None => {
             assert!(matches!(
@@ -500,7 +505,7 @@ fn test_gte(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<F
     }
 }
 
-fn test_lte(exp1: &Expression, exp2: &Expression, row: &Record, result: Option<Field>) {
+fn test_lte(exp1: &mut Expression, exp2: &mut Expression, row: &Record, result: Option<Field>) {
     match result {
         None => {
             assert!(matches!(

--- a/dozer-sql/expression/src/conditional.rs
+++ b/dozer-sql/expression/src/conditional.rs
@@ -33,7 +33,7 @@ impl ConditionalExpressionType {
     pub(crate) fn evaluate(
         &self,
         schema: &Schema,
-        args: &[Expression],
+        args: &mut [Expression],
         record: &Record,
     ) -> Result<Field, Error> {
         match self {
@@ -67,7 +67,7 @@ pub(crate) fn validate_coalesce(
 
 pub(crate) fn evaluate_coalesce(
     schema: &Schema,
-    args: &[Expression],
+    args: &mut [Expression],
     record: &Record,
 ) -> Result<Field, Error> {
     // The COALESCE function returns the first of its arguments that is not null.
@@ -130,181 +130,181 @@ mod tests {
             let f = Field::UInt(u_num1);
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), uint1.clone()];
+            let mut args = vec![null.clone(), uint1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), uint1.clone()];
+            let mut args = vec![null.clone(), null.clone(), uint1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), uint1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), uint1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), uint1, uint2];
+            let mut args = vec![null.clone(), null.clone(), uint1, uint2];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // Int
             let typ = FieldType::Int;
             let f = Field::Int(i_num1);
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), int1.clone()];
+            let mut args = vec![null.clone(), int1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), int1.clone()];
+            let mut args = vec![null.clone(), null.clone(), int1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), int1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), int1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), int1, int2];
+            let mut args = vec![null.clone(), null.clone(), int1, int2];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // Float
             let typ = FieldType::Float;
             let f = Field::Float(OrderedFloat(f_num1));
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), float1.clone()];
+            let mut args = vec![null.clone(), float1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), float1.clone()];
+            let mut args = vec![null.clone(), null.clone(), float1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), float1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), float1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), float1, float2];
+            let mut args = vec![null.clone(), null.clone(), float1, float2];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // Decimal
             let typ = FieldType::Decimal;
             let f = Field::Decimal(d_num1.0);
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), dec1.clone()];
+            let mut args = vec![null.clone(), dec1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), dec1.clone()];
+            let mut args = vec![null.clone(), null.clone(), dec1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), dec1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), dec1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), dec1, dec2];
+            let mut args = vec![null.clone(), null.clone(), dec1, dec2];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // String
             let typ = FieldType::String;
             let f = Field::String(s_val1.clone());
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), str1.clone()];
+            let mut args = vec![null.clone(), str1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), str1.clone()];
+            let mut args = vec![null.clone(), null.clone(), str1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), str1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), str1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), str1.clone(), str2.clone()];
+            let mut args = vec![null.clone(), null.clone(), str1.clone(), str2.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // String
             let typ = FieldType::String;
             let f = Field::String(s_val1);
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), str1.clone()];
+            let mut args = vec![null.clone(), str1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), str1.clone()];
+            let mut args = vec![null.clone(), null.clone(), str1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), str1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), str1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), str1, str2];
+            let mut args = vec![null.clone(), null.clone(), str1, str2];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // Timestamp
             let typ = FieldType::Timestamp;
             let f = Field::Timestamp(dt_val1.0);
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), t1.clone()];
+            let mut args = vec![null.clone(), t1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), t1.clone()];
+            let mut args = vec![null.clone(), null.clone(), t1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), t1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), t1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), t1, t2];
+            let mut args = vec![null.clone(), null.clone(), t1, t2];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // Date
             let typ = FieldType::Date;
             let f = Field::Date(dt_val1.0.date_naive());
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone(), dt1.clone()];
+            let mut args = vec![null.clone(), dt1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), dt1.clone()];
+            let mut args = vec![null.clone(), null.clone(), dt1.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), dt1.clone(), null.clone()];
+            let mut args = vec![null.clone(), null.clone(), dt1.clone(), null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null.clone(), dt1, dt2];
+            let mut args = vec![null.clone(), null.clone(), dt1, dt2];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
 
             // Null
             let typ = FieldType::Date;
             let f = Field::Null;
             let row = Record::new(vec![f.clone()]);
 
-            let args = vec![null.clone()];
+            let mut args = vec![null.clone()];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f.clone());
+            test_evaluate_coalesce(&mut args, &row, typ, f.clone());
 
-            let args = vec![null.clone(), null];
+            let mut args = vec![null.clone(), null];
             test_validate_coalesce(&args, typ);
-            test_evaluate_coalesce(&args, &row, typ, f);
+            test_evaluate_coalesce(&mut args, &row, typ, f);
         });
     }
 
@@ -320,7 +320,12 @@ mod tests {
         assert_eq!(result, typ);
     }
 
-    fn test_evaluate_coalesce(args: &[Expression], row: &Record, typ: FieldType, _result: Field) {
+    fn test_evaluate_coalesce(
+        args: &mut [Expression],
+        row: &Record,
+        typ: FieldType,
+        _result: Field,
+    ) {
         let schema = Schema::default()
             .field(
                 FieldDefinition::new(String::from("field"), typ, false, SourceDefinition::Dynamic),

--- a/dozer-sql/expression/src/datetime.rs
+++ b/dozer-sql/expression/src/datetime.rs
@@ -85,7 +85,7 @@ impl DateTimeFunctionType {
     pub(crate) fn evaluate(
         &self,
         schema: &Schema,
-        arg: &Expression,
+        arg: &mut Expression,
         record: &Record,
     ) -> Result<Field, Error> {
         match self {
@@ -107,7 +107,7 @@ impl DateTimeFunctionType {
 pub(crate) fn evaluate_date_part(
     schema: &Schema,
     field: &sqlparser::ast::DateTimeField,
-    arg: &Expression,
+    arg: &mut Expression,
     record: &Record,
 ) -> Result<Field, Error> {
     let value = arg.evaluate(record, schema)?;
@@ -149,7 +149,7 @@ pub(crate) fn evaluate_date_part(
 pub(crate) fn evaluate_interval(
     schema: &Schema,
     field: &sqlparser::ast::DateTimeField,
-    arg: &Expression,
+    arg: &mut Expression,
     record: &Record,
 ) -> Result<Field, Error> {
     let value = arg.evaluate(record, schema)?;
@@ -240,10 +240,10 @@ mod tests {
             ),
         ];
 
-        let v = Expression::Literal(Field::Date(datetime.0.date_naive()));
+        let mut v = Expression::Literal(Field::Date(datetime.0.date_naive()));
 
         for (part, value) in date_parts {
-            let result = evaluate_date_part(&Schema::default(), &part, &v, &row).unwrap();
+            let result = evaluate_date_part(&Schema::default(), &part, &mut v, &row).unwrap();
             assert_eq!(result, Field::Int(value));
         }
     }

--- a/dozer-sql/expression/src/execution.rs
+++ b/dozer-sql/expression/src/execution.rs
@@ -302,7 +302,7 @@ impl ExpressionType {
 }
 
 impl Expression {
-    pub fn evaluate(&self, record: &Record, schema: &Schema) -> Result<Field, Error> {
+    pub fn evaluate(&mut self, record: &Record, schema: &Schema) -> Result<Field, Error> {
         match self {
             Expression::Literal(field) => Ok(field.clone()),
             Expression::Column { index } => Ok(record.values[*index].clone()),

--- a/dozer-sql/expression/src/geo/common.rs
+++ b/dozer-sql/expression/src/geo/common.rs
@@ -45,7 +45,7 @@ impl GeoFunctionType {
     pub(crate) fn evaluate(
         &self,
         schema: &Schema,
-        args: &[Expression],
+        args: &mut [Expression],
         record: &Record,
     ) -> Result<Field, Error> {
         match self {

--- a/dozer-sql/expression/src/geo/distance.rs
+++ b/dozer-sql/expression/src/geo/distance.rs
@@ -68,7 +68,7 @@ pub(crate) fn validate_distance(
 
 pub(crate) fn evaluate_distance(
     schema: &Schema,
-    args: &[Expression],
+    args: &mut [Expression],
     record: &Record,
 ) -> Result<Field, Error> {
     validate_num_arguments(2..4, args.len(), GeoFunctionType::Distance)?;
@@ -81,7 +81,7 @@ pub(crate) fn evaluate_distance(
     } else {
         let from = extract_point(f_from, GeoFunctionType::Distance, 0)?;
         let to = extract_point(f_to, GeoFunctionType::Distance, 1)?;
-        let calculation_type = args.get(2).map_or_else(
+        let calculation_type = args.get_mut(2).map_or_else(
             || Ok(DEFAULT_ALGORITHM),
             |arg| {
                 let f = arg.evaluate(record, schema)?;
@@ -144,7 +144,7 @@ mod tests {
         row: &Record,
         result: Option<Result<Field, Error>>,
     ) {
-        let args = &vec![Literal(from.clone()), Literal(to.clone())];
+        let args = &mut [Literal(from.clone()), Literal(to.clone())];
         if validate_distance(args, &Schema::default()).is_ok() {
             match result {
                 None => {

--- a/dozer-sql/expression/src/geo/point.rs
+++ b/dozer-sql/expression/src/geo/point.rs
@@ -34,7 +34,7 @@ pub fn validate_point(args: &[Expression], schema: &Schema) -> Result<Expression
 
 pub fn evaluate_point(
     schema: &Schema,
-    args: &[Expression],
+    args: &mut [Expression],
     record: &Record,
 ) -> Result<Field, Error> {
     validate_num_arguments(2..3, args.len(), GeoFunctionType::Point)?;
@@ -182,14 +182,14 @@ mod tests {
             )
             .clone();
 
-        let result = evaluate_point(&schema, &[], &row);
+        let result = evaluate_point(&schema, &mut [], &row);
         assert!(result.is_err());
         assert!(matches!(
             result,
             Err(Error::InvalidNumberOfArguments { .. })
         ));
 
-        let result = evaluate_point(&schema, &[Expression::Literal(Field::Int(x))], &row);
+        let result = evaluate_point(&schema, &mut [Expression::Literal(Field::Int(x))], &row);
         assert!(result.is_err());
         assert!(matches!(
             result,
@@ -198,7 +198,7 @@ mod tests {
 
         let result = evaluate_point(
             &schema,
-            &[
+            &mut [
                 Expression::Literal(Field::Int(x)),
                 Expression::Literal(Field::Int(y)),
             ],
@@ -209,7 +209,7 @@ mod tests {
 
         let result = evaluate_point(
             &schema,
-            &[
+            &mut [
                 Expression::Literal(Field::Int(x)),
                 Expression::Literal(Field::Null),
             ],
@@ -221,7 +221,7 @@ mod tests {
 
         let result = evaluate_point(
             &schema,
-            &[
+            &mut [
                 Expression::Literal(Field::Null),
                 Expression::Literal(Field::Int(y)),
             ],

--- a/dozer-sql/expression/src/in_list.rs
+++ b/dozer-sql/expression/src/in_list.rs
@@ -6,8 +6,8 @@ use crate::execution::Expression;
 
 pub(crate) fn evaluate_in_list(
     schema: &Schema,
-    expr: &Expression,
-    list: &[Expression],
+    expr: &mut Expression,
+    list: &mut [Expression],
     negated: bool,
     record: &Record,
 ) -> Result<Field, Error> {

--- a/dozer-sql/expression/src/json_functions.rs
+++ b/dozer-sql/expression/src/json_functions.rs
@@ -36,7 +36,7 @@ impl JsonFunctionType {
     pub(crate) fn evaluate(
         &self,
         schema: &Schema,
-        args: &Vec<Expression>,
+        args: &mut [Expression],
         record: &Record,
     ) -> Result<Field, Error> {
         match self {
@@ -48,7 +48,7 @@ impl JsonFunctionType {
     pub(crate) fn evaluate_json_value(
         &self,
         schema: &Schema,
-        args: &Vec<Expression>,
+        args: &mut [Expression],
         record: &Record,
     ) -> Result<Field, Error> {
         validate_num_arguments(2..3, args.len(), self)?;
@@ -72,7 +72,7 @@ impl JsonFunctionType {
     pub(crate) fn evaluate_json_query(
         &self,
         schema: &Schema,
-        args: &Vec<Expression>,
+        args: &mut [Expression],
         record: &Record,
     ) -> Result<Field, Error> {
         validate_num_arguments(1..3, args.len(), self)?;

--- a/dozer-sql/expression/src/logical.rs
+++ b/dozer-sql/expression/src/logical.rs
@@ -6,8 +6,8 @@ use crate::execution::Expression;
 
 pub fn evaluate_and(
     schema: &Schema,
-    left: &Expression,
-    right: &Expression,
+    left: &mut Expression,
+    right: &mut Expression,
     record: &Record,
 ) -> Result<Field, Error> {
     let l_field = left.evaluate(record, schema)?;
@@ -71,8 +71,8 @@ pub fn evaluate_and(
 
 pub fn evaluate_or(
     schema: &Schema,
-    left: &Expression,
-    right: &Expression,
+    left: &mut Expression,
+    right: &mut Expression,
     record: &Record,
 ) -> Result<Field, Error> {
     let l_field = left.evaluate(record, schema)?;
@@ -133,7 +133,11 @@ pub fn evaluate_or(
     }
 }
 
-pub fn evaluate_not(schema: &Schema, value: &Expression, record: &Record) -> Result<Field, Error> {
+pub fn evaluate_not(
+    schema: &Schema,
+    value: &mut Expression,
+    record: &Record,
+) -> Result<Field, Error> {
     let value_p = value.evaluate(record, schema)?;
 
     match value_p {
@@ -213,10 +217,10 @@ mod tests {
 
     fn _test_bool_bool_and(bool1: bool, bool2: bool) {
         let row = Record::new(vec![]);
-        let l = Box::new(Literal(Field::Boolean(bool1)));
-        let r = Box::new(Literal(Field::Boolean(bool2)));
+        let mut l = Box::new(Literal(Field::Boolean(bool1)));
+        let mut r = Box::new(Literal(Field::Boolean(bool2)));
         assert!(matches!(
-            evaluate_and(&Schema::default(), &l, &r, &row)
+            evaluate_and(&Schema::default(), &mut l, &mut r, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Boolean(_ans)
         ));
@@ -224,10 +228,10 @@ mod tests {
 
     fn _test_bool_null_and(f1: Field, f2: Field) {
         let row = Record::new(vec![]);
-        let l = Box::new(Literal(f1));
-        let r = Box::new(Literal(f2));
+        let mut l = Box::new(Literal(f1));
+        let mut r = Box::new(Literal(f2));
         assert!(matches!(
-            evaluate_and(&Schema::default(), &l, &r, &row)
+            evaluate_and(&Schema::default(), &mut l, &mut r, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Boolean(false)
         ));
@@ -235,10 +239,10 @@ mod tests {
 
     fn _test_bool_bool_or(bool1: bool, bool2: bool) {
         let row = Record::new(vec![]);
-        let l = Box::new(Literal(Field::Boolean(bool1)));
-        let r = Box::new(Literal(Field::Boolean(bool2)));
+        let mut l = Box::new(Literal(Field::Boolean(bool1)));
+        let mut r = Box::new(Literal(Field::Boolean(bool2)));
         assert!(matches!(
-            evaluate_or(&Schema::default(), &l, &r, &row)
+            evaluate_or(&Schema::default(), &mut l, &mut r, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Boolean(_ans)
         ));
@@ -246,10 +250,10 @@ mod tests {
 
     fn _test_bool_null_or(_bool: bool) {
         let row = Record::new(vec![]);
-        let l = Box::new(Literal(Field::Boolean(_bool)));
-        let r = Box::new(Literal(Field::Null));
+        let mut l = Box::new(Literal(Field::Boolean(_bool)));
+        let mut r = Box::new(Literal(Field::Null));
         assert!(matches!(
-            evaluate_or(&Schema::default(), &l, &r, &row)
+            evaluate_or(&Schema::default(), &mut l, &mut r, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Boolean(_bool)
         ));
@@ -257,10 +261,10 @@ mod tests {
 
     fn _test_null_bool_or(_bool: bool) {
         let row = Record::new(vec![]);
-        let l = Box::new(Literal(Field::Null));
-        let r = Box::new(Literal(Field::Boolean(_bool)));
+        let mut l = Box::new(Literal(Field::Null));
+        let mut r = Box::new(Literal(Field::Boolean(_bool)));
         assert!(matches!(
-            evaluate_or(&Schema::default(), &l, &r, &row)
+            evaluate_or(&Schema::default(), &mut l, &mut r, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Boolean(_bool)
         ));
@@ -268,9 +272,9 @@ mod tests {
 
     fn _test_bool_not(bool: bool) {
         let row = Record::new(vec![]);
-        let v = Box::new(Literal(Field::Boolean(bool)));
+        let mut v = Box::new(Literal(Field::Boolean(bool)));
         assert!(matches!(
-            evaluate_not(&Schema::default(), &v, &row)
+            evaluate_not(&Schema::default(), &mut v, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Boolean(_ans)
         ));
@@ -278,15 +282,15 @@ mod tests {
 
     fn _test_bool_non_bool_and(f1: Field, f2: Field) {
         let row = Record::new(vec![]);
-        let l = Box::new(Literal(f1));
-        let r = Box::new(Literal(f2));
-        assert!(evaluate_and(&Schema::default(), &l, &r, &row).is_err());
+        let mut l = Box::new(Literal(f1));
+        let mut r = Box::new(Literal(f2));
+        assert!(evaluate_and(&Schema::default(), &mut l, &mut r, &row).is_err());
     }
 
     fn _test_bool_non_bool_or(f1: Field, f2: Field) {
         let row = Record::new(vec![]);
-        let l = Box::new(Literal(f1));
-        let r = Box::new(Literal(f2));
-        assert!(evaluate_or(&Schema::default(), &l, &r, &row).is_err());
+        let mut l = Box::new(Literal(f1));
+        let mut r = Box::new(Literal(f2));
+        assert!(evaluate_or(&Schema::default(), &mut l, &mut r, &row).is_err());
     }
 }

--- a/dozer-sql/expression/src/mathematical/mod.rs
+++ b/dozer-sql/expression/src/mathematical/mod.rs
@@ -15,8 +15,8 @@ macro_rules! define_math_operator {
     ($id:ident, $op:expr, $fct:expr, $t: expr) => {
         pub fn $id(
             schema: &Schema,
-            left: &Expression,
-            right: &Expression,
+            left: &mut Expression,
+            right: &mut Expression,
             record: &Record,
         ) -> Result<Field, PipelineError> {
             let left_p = left.evaluate(&record, schema)?;
@@ -1777,7 +1777,7 @@ define_math_operator!(evaluate_mod, "%", std::ops::Rem::rem, 0);
 
 pub fn evaluate_plus(
     schema: &Schema,
-    expression: &Expression,
+    expression: &mut Expression,
     record: &Record,
 ) -> Result<Field, PipelineError> {
     let expression_result = expression.evaluate(record, schema)?;
@@ -1806,7 +1806,7 @@ pub fn evaluate_plus(
 
 pub fn evaluate_minus(
     schema: &Schema,
-    expression: &Expression,
+    expression: &mut Expression,
     record: &Record,
 ) -> Result<Field, PipelineError> {
     let expression_result = expression.evaluate(record, schema)?;

--- a/dozer-sql/expression/src/mathematical/tests.rs
+++ b/dozer-sql/expression/src/mathematical/tests.rs
@@ -18,49 +18,49 @@ fn test_uint_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
-        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
-        let u128_1 = Box::new(Literal(Field::U128(u128_num1)));
-        let u128_2 = Box::new(Literal(Field::U128(u128_num2)));
-        let int1 = Box::new(Literal(Field::Int(i_num1)));
-        let int2 = Box::new(Literal(Field::Int(i_num2)));
-        let i128_1 = Box::new(Literal(Field::I128(i128_num1)));
-        let i128_2 = Box::new(Literal(Field::I128(i128_num2)));
-        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
-        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
-        let dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
-        let dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
+        let mut uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let mut uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let mut u128_1 = Box::new(Literal(Field::U128(u128_num1)));
+        let mut u128_2 = Box::new(Literal(Field::U128(u128_num2)));
+        let mut int1 = Box::new(Literal(Field::Int(i_num1)));
+        let mut int2 = Box::new(Literal(Field::Int(i_num2)));
+        let mut i128_1 = Box::new(Literal(Field::I128(i128_num1)));
+        let mut i128_2 = Box::new(Literal(Field::I128(i128_num2)));
+        let mut float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let mut float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let mut dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
+        let mut dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
 
-        let null = Box::new(Literal(Field::Null));
+        let mut null = Box::new(Literal(Field::Null));
 
         //// left: UInt, right: UInt
         assert_eq!(
             // UInt + UInt = UInt
-            evaluate_add(&Schema::default(), &uint1, &uint2, &row)
+            evaluate_add(&Schema::default(), &mut uint1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num1) + Wrapping(u_num2)).0)
         );
         assert_eq!(
             // UInt - UInt = UInt
-            evaluate_sub(&Schema::default(), &uint1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &mut uint1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num1) - Wrapping(u_num2)).0)
         );
         assert_eq!(
             // UInt * UInt = UInt
-            evaluate_mul(&Schema::default(), &uint2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &mut uint2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num2) * Wrapping(u_num1)).0)
         );
         assert_eq!(
             // UInt / UInt = Float
-            evaluate_div(&Schema::default(), &uint2, &uint1, &row)
+            evaluate_div(&Schema::default(), &mut uint2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // UInt % UInt = UInt
-            evaluate_mod(&Schema::default(), &uint1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &mut uint1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::UInt((Wrapping(u_num1) % Wrapping(u_num2)).0)
         );
@@ -68,31 +68,31 @@ fn test_uint_math() {
         //// left: UInt, right: U128
         assert_eq!(
             // UInt + U128 = U128
-            evaluate_add(&Schema::default(), &uint1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &mut uint1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num1 as u128) + Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // UInt - U128 = U128
-            evaluate_sub(&Schema::default(), &uint1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &mut uint1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num1 as u128) - Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // UInt * U128 = U128
-            evaluate_mul(&Schema::default(), &uint2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &mut uint2, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num2 as u128) * Wrapping(u128_num1)).0)
         );
         assert_eq!(
             // UInt / U128 = Float
-            evaluate_div(&Schema::default(), &uint2, &u128_1, &row)
+            evaluate_div(&Schema::default(), &mut uint2, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_u128(u128_num1).unwrap()))
         );
         assert_eq!(
             // UInt % U128 = U128
-            evaluate_mod(&Schema::default(), &uint1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &mut uint1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u_num1 as u128) % Wrapping(u128_num2)).0)
         );
@@ -100,31 +100,31 @@ fn test_uint_math() {
         //// left: UInt, right: Int
         assert_eq!(
             // UInt + Int = Int
-            evaluate_add(&Schema::default(), &uint1, &int2, &row)
+            evaluate_add(&Schema::default(), &mut uint1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num1 as i64) + Wrapping(i_num2)).0)
         );
         assert_eq!(
             // UInt - Int = Int
-            evaluate_sub(&Schema::default(), &uint1, &int2, &row)
+            evaluate_sub(&Schema::default(), &mut uint1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num1 as i64) - Wrapping(i_num2)).0)
         );
         assert_eq!(
             // UInt * Int = Int
-            evaluate_mul(&Schema::default(), &uint2, &int1, &row)
+            evaluate_mul(&Schema::default(), &mut uint2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num2 as i64) * Wrapping(i_num1)).0)
         );
         assert_eq!(
             // UInt / Int = Float
-            evaluate_div(&Schema::default(), &uint2, &int1, &row)
+            evaluate_div(&Schema::default(), &mut uint2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // UInt % Int = Int
-            evaluate_mod(&Schema::default(), &uint1, &int2, &row)
+            evaluate_mod(&Schema::default(), &mut uint1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(u_num1 as i64) % Wrapping(i_num2)).0)
         );
@@ -132,31 +132,31 @@ fn test_uint_math() {
         //// left: UInt, right: I128
         assert_eq!(
             // UInt + I128 = I128
-            evaluate_add(&Schema::default(), &uint1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &mut uint1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num1 as i128) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // UInt - I128 = I128
-            evaluate_sub(&Schema::default(), &uint1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &mut uint1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num1 as i128) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // UInt * I128 = I128
-            evaluate_mul(&Schema::default(), &uint2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &mut uint2, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num2 as i128) * Wrapping(i128_num1)).0)
         );
         assert_eq!(
             // UInt / I128 = Float
-            evaluate_div(&Schema::default(), &uint2, &i128_1, &row)
+            evaluate_div(&Schema::default(), &mut uint2, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
         );
         assert_eq!(
             // UInt % I128 = I128
-            evaluate_mod(&Schema::default(), &uint1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &mut uint1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u_num1 as i128) % Wrapping(i128_num2)).0)
         );
@@ -164,26 +164,26 @@ fn test_uint_math() {
         //// left: UInt, right: Float
         assert_eq!(
             // UInt + Float = Float
-            evaluate_add(&Schema::default(), &uint1, &float2, &row)
+            evaluate_add(&Schema::default(), &mut uint1, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() + f_num2))
         );
         assert_eq!(
             // UInt - Float = Float
-            evaluate_sub(&Schema::default(), &uint1, &float2, &row)
+            evaluate_sub(&Schema::default(), &mut uint1, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() - f_num2))
         );
         assert_eq!(
             // UInt * Float = Float
-            evaluate_mul(&Schema::default(), &uint2, &float1, &row)
+            evaluate_mul(&Schema::default(), &mut uint2, &mut float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() * f_num1))
         );
         if *float1 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // UInt / Float = Float
-                evaluate_div(&Schema::default(), &uint2, &float1, &row)
+                evaluate_div(&Schema::default(), &mut uint2, &mut float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u64(u_num2).unwrap() / f_num1))
             );
@@ -191,7 +191,7 @@ fn test_uint_math() {
         if *float2 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // UInt % Float = Float
-                evaluate_mod(&Schema::default(), &uint1, &float2, &row)
+                evaluate_mod(&Schema::default(), &mut uint1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u64(u_num1).unwrap() % f_num2))
             );
@@ -200,18 +200,18 @@ fn test_uint_math() {
         //// left: UInt, right: Decimal
         assert_eq!(
             // UInt + Decimal = Decimal
-            evaluate_add(&Schema::default(), &uint1, &dec2, &row)
+            evaluate_add(&Schema::default(), &mut uint1, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_u64(u_num1).unwrap() + d_num2.0)
         );
         assert_eq!(
             // UInt - Decimal = Decimal
-            evaluate_sub(&Schema::default(), &uint1, &dec2, &row)
+            evaluate_sub(&Schema::default(), &mut uint1, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_u64(u_num1).unwrap() - d_num2.0)
         );
         // UInt * Decimal = Decimal
-        let res = evaluate_mul(&Schema::default(), &uint2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut uint2, &mut dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_u64(u_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -224,7 +224,7 @@ fn test_uint_math() {
             ));
         }
         // UInt / Decimal = Decimal
-        let res = evaluate_div(&Schema::default(), &uint2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &mut uint2, &mut dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -244,7 +244,7 @@ fn test_uint_math() {
             ));
         }
         // UInt % Decimal = Decimal
-        let res = evaluate_mod(&Schema::default(), &uint2, &dec1, &row);
+        let res = evaluate_mod(&Schema::default(), &mut uint2, &mut dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -267,31 +267,31 @@ fn test_uint_math() {
         //// left: UInt, right: Null
         assert_eq!(
             // UInt + Null = Null
-            evaluate_add(&Schema::default(), &uint1, &null, &row)
+            evaluate_add(&Schema::default(), &mut uint1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt - Null = Null
-            evaluate_sub(&Schema::default(), &uint1, &null, &row)
+            evaluate_sub(&Schema::default(), &mut uint1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt * Null = Null
-            evaluate_mul(&Schema::default(), &uint2, &null, &row)
+            evaluate_mul(&Schema::default(), &mut uint2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt / Null = Null
-            evaluate_div(&Schema::default(), &uint2, &null, &row)
+            evaluate_div(&Schema::default(), &mut uint2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // UInt % Null = Null
-            evaluate_mod(&Schema::default(), &uint1, &null, &row)
+            evaluate_mod(&Schema::default(), &mut uint1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -303,49 +303,49 @@ fn test_u128_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
-        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
-        let u128_1 = Box::new(Literal(Field::U128(u128_num1)));
-        let u128_2 = Box::new(Literal(Field::U128(u128_num2)));
-        let int1 = Box::new(Literal(Field::Int(i_num1)));
-        let int2 = Box::new(Literal(Field::Int(i_num2)));
-        let i128_1 = Box::new(Literal(Field::I128(i128_num1)));
-        let i128_2 = Box::new(Literal(Field::I128(i128_num2)));
-        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
-        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
-        let dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
-        let dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
+        let mut uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let mut uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let mut u128_1 = Box::new(Literal(Field::U128(u128_num1)));
+        let mut u128_2 = Box::new(Literal(Field::U128(u128_num2)));
+        let mut int1 = Box::new(Literal(Field::Int(i_num1)));
+        let mut int2 = Box::new(Literal(Field::Int(i_num2)));
+        let mut i128_1 = Box::new(Literal(Field::I128(i128_num1)));
+        let mut i128_2 = Box::new(Literal(Field::I128(i128_num2)));
+        let mut float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let mut float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let mut dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
+        let mut dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
 
-        let null = Box::new(Literal(Field::Null));
+        let mut null = Box::new(Literal(Field::Null));
 
         //// left: U128, right: UInt
         assert_eq!(
             // U128 + UInt = U128
-            evaluate_add(&Schema::default(), &u128_1, &uint2, &row)
+            evaluate_add(&Schema::default(), &mut u128_1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) + Wrapping(u_num2 as u128)).0)
         );
         assert_eq!(
             // U128 - UInt = U128
-            evaluate_sub(&Schema::default(), &u128_1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &mut u128_1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) - Wrapping(u_num2 as u128)).0)
         );
         assert_eq!(
             // U128 * UInt = U128
-            evaluate_mul(&Schema::default(), &u128_2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &mut u128_2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num2) * Wrapping(u_num1 as u128)).0)
         );
         assert_eq!(
             // U128 / UInt = Float
-            evaluate_div(&Schema::default(), &u128_2, &uint1, &row)
+            evaluate_div(&Schema::default(), &mut u128_2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // U128 % UInt = U128
-            evaluate_mod(&Schema::default(), &u128_1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &mut u128_1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) % Wrapping(u_num2 as u128)).0)
         );
@@ -353,31 +353,31 @@ fn test_u128_math() {
         //// left: U128, right: U128
         assert_eq!(
             // U128 + U128 = U128
-            evaluate_add(&Schema::default(), &u128_1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &mut u128_1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) + Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // U128 - U128 = U128
-            evaluate_sub(&Schema::default(), &u128_1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &mut u128_1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) - Wrapping(u128_num2)).0)
         );
         assert_eq!(
             // U128 * U128 = U128
-            evaluate_mul(&Schema::default(), &u128_2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &mut u128_2, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num2) * Wrapping(u128_num1)).0)
         );
         assert_eq!(
             // U128 / U128 = Float
-            evaluate_div(&Schema::default(), &u128_2, &u128_1, &row)
+            evaluate_div(&Schema::default(), &mut u128_2, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_u128(u128_num1).unwrap()))
         );
         assert_eq!(
             // U128 % U128 = U128
-            evaluate_mod(&Schema::default(), &u128_1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &mut u128_1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::U128((Wrapping(u128_num1) % Wrapping(u128_num2)).0)
         );
@@ -385,31 +385,31 @@ fn test_u128_math() {
         //// left: U128, right: Int
         assert_eq!(
             // U128 + Int = I128
-            evaluate_add(&Schema::default(), &u128_1, &int2, &row)
+            evaluate_add(&Schema::default(), &mut u128_1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) + Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // U128 - Int = I128
-            evaluate_sub(&Schema::default(), &u128_1, &int2, &row)
+            evaluate_sub(&Schema::default(), &mut u128_1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) - Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // U128 * Int = I128
-            evaluate_mul(&Schema::default(), &u128_2, &int1, &row)
+            evaluate_mul(&Schema::default(), &mut u128_2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num2 as i128) * Wrapping(i_num1 as i128)).0)
         );
         assert_eq!(
             // U128 / Int = Float
-            evaluate_div(&Schema::default(), &u128_2, &int1, &row)
+            evaluate_div(&Schema::default(), &mut u128_2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // U128 % Int = I128
-            evaluate_mod(&Schema::default(), &u128_1, &int2, &row)
+            evaluate_mod(&Schema::default(), &mut u128_1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) % Wrapping(i_num2 as i128)).0)
         );
@@ -417,103 +417,103 @@ fn test_u128_math() {
         //// left: U128, right: I128
         assert_eq!(
             // U128 + I128 = I128
-            evaluate_add(&Schema::default(), &u128_1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &mut u128_1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // U128 - I128 = I128
-            evaluate_sub(&Schema::default(), &u128_1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &mut u128_1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // U128 * I128 = I128
-            evaluate_mul(&Schema::default(), &u128_2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &mut u128_2, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num2 as i128) * Wrapping(i128_num1)).0)
         );
         assert_eq!(
             // U128 / I128 = Float
-            evaluate_div(&Schema::default(), &u128_2, &i128_1, &row)
+            evaluate_div(&Schema::default(), &mut u128_2, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
         );
         assert_eq!(
             // U128 % I128 = I128
-            evaluate_mod(&Schema::default(), &u128_1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &mut u128_1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(u128_num1 as i128) % Wrapping(i128_num2)).0)
         );
 
         //// left: U128, right: Float
-        let res = evaluate_add(&Schema::default(), &u128_1, &float2, &row);
+        let res = evaluate_add(&Schema::default(), &mut u128_1, &mut float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 + Float = Float
-                evaluate_add(&Schema::default(), &u128_1, &float2, &row)
+                evaluate_add(&Schema::default(), &mut u128_1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num1).unwrap() + f_num2))
             );
         }
-        let res = evaluate_sub(&Schema::default(), &u128_1, &float2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut u128_1, &mut float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 - Float = Float
-                evaluate_sub(&Schema::default(), &u128_1, &float2, &row)
+                evaluate_sub(&Schema::default(), &mut u128_1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num1).unwrap() - f_num2))
             );
         }
-        let res = evaluate_mul(&Schema::default(), &u128_2, &float1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut u128_2, &mut float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 * Float = Float
-                evaluate_mul(&Schema::default(), &u128_2, &float1, &row)
+                evaluate_mul(&Schema::default(), &mut u128_2, &mut float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() * f_num1))
             );
         }
-        let res = evaluate_div(&Schema::default(), &u128_2, &float1, &row);
+        let res = evaluate_div(&Schema::default(), &mut u128_2, &mut float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 / Float = Float
-                evaluate_div(&Schema::default(), &u128_2, &float1, &row)
+                evaluate_div(&Schema::default(), &mut u128_2, &mut float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num2).unwrap() / f_num1))
             );
         }
-        let res = evaluate_mod(&Schema::default(), &u128_1, &float2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut u128_1, &mut float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 % Float = Float
-                evaluate_mod(&Schema::default(), &u128_1, &float2, &row)
+                evaluate_mod(&Schema::default(), &mut u128_1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_u128(u128_num1).unwrap() % f_num2))
             );
         }
 
         //// left: U128, right: Decimal
-        let res = evaluate_add(&Schema::default(), &u128_1, &dec2, &row);
+        let res = evaluate_add(&Schema::default(), &mut u128_1, &mut dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 + Decimal = Decimal
-                evaluate_add(&Schema::default(), &u128_1, &dec2, &row)
+                evaluate_add(&Schema::default(), &mut u128_1, &mut dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_u128(u128_num1).unwrap() + d_num2.0)
             );
         }
-        let res = evaluate_sub(&Schema::default(), &u128_1, &dec2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut u128_1, &mut dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // U128 - Decimal = Decimal
-                evaluate_sub(&Schema::default(), &u128_1, &dec2, &row)
+                evaluate_sub(&Schema::default(), &mut u128_1, &mut dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_u128(u128_num1).unwrap() - d_num2.0)
             );
         }
         // U128 * Decimal = Decimal
-        let res = evaluate_mul(&Schema::default(), &u128_2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut u128_2, &mut dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_u128(u128_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -528,7 +528,7 @@ fn test_u128_math() {
             }
         }
         // U128 / Decimal = Decimal
-        let res = evaluate_div(&Schema::default(), &u128_2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &mut u128_2, &mut dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -552,7 +552,7 @@ fn test_u128_math() {
             }
         }
         // U128 % Decimal = Decimal
-        let res = evaluate_mod(&Schema::default(), &u128_1, &dec1, &row);
+        let res = evaluate_mod(&Schema::default(), &mut u128_1, &mut dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -579,31 +579,31 @@ fn test_u128_math() {
         //// left: U128, right: Null
         assert_eq!(
             // U128 + Null = Null
-            evaluate_add(&Schema::default(), &u128_1, &null, &row)
+            evaluate_add(&Schema::default(), &mut u128_1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 - Null = Null
-            evaluate_sub(&Schema::default(), &u128_1, &null, &row)
+            evaluate_sub(&Schema::default(), &mut u128_1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 * Null = Null
-            evaluate_mul(&Schema::default(), &u128_2, &null, &row)
+            evaluate_mul(&Schema::default(), &mut u128_2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 / Null = Null
-            evaluate_div(&Schema::default(), &u128_2, &null, &row)
+            evaluate_div(&Schema::default(), &mut u128_2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // U128 % Null = Null
-            evaluate_mod(&Schema::default(), &u128_1, &null, &row)
+            evaluate_mod(&Schema::default(), &mut u128_1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -615,49 +615,49 @@ fn test_int_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
-        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
-        let u128_1 = Box::new(Literal(Field::U128(u128_num1)));
-        let u128_2 = Box::new(Literal(Field::U128(u128_num2)));
-        let int1 = Box::new(Literal(Field::Int(i_num1)));
-        let int2 = Box::new(Literal(Field::Int(i_num2)));
-        let i128_1 = Box::new(Literal(Field::I128(i128_num1)));
-        let i128_2 = Box::new(Literal(Field::I128(i128_num2)));
-        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
-        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
-        let dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
-        let dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
+        let mut uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let mut uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let mut u128_1 = Box::new(Literal(Field::U128(u128_num1)));
+        let mut u128_2 = Box::new(Literal(Field::U128(u128_num2)));
+        let mut int1 = Box::new(Literal(Field::Int(i_num1)));
+        let mut int2 = Box::new(Literal(Field::Int(i_num2)));
+        let mut i128_1 = Box::new(Literal(Field::I128(i128_num1)));
+        let mut i128_2 = Box::new(Literal(Field::I128(i128_num2)));
+        let mut float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let mut float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let mut dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
+        let mut dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
 
-        let null = Box::new(Literal(Field::Null));
+        let mut null = Box::new(Literal(Field::Null));
 
         //// left: Int, right: UInt
         assert_eq!(
             // Int + UInt = Int
-            evaluate_add(&Schema::default(), &int1, &uint2, &row)
+            evaluate_add(&Schema::default(), &mut int1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) + Wrapping(u_num2 as i64)).0)
         );
         assert_eq!(
             // Int - UInt = Int
-            evaluate_sub(&Schema::default(), &int1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &mut int1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) - Wrapping(u_num2 as i64)).0)
         );
         assert_eq!(
             // Int * UInt = Int
-            evaluate_mul(&Schema::default(), &int2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &mut int2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num2) * Wrapping(u_num1 as i64)).0)
         );
         assert_eq!(
             // Int / UInt = Float
-            evaluate_div(&Schema::default(), &int2, &uint1, &row)
+            evaluate_div(&Schema::default(), &mut int2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // Int % UInt = Int
-            evaluate_mod(&Schema::default(), &int1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &mut int1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) % Wrapping(u_num2 as i64)).0)
         );
@@ -665,33 +665,33 @@ fn test_int_math() {
         //// left: Int, right: U128
         assert_eq!(
             // Int + U128 = I128
-            evaluate_add(&Schema::default(), &int1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &mut int1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) + Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // Int - U128 = I128
-            evaluate_sub(&Schema::default(), &int1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &mut int1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) - Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // Int * U128 = I128
-            evaluate_mul(&Schema::default(), &int2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &mut int2, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num2 as i128) * Wrapping(u128_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::default(), &int2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut int2, &mut u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Int / U128 = Float
-                evaluate_div(&Schema::default(), &int2, &u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+                evaluate_div(&Schema::default(), &mut int2, &mut u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i_num2 as i128).unwrap() / f64::from_i128(u128_num1 as i128).unwrap()))
             );
         }
         assert_eq!(
             // Int % U128 = I128
-            evaluate_mod(&Schema::default(), &int1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &mut int1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) % Wrapping(u128_num2 as i128)).0)
         );
@@ -699,31 +699,31 @@ fn test_int_math() {
         //// left: Int, right: Int
         assert_eq!(
             // Int + Int = Int
-            evaluate_add(&Schema::default(), &int1, &int2, &row)
+            evaluate_add(&Schema::default(), &mut int1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) + Wrapping(i_num2)).0)
         );
         assert_eq!(
             // Int - Int = Int
-            evaluate_sub(&Schema::default(), &int1, &int2, &row)
+            evaluate_sub(&Schema::default(), &mut int1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) - Wrapping(i_num2)).0)
         );
         assert_eq!(
             // Int * Int = Int
-            evaluate_mul(&Schema::default(), &int2, &int1, &row)
+            evaluate_mul(&Schema::default(), &mut int2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num2) * Wrapping(i_num1)).0)
         );
         assert_eq!(
             // Int / Int = Float
-            evaluate_div(&Schema::default(), &int2, &int1, &row)
+            evaluate_div(&Schema::default(), &mut int2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // Int % Int = Int
-            evaluate_mod(&Schema::default(), &int1, &int2, &row)
+            evaluate_mod(&Schema::default(), &mut int1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int((Wrapping(i_num1) % Wrapping(i_num2)).0)
         );
@@ -731,34 +731,34 @@ fn test_int_math() {
         //// left: Int, right: I128
         assert_eq!(
             // Int + I128 = I128
-            evaluate_add(&Schema::default(), &int1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &mut int1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // Int - I128 = I128
-            evaluate_sub(&Schema::default(), &int1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &mut int1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // Int * I128 = I128
-            evaluate_mul(&Schema::default(), &int2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &mut int2, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num2 as i128) * Wrapping(i128_num1)).0)
         );
-        let res = evaluate_div(&Schema::default(), &int2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut int2, &mut i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Int / I128 = Float
-                evaluate_div(&Schema::default(), &int2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &mut int2, &mut i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
             );
         }
         assert_eq!(
             // Int % I128 = I128
-            evaluate_mod(&Schema::default(), &int1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &mut int1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i_num1 as i128) % Wrapping(i128_num2)).0)
         );
@@ -766,26 +766,26 @@ fn test_int_math() {
         //// left: Int, right: Float
         assert_eq!(
             // Int + Float = Float
-            evaluate_add(&Schema::default(), &int1, &float2, &row)
+            evaluate_add(&Schema::default(), &mut int1, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() + f_num2))
         );
         assert_eq!(
             // Int - Float = Float
-            evaluate_sub(&Schema::default(), &int1, &float2, &row)
+            evaluate_sub(&Schema::default(), &mut int1, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() - f_num2))
         );
         assert_eq!(
             // Int * Float = Float
-            evaluate_mul(&Schema::default(), &int2, &float1, &row)
+            evaluate_mul(&Schema::default(), &mut int2, &mut float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() * f_num1))
         );
         if *float1 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Int / Float = Float
-                evaluate_div(&Schema::default(), &int2, &float1, &row)
+                evaluate_div(&Schema::default(), &mut int2, &mut float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i64(i_num2).unwrap() / f_num1))
             );
@@ -793,7 +793,7 @@ fn test_int_math() {
         if *float2 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Int % Float = Float
-                evaluate_mod(&Schema::default(), &int1, &float2, &row)
+                evaluate_mod(&Schema::default(), &mut int1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i64(i_num1).unwrap() % f_num2))
             );
@@ -802,18 +802,18 @@ fn test_int_math() {
         //// left: Int, right: Decimal
         assert_eq!(
             // Int + Decimal = Decimal
-            evaluate_add(&Schema::default(), &int1, &dec2, &row)
+            evaluate_add(&Schema::default(), &mut int1, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_i64(i_num1).unwrap() + d_num2.0)
         );
         assert_eq!(
             // Int - Decimal = Decimal
-            evaluate_sub(&Schema::default(), &int1, &dec2, &row)
+            evaluate_sub(&Schema::default(), &mut int1, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(Decimal::from_i64(i_num1).unwrap() - d_num2.0)
         );
         // Int * Decimal = Decimal
-        let res = evaluate_mul(&Schema::default(), &int2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut int2, &mut dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_i64(i_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -826,7 +826,7 @@ fn test_int_math() {
             ));
         }
         // Int / Decimal = Decimal
-        let res = evaluate_div(&Schema::default(), &int2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &mut int2, &mut dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -846,7 +846,7 @@ fn test_int_math() {
             ));
         }
         // Int % Decimal = Decimal
-        let res = evaluate_mod(&Schema::default(), &int1, &dec2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut int1, &mut dec2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -869,31 +869,31 @@ fn test_int_math() {
         //// left: Int, right: Null
         assert_eq!(
             // Int + Null = Null
-            evaluate_add(&Schema::default(), &int1, &null, &row)
+            evaluate_add(&Schema::default(), &mut int1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int - Null = Null
-            evaluate_sub(&Schema::default(), &int1, &null, &row)
+            evaluate_sub(&Schema::default(), &mut int1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int * Null = Null
-            evaluate_mul(&Schema::default(), &int2, &null, &row)
+            evaluate_mul(&Schema::default(), &mut int2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int / Null = Null
-            evaluate_div(&Schema::default(), &int2, &null, &row)
+            evaluate_div(&Schema::default(), &mut int2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Int % Null = Null
-            evaluate_mod(&Schema::default(), &int1, &null, &row)
+            evaluate_mod(&Schema::default(), &mut int1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -905,52 +905,52 @@ fn test_i128_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
-        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
-        let u128_1 = Box::new(Literal(Field::U128(u128_num1)));
-        let u128_2 = Box::new(Literal(Field::U128(u128_num2)));
-        let int1 = Box::new(Literal(Field::Int(i_num1)));
-        let int2 = Box::new(Literal(Field::Int(i_num2)));
-        let i128_1 = Box::new(Literal(Field::I128(i128_num1)));
-        let i128_2 = Box::new(Literal(Field::I128(i128_num2)));
-        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
-        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
-        let dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
-        let dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
+        let mut uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let mut uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let mut u128_1 = Box::new(Literal(Field::U128(u128_num1)));
+        let mut u128_2 = Box::new(Literal(Field::U128(u128_num2)));
+        let mut int1 = Box::new(Literal(Field::Int(i_num1)));
+        let mut int2 = Box::new(Literal(Field::Int(i_num2)));
+        let mut i128_1 = Box::new(Literal(Field::I128(i128_num1)));
+        let mut i128_2 = Box::new(Literal(Field::I128(i128_num2)));
+        let mut float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let mut float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let mut dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
+        let mut dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
 
-        let null = Box::new(Literal(Field::Null));
+        let mut null = Box::new(Literal(Field::Null));
 
         //// left: I128, right: UInt
         assert_eq!(
             // I128 + UInt = I128
-            evaluate_add(&Schema::default(), &i128_1, &uint2, &row)
+            evaluate_add(&Schema::default(), &mut i128_1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(u_num2 as i128)).0)
         );
         assert_eq!(
             // I128 - UInt = I128
-            evaluate_sub(&Schema::default(), &i128_1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &mut i128_1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(u_num2 as i128)).0)
         );
         assert_eq!(
             // I128 * UInt = I128
-            evaluate_mul(&Schema::default(), &i128_2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &mut i128_2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(u_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::default(), &i128_2, &uint1, &row);
+        let res = evaluate_div(&Schema::default(), &mut i128_2, &mut uint1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / UInt = Float
-                evaluate_div(&Schema::default(), &i128_2, &uint1, &row)
+                evaluate_div(&Schema::default(), &mut i128_2, &mut uint1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_u64(u_num1).unwrap()))
             );
         }
         assert_eq!(
             // I128 % UInt = I128
-            evaluate_mod(&Schema::default(), &i128_1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &mut i128_1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(u_num2 as i128)).0)
         );
@@ -958,33 +958,33 @@ fn test_i128_math() {
         //// left: I128, right: U128
         assert_eq!(
             // I128 + U128 = I128
-            evaluate_add(&Schema::default(), &i128_1, &u128_2, &row)
+            evaluate_add(&Schema::default(), &mut i128_1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // I128 - U128 = I128
-            evaluate_sub(&Schema::default(), &i128_1, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &mut i128_1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(u128_num2 as i128)).0)
         );
         assert_eq!(
             // I128 * U128 = I128
-            evaluate_mul(&Schema::default(), &i128_2, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &mut i128_2, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(u128_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::default(), &i128_2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut i128_2, &mut u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / U128 = Float
-                evaluate_div(&Schema::default(), &i128_2, &u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
+                evaluate_div(&Schema::default(), &mut i128_2, &mut u128_1, &row).unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_i128(u128_num1 as i128).unwrap()))
             );
         }
         assert_eq!(
             // I128 % U128 = I128
-            evaluate_mod(&Schema::default(), &i128_1, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &mut i128_1, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(u128_num2 as i128)).0)
         );
@@ -992,34 +992,34 @@ fn test_i128_math() {
         //// left: I128, right: Int
         assert_eq!(
             // I128 + Int = I128
-            evaluate_add(&Schema::default(), &i128_1, &int2, &row)
+            evaluate_add(&Schema::default(), &mut i128_1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // I128 - Int = I128
-            evaluate_sub(&Schema::default(), &i128_1, &int2, &row)
+            evaluate_sub(&Schema::default(), &mut i128_1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(i_num2 as i128)).0)
         );
         assert_eq!(
             // I128 * Int = I128
-            evaluate_mul(&Schema::default(), &i128_2, &int1, &row)
+            evaluate_mul(&Schema::default(), &mut i128_2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(i_num1 as i128)).0)
         );
-        let res = evaluate_div(&Schema::default(), &i128_2, &int1, &row);
+        let res = evaluate_div(&Schema::default(), &mut i128_2, &mut int1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / Int = Float
-                evaluate_div(&Schema::default(), &i128_2, &int1, &row)
+                evaluate_div(&Schema::default(), &mut i128_2, &mut int1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_i64(i_num1).unwrap()))
             );
         }
         assert_eq!(
             // I128 % Int = I128
-            evaluate_mod(&Schema::default(), &i128_1, &int2, &row)
+            evaluate_mod(&Schema::default(), &mut i128_1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(i_num2 as i128)).0)
         );
@@ -1027,106 +1027,106 @@ fn test_i128_math() {
         //// left: I128, right: I128
         assert_eq!(
             // I128 + I128 = I128
-            evaluate_add(&Schema::default(), &i128_1, &i128_2, &row)
+            evaluate_add(&Schema::default(), &mut i128_1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) + Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // I128 - I128 = I128
-            evaluate_sub(&Schema::default(), &i128_1, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &mut i128_1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) - Wrapping(i128_num2)).0)
         );
         assert_eq!(
             // I128 * I128 = I128
-            evaluate_mul(&Schema::default(), &i128_2, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &mut i128_2, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num2) * Wrapping(i128_num1)).0)
         );
-        let res = evaluate_div(&Schema::default(), &i128_2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut i128_2, &mut i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / I128 = Float
-                evaluate_div(&Schema::default(), &i128_2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &mut i128_2, &mut i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f64::from_i128(i128_num1).unwrap()))
             );
         }
         assert_eq!(
             // I128 % I128 = I128
-            evaluate_mod(&Schema::default(), &i128_1, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &mut i128_1, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::I128((Wrapping(i128_num1) % Wrapping(i128_num2)).0)
         );
 
         //// left: I128, right: Float
-        let res = evaluate_add(&Schema::default(), &i128_1, &float2, &row);
+        let res = evaluate_add(&Schema::default(), &mut i128_1, &mut float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 + Float = Float
-                evaluate_add(&Schema::default(), &i128_1, &float2, &row)
+                evaluate_add(&Schema::default(), &mut i128_1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num1).unwrap() + f_num2))
             );
         }
-        let res = evaluate_sub(&Schema::default(), &i128_1, &float2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut i128_1, &mut float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 - Float = Float
-                evaluate_sub(&Schema::default(), &i128_1, &float2, &row)
+                evaluate_sub(&Schema::default(), &mut i128_1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num1).unwrap() - f_num2))
             );
         }
-        let res = evaluate_mul(&Schema::default(), &i128_2, &float1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut i128_2, &mut float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 * Float = Float
-                evaluate_mul(&Schema::default(), &i128_2, &float1, &row)
+                evaluate_mul(&Schema::default(), &mut i128_2, &mut float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() * f_num1))
             );
         }
-        let res = evaluate_div(&Schema::default(), &i128_2, &float1, &row);
+        let res = evaluate_div(&Schema::default(), &mut i128_2, &mut float1, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 / Float = Float
-                evaluate_div(&Schema::default(), &i128_2, &float1, &row)
+                evaluate_div(&Schema::default(), &mut i128_2, &mut float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num2).unwrap() / f_num1))
             );
         }
-        let res = evaluate_mod(&Schema::default(), &i128_1, &float2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut i128_1, &mut float2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 % Float = Float
-                evaluate_mod(&Schema::default(), &i128_1, &float2, &row)
+                evaluate_mod(&Schema::default(), &mut i128_1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f64::from_i128(i128_num1).unwrap() % f_num2))
             );
         }
 
         //// left: I128, right: Decimal
-        let res = evaluate_add(&Schema::default(), &i128_1, &dec2, &row);
+        let res = evaluate_add(&Schema::default(), &mut i128_1, &mut dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 + Decimal = Decimal
-                evaluate_add(&Schema::default(), &i128_1, &dec2, &row)
+                evaluate_add(&Schema::default(), &mut i128_1, &mut dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_i128(i128_num1).unwrap() + d_num2.0)
             );
         }
-        let res = evaluate_sub(&Schema::default(), &i128_1, &dec2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut i128_1, &mut dec2, &row);
         if res.is_ok() {
             assert_eq!(
                 // I128 - Decimal = Decimal
-                evaluate_sub(&Schema::default(), &i128_1, &dec2, &row)
+                evaluate_sub(&Schema::default(), &mut i128_1, &mut dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(Decimal::from_i128(i128_num1).unwrap() - d_num2.0)
             );
         }
         // I128 * Decimal = Decimal
-        let res = evaluate_mul(&Schema::default(), &i128_2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut i128_2, &mut dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(Decimal::from_i128(i128_num2).unwrap().checked_mul(d_num1.0).unwrap())
@@ -1141,7 +1141,7 @@ fn test_i128_math() {
             }
         }
         // I128 / Decimal = Decimal
-        let res = evaluate_div(&Schema::default(), &i128_2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &mut i128_2, &mut dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1165,7 +1165,7 @@ fn test_i128_math() {
             }
         }
         // I128 % Decimal = Decimal
-        let res = evaluate_mod(&Schema::default(), &i128_1, &dec2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut i128_1, &mut dec2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1192,31 +1192,31 @@ fn test_i128_math() {
         //// left: I128, right: Null
         assert_eq!(
             // I128 + Null = Null
-            evaluate_add(&Schema::default(), &i128_1, &null, &row)
+            evaluate_add(&Schema::default(), &mut i128_1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 - Null = Null
-            evaluate_sub(&Schema::default(), &i128_1, &null, &row)
+            evaluate_sub(&Schema::default(), &mut i128_1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 * Null = Null
-            evaluate_mul(&Schema::default(), &i128_2, &null, &row)
+            evaluate_mul(&Schema::default(), &mut i128_2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 / Null = Null
-            evaluate_div(&Schema::default(), &i128_2, &null, &row)
+            evaluate_div(&Schema::default(), &mut i128_2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // I128 % Null = Null
-            evaluate_mod(&Schema::default(), &i128_1, &null, &row)
+            evaluate_mod(&Schema::default(), &mut i128_1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -1228,95 +1228,95 @@ fn test_float_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
-        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
-        let u128_1 = Box::new(Literal(Field::U128(u128_num1)));
-        let u128_2 = Box::new(Literal(Field::U128(u128_num2)));
-        let int1 = Box::new(Literal(Field::Int(i_num1)));
-        let int2 = Box::new(Literal(Field::Int(i_num2)));
-        let i128_1 = Box::new(Literal(Field::I128(i128_num1)));
-        let i128_2 = Box::new(Literal(Field::I128(i128_num2)));
-        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
-        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
-        let dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
-        let dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
+        let mut uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let mut uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let mut u128_1 = Box::new(Literal(Field::U128(u128_num1)));
+        let mut u128_2 = Box::new(Literal(Field::U128(u128_num2)));
+        let mut int1 = Box::new(Literal(Field::Int(i_num1)));
+        let mut int2 = Box::new(Literal(Field::Int(i_num2)));
+        let mut i128_1 = Box::new(Literal(Field::I128(i128_num1)));
+        let mut i128_2 = Box::new(Literal(Field::I128(i128_num2)));
+        let mut float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let mut float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let mut dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
+        let mut dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
 
-        let null = Box::new(Literal(Field::Null));
+        let mut null = Box::new(Literal(Field::Null));
 
         //// left: Float, right: UInt
         assert_eq!(
             // Float + UInt = Float
-            evaluate_add(&Schema::default(), &float1, &uint2, &row)
+            evaluate_add(&Schema::default(), &mut float1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_u64(u_num2).unwrap()))
         );
         assert_eq!(
             // Float - UInt = Float
-            evaluate_sub(&Schema::default(), &float1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &mut float1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_u64(u_num2).unwrap()))
         );
         assert_eq!(
             // Float * UInt = Float
-            evaluate_mul(&Schema::default(), &float2, &uint1, &row)
+            evaluate_mul(&Schema::default(), &mut float2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // Float / UInt = Float
-            evaluate_div(&Schema::default(), &float2, &uint1, &row)
+            evaluate_div(&Schema::default(), &mut float2, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_u64(u_num1).unwrap()))
         );
         assert_eq!(
             // Float % UInt = Float
-            evaluate_mod(&Schema::default(), &float1, &uint2, &row)
+            evaluate_mod(&Schema::default(), &mut float1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_u64(u_num2).unwrap()))
         );
 
         //// left: Float, right: U128
-        let res = evaluate_add(&Schema::default(), &float1, &u128_2, &row);
+        let res = evaluate_add(&Schema::default(), &mut float1, &mut u128_2, &row);
         if res.is_ok() {
            assert_eq!(
                 // Float + U128 = Float
-                evaluate_add(&Schema::default(), &float1, &u128_2, &row)
+                evaluate_add(&Schema::default(), &mut float1, &mut u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_u128(u128_num2).unwrap()))
             );
         }
-        let res = evaluate_sub(&Schema::default(), &float1, &u128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut float1, &mut u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float - U128 = Float
-                evaluate_sub(&Schema::default(), &float1, &u128_2, &row)
+                evaluate_sub(&Schema::default(), &mut float1, &mut u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_u128(u128_num2).unwrap()))
             );
         }
-        let res = evaluate_mul(&Schema::default(), &float2, &u128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut float2, &mut u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float * U128 = Float
-                evaluate_mul(&Schema::default(), &float2, &u128_1, &row)
+                evaluate_mul(&Schema::default(), &mut float2, &mut u128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_u128(u128_num1).unwrap()))
             );
         }
-        let res = evaluate_div(&Schema::default(), &float2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut float2, &mut u128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float / U128 = Float
-                evaluate_div(&Schema::default(), &float2, &u128_1, &row)
+                evaluate_div(&Schema::default(), &mut float2, &mut u128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_u128(u128_num1).unwrap()))
             );
         }
-        let res = evaluate_mod(&Schema::default(), &float1, &u128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut float1, &mut u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float % U128 = Float
-                evaluate_mod(&Schema::default(), &float1, &u128_2, &row)
+                evaluate_mod(&Schema::default(), &mut float1, &mut u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_u128(u128_num2).unwrap()))
             );
@@ -1325,77 +1325,77 @@ fn test_float_math() {
         //// left: Float, right: Int
         assert_eq!(
             // Float + Int = Float
-            evaluate_add(&Schema::default(), &float1, &int2, &row)
+            evaluate_add(&Schema::default(), &mut float1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_i64(i_num2).unwrap()))
         );
         assert_eq!(
             // Float - Int = Float
-            evaluate_sub(&Schema::default(), &float1, &int2, &row)
+            evaluate_sub(&Schema::default(), &mut float1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_i64(i_num2).unwrap()))
         );
         assert_eq!(
             // Float * Int = Float
-            evaluate_mul(&Schema::default(), &float2, &int1, &row)
+            evaluate_mul(&Schema::default(), &mut float2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // Float / Int = Float
-            evaluate_div(&Schema::default(), &float2, &int1, &row)
+            evaluate_div(&Schema::default(), &mut float2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_i64(i_num1).unwrap()))
         );
         assert_eq!(
             // Float % Int = Float
-            evaluate_mod(&Schema::default(), &float1, &int2, &row)
+            evaluate_mod(&Schema::default(), &mut float1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_i64(i_num2).unwrap()))
         );
 
         //// left: Float, right: I128
-        let res = evaluate_add(&Schema::default(), &float1, &i128_2, &row);
+        let res = evaluate_add(&Schema::default(), &mut float1, &mut i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float + I128 = Float
-                evaluate_add(&Schema::default(), &float1, &i128_2, &row)
+                evaluate_add(&Schema::default(), &mut float1, &mut i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) + OrderedFloat(f64::from_i128(i128_num2).unwrap()))
             );
         }
-        let res = evaluate_sub(&Schema::default(), &float1, &i128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut float1, &mut i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float - I128 = Float
-                evaluate_sub(&Schema::default(), &float1, &i128_2, &row)
+                evaluate_sub(&Schema::default(), &mut float1, &mut i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) - OrderedFloat(f64::from_i128(i128_num2).unwrap()))
             );
         }
-        let res = evaluate_mul(&Schema::default(), &float2, &i128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut float2, &mut i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float * I128 = Float
-                evaluate_mul(&Schema::default(), &float2, &i128_1, &row)
+                evaluate_mul(&Schema::default(), &mut float2, &mut i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) * OrderedFloat(f64::from_i128(i128_num1).unwrap()))
             );
         }
-        let res = evaluate_div(&Schema::default(), &float2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut float2, &mut i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float / I128 = Float
-                evaluate_div(&Schema::default(), &float2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &mut float2, &mut i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2) / OrderedFloat(f64::from_i128(i128_num1).unwrap()))
             );
         }
-        let res = evaluate_mod(&Schema::default(), &float1, &i128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut float1, &mut i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Float % I128 = Float
-                evaluate_mod(&Schema::default(), &float1, &i128_2, &row)
+                evaluate_mod(&Schema::default(), &mut float1, &mut i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1) % OrderedFloat(f64::from_i128(i128_num2).unwrap()))
             );
@@ -1404,26 +1404,26 @@ fn test_float_math() {
         //// left: Float, right: Float
         assert_eq!(
             // Float + Float = Float
-            evaluate_add(&Schema::default(), &float1, &float2, &row)
+            evaluate_add(&Schema::default(), &mut float1, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1 + f_num2))
         );
         assert_eq!(
             // Float - Float = Float
-            evaluate_sub(&Schema::default(), &float1, &float2, &row)
+            evaluate_sub(&Schema::default(), &mut float1, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num1 - f_num2))
         );
         assert_eq!(
             // Float * Float = Float
-            evaluate_mul(&Schema::default(), &float2, &float1, &row)
+            evaluate_mul(&Schema::default(), &mut float2, &mut float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num2 * f_num1))
         );
         if *float1 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Float / Float = Float
-                evaluate_div(&Schema::default(), &float2, &float1, &row)
+                evaluate_div(&Schema::default(), &mut float2, &mut float1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num2 / f_num1))
             );
@@ -1431,7 +1431,7 @@ fn test_float_math() {
         if *float2 != Literal(Field::Float(OrderedFloat(0_f64))) {
             assert_eq!(
                 // Float % Float = Float
-                evaluate_mod(&Schema::default(), &float1, &float2, &row)
+                evaluate_mod(&Schema::default(), &mut float1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num1 % f_num2))
             );
@@ -1443,18 +1443,18 @@ fn test_float_math() {
         if d_val1.is_some() && d_val2.is_some() {
             assert_eq!(
                 // Float + Decimal = Decimal
-                evaluate_add(&Schema::default(), &float1, &dec2, &row)
+                evaluate_add(&Schema::default(), &mut float1, &mut dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_val1.unwrap() + d_num2.0)
             );
             assert_eq!(
                 // Float - Decimal = Decimal
-                evaluate_sub(&Schema::default(), &float1, &dec2, &row)
+                evaluate_sub(&Schema::default(), &mut float1, &mut dec2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_val1.unwrap() - d_num2.0)
             );
             // Float * Decimal = Decimal
-            let res = evaluate_mul(&Schema::default(), &float2, &dec1, &row);
+            let res = evaluate_mul(&Schema::default(), &mut float2, &mut dec1, &row);
             if res.is_ok() {
                  assert_eq!(
                     res.unwrap(), Field::Decimal(d_val2.unwrap().checked_mul(d_num1.0).unwrap())
@@ -1467,7 +1467,7 @@ fn test_float_math() {
                 ));
             }
             // Float / Decimal = Decimal
-            let res = evaluate_div(&Schema::default(), &float2, &dec1, &row);
+            let res = evaluate_div(&Schema::default(), &mut float2, &mut dec1, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1487,7 +1487,7 @@ fn test_float_math() {
                 ));
             }
             // Float % Decimal = Decimal
-            let res = evaluate_mod(&Schema::default(), &float1, &dec2, &row);
+            let res = evaluate_mod(&Schema::default(), &mut float1, &mut dec2, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1511,31 +1511,31 @@ fn test_float_math() {
         //// left: Float, right: Null
         assert_eq!(
             // Float + Null = Null
-            evaluate_add(&Schema::default(), &float1, &null, &row)
+            evaluate_add(&Schema::default(), &mut float1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float - Null = Null
-            evaluate_sub(&Schema::default(), &float1, &null, &row)
+            evaluate_sub(&Schema::default(), &mut float1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float * Null = Null
-            evaluate_mul(&Schema::default(), &float2, &null, &row)
+            evaluate_mul(&Schema::default(), &mut float2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float / Null = Null
-            evaluate_div(&Schema::default(), &float2, &null, &row)
+            evaluate_div(&Schema::default(), &mut float2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Float % Null = Null
-            evaluate_mod(&Schema::default(), &float1, &null, &row)
+            evaluate_mod(&Schema::default(), &mut float1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -1547,36 +1547,36 @@ fn test_decimal_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
-        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
-        let u128_1 = Box::new(Literal(Field::U128(u128_num1)));
-        let u128_2 = Box::new(Literal(Field::U128(u128_num2)));
-        let int1 = Box::new(Literal(Field::Int(i_num1)));
-        let int2 = Box::new(Literal(Field::Int(i_num2)));
-        let i128_1 = Box::new(Literal(Field::I128(i128_num1)));
-        let i128_2 = Box::new(Literal(Field::I128(i128_num2)));
-        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
-        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
-        let dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
-        let dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
+        let mut uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let mut uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let mut u128_1 = Box::new(Literal(Field::U128(u128_num1)));
+        let mut u128_2 = Box::new(Literal(Field::U128(u128_num2)));
+        let mut int1 = Box::new(Literal(Field::Int(i_num1)));
+        let mut int2 = Box::new(Literal(Field::Int(i_num2)));
+        let mut i128_1 = Box::new(Literal(Field::I128(i128_num1)));
+        let mut i128_2 = Box::new(Literal(Field::I128(i128_num2)));
+        let mut float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let mut float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let mut dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
+        let mut dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
 
-        let null = Box::new(Literal(Field::Null));
+        let mut null = Box::new(Literal(Field::Null));
 
         //// left: Decimal, right: UInt
         assert_eq!(
             // Decimal + UInt = Decimal
-            evaluate_add(&Schema::default(), &dec1, &uint2, &row)
+            evaluate_add(&Schema::default(), &mut dec1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 + Decimal::from(u_num2))
         );
         assert_eq!(
             // Decimal - UInt = Decimal
-            evaluate_sub(&Schema::default(), &dec1, &uint2, &row)
+            evaluate_sub(&Schema::default(), &mut dec1, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 - Decimal::from(u_num2))
         );
         // Decimal * UInt = Decimal
-        let res = evaluate_mul(&Schema::default(), &dec2, &uint1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut dec2, &mut uint1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(d_num2.0 * Decimal::from(u_num1))
@@ -1589,7 +1589,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal / UInt = Decimal
-        let res = evaluate_div(&Schema::default(), &dec2, &uint1, &row);
+        let res = evaluate_div(&Schema::default(), &mut dec2, &mut uint1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1609,7 +1609,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal % UInt = Decimal
-        let res = evaluate_mod(&Schema::default(), &dec1, &uint2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut dec1, &mut uint2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1630,26 +1630,26 @@ fn test_decimal_math() {
         }
 
         //// left: Decimal, right: U128
-        let res = evaluate_add(&Schema::default(), &dec1, &u128_2, &row);
+        let res = evaluate_add(&Schema::default(), &mut dec1, &mut u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal + U128 = Decimal
-                evaluate_add(&Schema::default(), &dec1, &u128_2, &row)
+                evaluate_add(&Schema::default(), &mut dec1, &mut u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 + Decimal::from_u128(u128_num2).unwrap())
             );
         }
-        let res = evaluate_sub(&Schema::default(), &dec1, &u128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut dec1, &mut u128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal - U128 = Decimal
-                evaluate_sub(&Schema::default(), &dec1, &u128_2, &row)
+                evaluate_sub(&Schema::default(), &mut dec1, &mut u128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 - Decimal::from_u128(u128_num2).unwrap())
             );
         }
         // Decimal * U128 = Decimal
-        let res = evaluate_mul(&Schema::default(), &dec2, &u128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut dec2, &mut u128_1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(d_num2.0 * Decimal::from_u128(u128_num1).unwrap())
@@ -1664,7 +1664,7 @@ fn test_decimal_math() {
             }
         }
         // Decimal / U128 = Decimal
-        let res = evaluate_div(&Schema::default(), &dec2, &u128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut dec2, &mut u128_1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1688,7 +1688,7 @@ fn test_decimal_math() {
             }
         }
         // Decimal % U128 = Decimal
-        let res = evaluate_mod(&Schema::default(), &dec1, &u128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut dec1, &mut u128_2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             if !matches!(res, Err(PipelineError::UnableToCast(_, _))) {
@@ -1715,80 +1715,80 @@ fn test_decimal_math() {
         //// left: Decimal, right: Int
         assert_eq!(
             // Decimal + Int = Decimal
-            evaluate_add(&Schema::default(), &dec1, &int2, &row)
+            evaluate_add(&Schema::default(), &mut dec1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 + Decimal::from(i_num2))
         );
         assert_eq!(
             // Decimal - Int = Decimal
-            evaluate_sub(&Schema::default(), &dec1, &int2, &row)
+            evaluate_sub(&Schema::default(), &mut dec1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 - Decimal::from(i_num2))
         );
-        let res = evaluate_mul(&Schema::default(), &dec2, &int1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut dec2, &mut int1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal * Int = Decimal
-                evaluate_mul(&Schema::default(), &dec2, &int1, &row)
+                evaluate_mul(&Schema::default(), &mut dec2, &mut int1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num2.0 * Decimal::from(i_num1))
             );
         }
         assert_eq!(
             // Decimal / Int = Decimal
-            evaluate_div(&Schema::default(), &dec2, &int1, &row)
+            evaluate_div(&Schema::default(), &mut dec2, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num2.0 / Decimal::from(i_num1))
         );
         assert_eq!(
             // Decimal % Int = Decimal
-            evaluate_mod(&Schema::default(), &dec1, &int2, &row)
+            evaluate_mod(&Schema::default(), &mut dec1, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 % Decimal::from(i_num2))
         );
 
         //// left: Decimal, right: I128
-        let res = evaluate_add(&Schema::default(), &dec1, &i128_2, &row);
+        let res = evaluate_add(&Schema::default(), &mut dec1, &mut i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal + I128 = Decimal
-                evaluate_add(&Schema::default(), &dec1, &i128_2, &row)
+                evaluate_add(&Schema::default(), &mut dec1, &mut i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 + Decimal::from_i128(i128_num2).unwrap())
             );
         }
-        let res = evaluate_sub(&Schema::default(), &dec1, &i128_2, &row);
+        let res = evaluate_sub(&Schema::default(), &mut dec1, &mut i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal - I128 = Decimal
-                evaluate_sub(&Schema::default(), &dec1, &i128_2, &row)
+                evaluate_sub(&Schema::default(), &mut dec1, &mut i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 - Decimal::from_i128(i128_num2).unwrap())
             );
         }
-        let res = evaluate_mul(&Schema::default(), &dec2, &i128_1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut dec2, &mut i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal * I128 = Decimal
-                evaluate_mul(&Schema::default(), &dec2, &i128_1, &row)
+                evaluate_mul(&Schema::default(), &mut dec2, &mut i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num2.0 * Decimal::from_i128(i128_num1).unwrap())
             );
         }
-        let res = evaluate_div(&Schema::default(), &dec2, &i128_1, &row);
+        let res = evaluate_div(&Schema::default(), &mut dec2, &mut i128_1, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal / I128 = Decimal
-                evaluate_div(&Schema::default(), &dec2, &i128_1, &row)
+                evaluate_div(&Schema::default(), &mut dec2, &mut i128_1, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num2.0 / Decimal::from_i128(i128_num1).unwrap())
             );
         }
-        let res = evaluate_mod(&Schema::default(), &dec1, &i128_2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut dec1, &mut i128_2, &row);
         if res.is_ok() {
             assert_eq!(
                 // Decimal % I128 = Decimal
-                evaluate_mod(&Schema::default(), &dec1, &i128_2, &row)
+                evaluate_mod(&Schema::default(), &mut dec1, &mut i128_2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 % Decimal::from_i128(i128_num2).unwrap())
             );
@@ -1800,18 +1800,18 @@ fn test_decimal_math() {
         if d_val1.is_some() && d_val2.is_some() && d_val1.unwrap() != Decimal::new(0, 0) && d_val2.unwrap() != Decimal::new(0, 0) {
             assert_eq!(
                 // Decimal + Float = Decimal
-                evaluate_add(&Schema::default(), &dec1, &float2, &row)
+                evaluate_add(&Schema::default(), &mut dec1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 + d_val2.unwrap())
             );
             assert_eq!(
                 // Decimal - Float = Decimal
-                evaluate_sub(&Schema::default(), &dec1, &float2, &row)
+                evaluate_sub(&Schema::default(), &mut dec1, &mut float2, &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Decimal(d_num1.0 - d_val2.unwrap())
             );
             // Decimal * Float = Decimal
-            let res = evaluate_mul(&Schema::default(), &dec2, &float1, &row);
+            let res = evaluate_mul(&Schema::default(), &mut dec2, &mut float1, &row);
             if res.is_ok() {
                  assert_eq!(
                     res.unwrap(), Field::Decimal(d_num2.0 * d_val1.unwrap())
@@ -1824,7 +1824,7 @@ fn test_decimal_math() {
                 ));
             }
             // Decimal / Float = Decimal
-            let res = evaluate_div(&Schema::default(), &dec2, &float1, &row);
+            let res = evaluate_div(&Schema::default(), &mut dec2, &mut float1, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1844,7 +1844,7 @@ fn test_decimal_math() {
                 ));
             }
             // Decimal % Float = Decimal
-            let res = evaluate_mod(&Schema::default(), &dec1, &float2, &row);
+            let res = evaluate_mod(&Schema::default(), &mut dec1, &mut float2, &row);
             if d_num1.0 == Decimal::new(0, 0) {
                 assert!(res.is_err());
                 assert!(matches!(
@@ -1869,18 +1869,18 @@ fn test_decimal_math() {
         //// left: Decimal, right: Decimal
         assert_eq!(
             // Decimal + Decimal = Decimal
-            evaluate_add(&Schema::default(), &dec1, &dec2, &row)
+            evaluate_add(&Schema::default(), &mut dec1, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 + d_num2.0)
         );
         assert_eq!(
             // Decimal - Decimal = Decimal
-            evaluate_sub(&Schema::default(), &dec1, &dec2, &row)
+            evaluate_sub(&Schema::default(), &mut dec1, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Decimal(d_num1.0 - d_num2.0)
         );
         // Decimal * Decimal = Decimal
-        let res = evaluate_mul(&Schema::default(), &dec2, &dec1, &row);
+        let res = evaluate_mul(&Schema::default(), &mut dec2, &mut dec1, &row);
         if res.is_ok() {
              assert_eq!(
                 res.unwrap(), Field::Decimal(d_num2.0 * d_num1.0)
@@ -1893,7 +1893,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal / Decimal = Decimal
-        let res = evaluate_div(&Schema::default(), &dec2, &dec1, &row);
+        let res = evaluate_div(&Schema::default(), &mut dec2, &mut dec1, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1913,7 +1913,7 @@ fn test_decimal_math() {
             ));
         }
         // Decimal % Decimal = Decimal
-        let res = evaluate_mod(&Schema::default(), &dec1, &dec2, &row);
+        let res = evaluate_mod(&Schema::default(), &mut dec1, &mut dec2, &row);
         if d_num1.0 == Decimal::new(0, 0) {
             assert!(res.is_err());
             assert!(matches!(
@@ -1936,31 +1936,31 @@ fn test_decimal_math() {
         //// left: Decimal, right: Null
         assert_eq!(
             // Decimal + Null = Null
-            evaluate_add(&Schema::default(), &dec1, &null, &row)
+            evaluate_add(&Schema::default(), &mut dec1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal - Null = Null
-            evaluate_sub(&Schema::default(), &dec1, &null, &row)
+            evaluate_sub(&Schema::default(), &mut dec1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal * Null = Null
-            evaluate_mul(&Schema::default(), &dec2, &null, &row)
+            evaluate_mul(&Schema::default(), &mut dec2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Null = Null
-            evaluate_div(&Schema::default(), &dec2, &null, &row)
+            evaluate_div(&Schema::default(), &mut dec2, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Null = Null
-            evaluate_mod(&Schema::default(), &dec1, &null, &row)
+            evaluate_mod(&Schema::default(), &mut dec1, &mut null, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -1972,49 +1972,49 @@ fn test_null_math() {
     proptest!(ProptestConfig::with_cases(1000), move |(u_num1: u64, u_num2: u64, u128_num1: u128, u128_num2: u128, i_num1: i64, i_num2: i64, i128_num1: i128, i128_num2: i128, f_num1: f64, f_num2: f64, d_num1: ArbitraryDecimal, d_num2: ArbitraryDecimal)| {
         let row = Record::new(vec![]);
 
-        let uint1 = Box::new(Literal(Field::UInt(u_num1)));
-        let uint2 = Box::new(Literal(Field::UInt(u_num2)));
-        let u128_1 = Box::new(Literal(Field::U128(u128_num1)));
-        let u128_2 = Box::new(Literal(Field::U128(u128_num2)));
-        let int1 = Box::new(Literal(Field::Int(i_num1)));
-        let int2 = Box::new(Literal(Field::Int(i_num2)));
-        let i128_1 = Box::new(Literal(Field::I128(i128_num1)));
-        let i128_2 = Box::new(Literal(Field::I128(i128_num2)));
-        let float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
-        let float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
-        let dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
-        let dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
+        let mut uint1 = Box::new(Literal(Field::UInt(u_num1)));
+        let mut uint2 = Box::new(Literal(Field::UInt(u_num2)));
+        let mut u128_1 = Box::new(Literal(Field::U128(u128_num1)));
+        let mut u128_2 = Box::new(Literal(Field::U128(u128_num2)));
+        let mut int1 = Box::new(Literal(Field::Int(i_num1)));
+        let mut int2 = Box::new(Literal(Field::Int(i_num2)));
+        let mut i128_1 = Box::new(Literal(Field::I128(i128_num1)));
+        let mut i128_2 = Box::new(Literal(Field::I128(i128_num2)));
+        let mut float1 = Box::new(Literal(Field::Float(OrderedFloat(f_num1))));
+        let mut float2 = Box::new(Literal(Field::Float(OrderedFloat(f_num2))));
+        let mut dec1 = Box::new(Literal(Field::Decimal(d_num1.0)));
+        let mut dec2 = Box::new(Literal(Field::Decimal(d_num2.0)));
 
-        let null = Box::new(Literal(Field::Null));
+        let mut null = Box::new(Literal(Field::Null));
 
         //// left: Null, right: UInt
         assert_eq!(
             // Null + UInt = Null
-            evaluate_add(&Schema::default(), &null, &uint2, &row)
+            evaluate_add(&Schema::default(), &mut null, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - UInt = Null
-            evaluate_sub(&Schema::default(), &null, &uint2, &row)
+            evaluate_sub(&Schema::default(), &mut null, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * UInt = Null
-            evaluate_mul(&Schema::default(), &null, &uint1, &row)
+            evaluate_mul(&Schema::default(), &mut null, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / UInt = Null
-            evaluate_div(&Schema::default(), &null, &uint1, &row)
+            evaluate_div(&Schema::default(), &mut null, &mut uint1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % UInt = Null
-            evaluate_mod(&Schema::default(), &null, &uint2, &row)
+            evaluate_mod(&Schema::default(), &mut null, &mut uint2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2022,31 +2022,31 @@ fn test_null_math() {
         //// left: Null, right: U128
         assert_eq!(
             // Null + U128 = Null
-            evaluate_add(&Schema::default(), &null, &u128_2, &row)
+            evaluate_add(&Schema::default(), &mut null, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - U128 = Null
-            evaluate_sub(&Schema::default(), &null, &u128_2, &row)
+            evaluate_sub(&Schema::default(), &mut null, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * U128 = Null
-            evaluate_mul(&Schema::default(), &null, &u128_1, &row)
+            evaluate_mul(&Schema::default(), &mut null, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / U128 = Null
-            evaluate_div(&Schema::default(), &null, &u128_1, &row)
+            evaluate_div(&Schema::default(), &mut null, &mut u128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % U128 = Null
-            evaluate_mod(&Schema::default(), &null, &u128_2, &row)
+            evaluate_mod(&Schema::default(), &mut null, &mut u128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2054,31 +2054,31 @@ fn test_null_math() {
         //// left: Null, right: Int
         assert_eq!(
             // Null + Int = Null
-            evaluate_add(&Schema::default(), &null, &int2, &row)
+            evaluate_add(&Schema::default(), &mut null, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Int = Null
-            evaluate_sub(&Schema::default(), &null, &int2, &row)
+            evaluate_sub(&Schema::default(), &mut null, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Int = Null
-            evaluate_mul(&Schema::default(), &null, &int1, &row)
+            evaluate_mul(&Schema::default(), &mut null, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Int = Null
-            evaluate_div(&Schema::default(), &null, &int1, &row)
+            evaluate_div(&Schema::default(), &mut null, &mut int1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Int = Null
-            evaluate_mod(&Schema::default(), &null, &int2, &row)
+            evaluate_mod(&Schema::default(), &mut null, &mut int2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2086,31 +2086,31 @@ fn test_null_math() {
         //// left: Null, right: I128
         assert_eq!(
             // Null + I128 = Null
-            evaluate_add(&Schema::default(), &null, &i128_2, &row)
+            evaluate_add(&Schema::default(), &mut null, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - I128 = Null
-            evaluate_sub(&Schema::default(), &null, &i128_2, &row)
+            evaluate_sub(&Schema::default(), &mut null, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * I128 = Null
-            evaluate_mul(&Schema::default(), &null, &i128_1, &row)
+            evaluate_mul(&Schema::default(), &mut null, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / I128 = Null
-            evaluate_div(&Schema::default(), &null, &i128_1, &row)
+            evaluate_div(&Schema::default(), &mut null, &mut i128_1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % I128 = Null
-            evaluate_mod(&Schema::default(), &null, &i128_2, &row)
+            evaluate_mod(&Schema::default(), &mut null, &mut i128_2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2118,31 +2118,31 @@ fn test_null_math() {
         //// left: Null, right: Float
         assert_eq!(
             // Null + Float = Null
-            evaluate_add(&Schema::default(), &null, &float2, &row)
+            evaluate_add(&Schema::default(), &mut null, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Float = Null
-            evaluate_sub(&Schema::default(), &null, &float2, &row)
+            evaluate_sub(&Schema::default(), &mut null, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Float = Null
-            evaluate_mul(&Schema::default(), &null, &float1, &row)
+            evaluate_mul(&Schema::default(), &mut null, &mut float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Float = Null
-            evaluate_div(&Schema::default(), &null, &float1, &row)
+            evaluate_div(&Schema::default(), &mut null, &mut float1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Float = Null
-            evaluate_mod(&Schema::default(), &null, &float2, &row)
+            evaluate_mod(&Schema::default(), &mut null, &mut float2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2150,63 +2150,64 @@ fn test_null_math() {
         //// left: Null, right: Decimal
         assert_eq!(
             // Null + Decimal = Null
-            evaluate_add(&Schema::default(), &null, &dec2, &row)
+            evaluate_add(&Schema::default(), &mut null, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Decimal = Null
-            evaluate_sub(&Schema::default(), &null, &dec2, &row)
+            evaluate_sub(&Schema::default(), &mut null, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Decimal = Null
-            evaluate_mul(&Schema::default(), &null, &dec1, &row)
+            evaluate_mul(&Schema::default(), &mut null, &mut dec1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Decimal = Null
-            evaluate_div(&Schema::default(), &null, &dec1, &row)
+            evaluate_div(&Schema::default(), &mut null, &mut dec1, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Decimal = Null
-            evaluate_mod(&Schema::default(), &null, &dec2, &row)
+            evaluate_mod(&Schema::default(), &mut null, &mut dec2, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
 
         //// left: Null, right: Null
+        let mut null_clone = null.clone();
         assert_eq!(
             // Null + Null = Null
-            evaluate_add(&Schema::default(), &null, &null, &row)
+            evaluate_add(&Schema::default(), &mut null, &mut null_clone, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null - Null = Null
-            evaluate_sub(&Schema::default(), &null, &null, &row)
+            evaluate_sub(&Schema::default(), &mut null, &mut null_clone, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Null * Null = Null
-            evaluate_mul(&Schema::default(), &null, &null, &row)
+            evaluate_mul(&Schema::default(), &mut null, &mut null_clone, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal / Null = Null
-            evaluate_div(&Schema::default(), &null, &null, &row)
+            evaluate_div(&Schema::default(), &mut null, &mut null_clone, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
         assert_eq!(
             // Decimal % Null = Null
-            evaluate_mod(&Schema::default(), &null, &null, &row)
+            evaluate_mod(&Schema::default(), &mut null, &mut null_clone, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Null
         );
@@ -2243,8 +2244,8 @@ fn test_timestamp_difference() {
 
     let result = evaluate_sub(
         &schema,
-        &Expression::Column { index: 0 },
-        &Expression::Column { index: 1 },
+        &mut Expression::Column { index: 0 },
+        &mut Expression::Column { index: 1 },
         &record,
     )
     .unwrap();
@@ -2258,8 +2259,8 @@ fn test_timestamp_difference() {
 
     let result = evaluate_sub(
         &schema,
-        &Expression::Column { index: 1 },
-        &Expression::Column { index: 0 },
+        &mut Expression::Column { index: 1 },
+        &mut Expression::Column { index: 0 },
         &record,
     );
     assert!(result.is_err());
@@ -2277,18 +2278,18 @@ fn test_duration() {
 fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
     let row = Record::new(vec![]);
 
-    let v = Expression::Literal(Field::Date(dt1.0.date_naive()));
-    let dur1 = Expression::Literal(Field::Duration(DozerDuration(
+    let mut v = Expression::Literal(Field::Date(dt1.0.date_naive()));
+    let mut dur1 = Expression::Literal(Field::Duration(DozerDuration(
         std::time::Duration::from_nanos(d1),
         TimeUnit::Nanoseconds,
     )));
-    let dur2 = Expression::Literal(Field::Duration(DozerDuration(
+    let mut dur2 = Expression::Literal(Field::Duration(DozerDuration(
         std::time::Duration::from_nanos(d2),
         TimeUnit::Nanoseconds,
     )));
 
     // Duration + Duration = Duration
-    let result = evaluate_add(&Schema::default(), &dur1, &dur2, &row);
+    let result = evaluate_add(&Schema::default(), &mut dur1, &mut dur2, &row);
     let sum = std::time::Duration::from_nanos(d1).checked_add(std::time::Duration::from_nanos(d2));
     if result.is_ok() && sum.is_some() {
         assert_eq!(
@@ -2297,7 +2298,7 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         );
     }
     // Duration - Duration = Duration
-    let result = evaluate_sub(&Schema::default(), &dur1, &dur2, &row);
+    let result = evaluate_sub(&Schema::default(), &mut dur1, &mut dur2, &row);
     let diff = std::time::Duration::from_nanos(d1).checked_sub(std::time::Duration::from_nanos(d2));
     if result.is_ok() && diff.is_some() {
         assert_eq!(
@@ -2306,33 +2307,33 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         );
     }
     // Duration * Duration = Error
-    let result = evaluate_mul(&Schema::default(), &dur1, &dur2, &row);
+    let result = evaluate_mul(&Schema::default(), &mut dur1, &mut dur2, &row);
     assert!(result.is_err());
     // Duration / Duration = Error
-    let result = evaluate_div(&Schema::default(), &dur1, &dur2, &row);
+    let result = evaluate_div(&Schema::default(), &mut dur1, &mut dur2, &row);
     assert!(result.is_err());
     // Duration % Duration = Error
-    let result = evaluate_mod(&Schema::default(), &dur1, &dur2, &row);
+    let result = evaluate_mod(&Schema::default(), &mut dur1, &mut dur2, &row);
     assert!(result.is_err());
 
     // Duration + Timestamp = Error
-    let result = evaluate_add(&Schema::default(), &dur1, &v, &row);
+    let result = evaluate_add(&Schema::default(), &mut dur1, &mut v, &row);
     assert!(result.is_err());
     // Duration - Timestamp = Error
-    let result = evaluate_sub(&Schema::default(), &dur1, &v, &row);
+    let result = evaluate_sub(&Schema::default(), &mut dur1, &mut v, &row);
     assert!(result.is_err());
     // Duration * Timestamp = Error
-    let result = evaluate_mul(&Schema::default(), &dur1, &v, &row);
+    let result = evaluate_mul(&Schema::default(), &mut dur1, &mut v, &row);
     assert!(result.is_err());
     // Duration / Timestamp = Error
-    let result = evaluate_div(&Schema::default(), &dur1, &v, &row);
+    let result = evaluate_div(&Schema::default(), &mut dur1, &mut v, &row);
     assert!(result.is_err());
     // Duration % Timestamp = Error
-    let result = evaluate_mod(&Schema::default(), &dur1, &v, &row);
+    let result = evaluate_mod(&Schema::default(), &mut dur1, &mut v, &row);
     assert!(result.is_err());
 
     // Timestamp + Duration = Timestamp
-    let result = evaluate_add(&Schema::default(), &v, &dur1, &row);
+    let result = evaluate_add(&Schema::default(), &mut v, &mut dur1, &row);
     let sum = dt1
         .0
         .checked_add_signed(chrono::Duration::nanoseconds(d1 as i64));
@@ -2340,7 +2341,7 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         assert_eq!(result.unwrap(), Field::Timestamp(sum.unwrap()));
     }
     // Timestamp - Duration = Timestamp
-    let result = evaluate_sub(&Schema::default(), &v, &dur2, &row);
+    let result = evaluate_sub(&Schema::default(), &mut v, &mut dur2, &row);
     let diff = dt1
         .0
         .checked_sub_signed(chrono::Duration::nanoseconds(d2 as i64));
@@ -2348,110 +2349,110 @@ fn test_duration_math(d1: u64, d2: u64, dt1: ArbitraryDateTime) {
         assert_eq!(result.unwrap(), Field::Timestamp(diff.unwrap()));
     }
     // Timestamp * Duration = Error
-    let result = evaluate_mul(&Schema::default(), &v, &dur1, &row);
+    let result = evaluate_mul(&Schema::default(), &mut v, &mut dur1, &row);
     assert!(result.is_err());
     // Timestamp / Duration = Error
-    let result = evaluate_div(&Schema::default(), &v, &dur1, &row);
+    let result = evaluate_div(&Schema::default(), &mut v, &mut dur1, &row);
     assert!(result.is_err());
     // Timestamp % Duration = Error
-    let result = evaluate_mod(&Schema::default(), &v, &dur1, &row);
+    let result = evaluate_mod(&Schema::default(), &mut v, &mut dur1, &row);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_decimal() {
-    let dec1 = Box::new(Literal(Field::Decimal(Decimal::from_i64(1_i64).unwrap())));
-    let dec2 = Box::new(Literal(Field::Decimal(Decimal::from_i64(2_i64).unwrap())));
-    let float1 = Box::new(Literal(Field::Float(
+    let mut dec1 = Box::new(Literal(Field::Decimal(Decimal::from_i64(1_i64).unwrap())));
+    let mut dec2 = Box::new(Literal(Field::Decimal(Decimal::from_i64(2_i64).unwrap())));
+    let mut float1 = Box::new(Literal(Field::Float(
         OrderedFloat::<f64>::from_i64(1_i64).unwrap(),
     )));
-    let float2 = Box::new(Literal(Field::Float(
+    let mut float2 = Box::new(Literal(Field::Float(
         OrderedFloat::<f64>::from_i64(2_i64).unwrap(),
     )));
-    let int1 = Box::new(Literal(Field::Int(1_i64)));
-    let int2 = Box::new(Literal(Field::Int(2_i64)));
-    let uint1 = Box::new(Literal(Field::UInt(1_u64)));
-    let uint2 = Box::new(Literal(Field::UInt(2_u64)));
+    let mut int1 = Box::new(Literal(Field::Int(1_i64)));
+    let mut int2 = Box::new(Literal(Field::Int(2_i64)));
+    let mut uint1 = Box::new(Literal(Field::UInt(1_u64)));
+    let mut uint2 = Box::new(Literal(Field::UInt(2_u64)));
 
     let row = Record::new(vec![]);
 
     // left: Int, right: Decimal
     assert_eq!(
-        evaluate_add(&Schema::default(), &int1, dec1.as_ref(), &row)
+        evaluate_add(&Schema::default(), &mut int1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_sub(&Schema::default(), &int1, dec1.as_ref(), &row)
+        evaluate_sub(&Schema::default(), &mut int1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
     assert_eq!(
-        evaluate_mul(&Schema::default(), &int2, dec1.as_ref(), &row)
+        evaluate_mul(&Schema::default(), &mut int2, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_div(&Schema::default(), &int1, dec2.as_ref(), &row)
+        evaluate_div(&Schema::default(), &mut int1, dec2.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_f64(0.5).unwrap())
     );
     assert_eq!(
-        evaluate_mod(&Schema::default(), &int1, dec1.as_ref(), &row)
+        evaluate_mod(&Schema::default(), &mut int1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
 
     // left: UInt, right: Decimal
     assert_eq!(
-        evaluate_add(&Schema::default(), &uint1, dec1.as_ref(), &row)
+        evaluate_add(&Schema::default(), &mut uint1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_sub(&Schema::default(), &uint1, dec1.as_ref(), &row)
+        evaluate_sub(&Schema::default(), &mut uint1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
     assert_eq!(
-        evaluate_mul(&Schema::default(), &uint2, dec1.as_ref(), &row)
+        evaluate_mul(&Schema::default(), &mut uint2, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_div(&Schema::default(), &uint1, dec2.as_ref(), &row)
+        evaluate_div(&Schema::default(), &mut uint1, dec2.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_f64(0.5).unwrap())
     );
     assert_eq!(
-        evaluate_mod(&Schema::default(), &uint1, dec1.as_ref(), &row)
+        evaluate_mod(&Schema::default(), &mut uint1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
 
     // left: Float, right: Decimal
     assert_eq!(
-        evaluate_add(&Schema::default(), &float1, dec1.as_ref(), &row)
+        evaluate_add(&Schema::default(), &mut float1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_sub(&Schema::default(), &float1, dec1.as_ref(), &row)
+        evaluate_sub(&Schema::default(), &mut float1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );
     assert_eq!(
-        evaluate_mul(&Schema::default(), &float2, dec1.as_ref(), &row)
+        evaluate_mul(&Schema::default(), &mut float2, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(2_i64).unwrap())
     );
     assert_eq!(
-        evaluate_div(&Schema::default(), &float1, dec2.as_ref(), &row)
+        evaluate_div(&Schema::default(), &mut float1, dec2.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_f64(0.5).unwrap())
     );
     assert_eq!(
-        evaluate_mod(&Schema::default(), &float1, dec1.as_ref(), &row)
+        evaluate_mod(&Schema::default(), &mut float1, dec1.as_mut(), &row)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Decimal(Decimal::from_i64(0_i64).unwrap())
     );

--- a/dozer-sql/expression/src/onnx/udf.rs
+++ b/dozer-sql/expression/src/onnx/udf.rs
@@ -18,11 +18,11 @@ use std::ops::Deref;
 pub fn evaluate_onnx_udf(
     schema: &Schema,
     session: &Session,
-    args: &[Expression],
+    args: &mut [Expression],
     record: &Record,
 ) -> Result<Field, Error> {
     let input_values = args
-        .iter()
+        .iter_mut()
         .map(|arg| arg.evaluate(record, schema))
         .collect::<Result<Vec<_>, Error>>()?;
 

--- a/dozer-sql/expression/src/operator.rs
+++ b/dozer-sql/expression/src/operator.rs
@@ -28,7 +28,7 @@ impl UnaryOperatorType {
     pub fn evaluate(
         &self,
         schema: &Schema,
-        value: &Expression,
+        value: &mut Expression,
         record: &Record,
     ) -> Result<Field, Error> {
         match self {
@@ -85,8 +85,8 @@ impl BinaryOperatorType {
     pub fn evaluate(
         &self,
         schema: &Schema,
-        left: &Expression,
-        right: &Expression,
+        left: &mut Expression,
+        right: &mut Expression,
         record: &Record,
     ) -> Result<Field, Error> {
         match self {

--- a/dozer-sql/expression/src/python_udf.rs
+++ b/dozer-sql/expression/src/python_udf.rs
@@ -29,12 +29,12 @@ pub enum Error {
 pub fn evaluate_py_udf(
     schema: &Schema,
     name: &str,
-    args: &[Expression],
+    args: &mut [Expression],
     return_type: &FieldType,
     record: &Record,
 ) -> Result<Field, crate::error::Error> {
     let values = args
-        .iter()
+        .iter_mut()
         .map(|arg| arg.evaluate(record, schema))
         .collect::<Result<Vec<_>, crate::error::Error>>()?;
 

--- a/dozer-sql/expression/src/scalar/common.rs
+++ b/dozer-sql/expression/src/scalar/common.rs
@@ -92,30 +92,32 @@ impl ScalarFunctionType {
     pub(crate) fn evaluate(
         &self,
         schema: &Schema,
-        args: &[Expression],
+        args: &mut [Expression],
         record: &Record,
     ) -> Result<Field, Error> {
         match self {
             ScalarFunctionType::Abs => {
                 validate_num_arguments(1..2, args.len(), ScalarFunctionType::Abs)?;
-                evaluate_abs(schema, &args[0], record)
+                evaluate_abs(schema, &mut args[0], record)
             }
             ScalarFunctionType::Round => {
                 validate_num_arguments(1..3, args.len(), ScalarFunctionType::Round)?;
-                evaluate_round(schema, &args[0], args.get(1), record)
+                let (arg0, arg1) = args.split_at_mut(1);
+                evaluate_round(schema, &mut arg0[0], arg1.get_mut(0), record)
             }
             ScalarFunctionType::Ucase => {
                 validate_num_arguments(1..2, args.len(), ScalarFunctionType::Ucase)?;
-                evaluate_ucase(schema, &args[0], record)
+                evaluate_ucase(schema, &mut args[0], record)
             }
             ScalarFunctionType::Concat => evaluate_concat(schema, args, record),
             ScalarFunctionType::Length => {
                 validate_num_arguments(1..2, args.len(), ScalarFunctionType::Length)?;
-                evaluate_length(schema, &args[0], record)
+                evaluate_length(schema, &mut args[0], record)
             }
             ScalarFunctionType::ToChar => {
                 validate_num_arguments(2..3, args.len(), ScalarFunctionType::ToChar)?;
-                evaluate_to_char(schema, &args[0], &args[1], record)
+                let (arg0, arg1) = args.split_at_mut(1);
+                evaluate_to_char(schema, &mut arg0[0], &mut arg1[0], record)
             }
         }
     }

--- a/dozer-sql/expression/src/scalar/number.rs
+++ b/dozer-sql/expression/src/scalar/number.rs
@@ -8,7 +8,7 @@ use num_traits::{Float, ToPrimitive};
 
 pub(crate) fn evaluate_abs(
     schema: &Schema,
-    arg: &Expression,
+    arg: &mut Expression,
     record: &Record,
 ) -> Result<Field, Error> {
     let value = arg.evaluate(record, schema)?;
@@ -38,8 +38,8 @@ pub(crate) fn evaluate_abs(
 
 pub(crate) fn evaluate_round(
     schema: &Schema,
-    arg: &Expression,
-    decimals: Option<&Expression>,
+    arg: &mut Expression,
+    decimals: Option<&mut Expression>,
     record: &Record,
 ) -> Result<Field, Error> {
     let value = arg.evaluate(record, schema)?;
@@ -115,18 +115,18 @@ mod tests {
         proptest!(ProptestConfig::with_cases(1000), |(i_num in 0i64..100000000i64, f_num in 0f64..100000000f64)| {
         let row = Record::new(vec![]);
 
-        let v = Box::new(Literal(Field::Int(i_num.neg())));
+        let mut v = Box::new(Literal(Field::Int(i_num.neg())));
         assert_eq!(
-            evaluate_abs(&Schema::default(), &v, &row)
+            evaluate_abs(&Schema::default(), &mut v, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Int(i_num)
         );
 
         let row = Record::new(vec![]);
 
-        let v = Box::new(Literal(Field::Float(OrderedFloat(f_num.neg()))));
+        let mut v = Box::new(Literal(Field::Float(OrderedFloat(f_num.neg()))));
         assert_eq!(
-            evaluate_abs(&Schema::default(), &v, &row)
+            evaluate_abs(&Schema::default(), &mut v, &row)
                 .unwrap_or_else(|e| panic!("{}", e.to_string())),
             Field::Float(OrderedFloat(f_num))
         );
@@ -138,52 +138,52 @@ mod tests {
         proptest!(ProptestConfig::with_cases(1000), |(i_num: i64, f_num: f64, i_pow: i32, f_pow: f32)| {
             let row = Record::new(vec![]);
 
-            let v = Box::new(Literal(Field::Int(i_num)));
-            let d = &Box::new(Literal(Field::Int(0)));
+            let mut v = Box::new(Literal(Field::Int(i_num)));
+            let d = &mut Box::new(Literal(Field::Int(0)));
             assert_eq!(
-                evaluate_round(&Schema::default(), &v, Some(d), &row)
+                evaluate_round(&Schema::default(), &mut v, Some(d), &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Int(i_num)
             );
 
-            let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
-            let d = &Box::new(Literal(Field::Int(0)));
+            let mut v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+            let d = &mut Box::new(Literal(Field::Int(0)));
             assert_eq!(
-                evaluate_round(&Schema::default(), &v, Some(d), &row)
+                evaluate_round(&Schema::default(), &mut v, Some(d), &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num.round()))
             );
 
-            let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
-            let d = &Box::new(Literal(Field::Int(i_pow as i64)));
+            let mut v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+            let d = &mut Box::new(Literal(Field::Int(i_pow as i64)));
             let order = 10.0_f64.powi(i_pow);
             assert_eq!(
-                evaluate_round(&Schema::default(), &v, Some(d), &row)
+                evaluate_round(&Schema::default(), &mut v, Some(d), &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat((f_num * order).round() / order))
             );
 
-            let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
-            let d = &Box::new(Literal(Field::Float(OrderedFloat(f_pow as f64))));
+            let mut v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+            let d = &mut Box::new(Literal(Field::Float(OrderedFloat(f_pow as f64))));
             let order = 10.0_f64.powi(f_pow.round() as i32);
             assert_eq!(
-                evaluate_round(&Schema::default(), &v, Some(d), &row)
+                evaluate_round(&Schema::default(), &mut v, Some(d), &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat((f_num * order).round() / order))
             );
 
-            let v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
-            let d = &Box::new(Literal(Field::String(f_pow.to_string())));
+            let mut v = Box::new(Literal(Field::Float(OrderedFloat(f_num))));
+            let d = &mut Box::new(Literal(Field::String(f_pow.to_string())));
             assert_eq!(
-                evaluate_round(&Schema::default(), &v, Some(d), &row)
+                evaluate_round(&Schema::default(), &mut v, Some(d), &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Float(OrderedFloat(f_num.round()))
             );
 
-            let v = Box::new(Literal(Field::Null));
-            let d = &Box::new(Literal(Field::String(i_pow.to_string())));
+            let mut v = Box::new(Literal(Field::Null));
+            let d = &mut Box::new(Literal(Field::String(i_pow.to_string())));
             assert_eq!(
-                evaluate_round(&Schema::default(), &v, Some(d), &row)
+                evaluate_round(&Schema::default(), &mut v, Some(d), &row)
                     .unwrap_or_else(|e| panic!("{}", e.to_string())),
                 Field::Null
             );

--- a/dozer-sql/expression/src/scalar/string.rs
+++ b/dozer-sql/expression/src/scalar/string.rs
@@ -21,7 +21,11 @@ pub(crate) fn validate_ucase(arg: &Expression, schema: &Schema) -> Result<Expres
     )
 }
 
-pub fn evaluate_ucase(schema: &Schema, arg: &Expression, record: &Record) -> Result<Field, Error> {
+pub fn evaluate_ucase(
+    schema: &Schema,
+    arg: &mut Expression,
+    record: &Record,
+) -> Result<Field, Error> {
     let f = arg.evaluate(record, schema)?;
     let v = f.to_string();
     let ret = v.to_uppercase();
@@ -69,7 +73,7 @@ pub fn validate_concat(args: &[Expression], schema: &Schema) -> Result<Expressio
 
 pub fn evaluate_concat(
     schema: &Schema,
-    args: &[Expression],
+    args: &mut [Expression],
     record: &Record,
 ) -> Result<Field, Error> {
     let mut res_type = FieldType::String;
@@ -106,7 +110,7 @@ pub fn evaluate_concat(
 
 pub(crate) fn evaluate_length(
     schema: &Schema,
-    arg0: &Expression,
+    arg0: &mut Expression,
     record: &Record,
 ) -> Result<Field, Error> {
     let f0 = arg0.evaluate(record, schema)?;
@@ -143,8 +147,8 @@ pub fn validate_trim(arg: &Expression, schema: &Schema) -> Result<ExpressionType
 
 pub fn evaluate_trim(
     schema: &Schema,
-    arg: &Expression,
-    what: &Option<Box<Expression>>,
+    arg: &mut Expression,
+    what: &mut Option<Box<Expression>>,
     typ: &Option<TrimType>,
     record: &Record,
 ) -> Result<Field, Error> {
@@ -209,8 +213,8 @@ pub(crate) fn get_like_operator_type(
 
 pub fn evaluate_like(
     schema: &Schema,
-    arg: &Expression,
-    pattern: &Expression,
+    arg: &mut Expression,
+    pattern: &mut Expression,
     escape: Option<char>,
     record: &Record,
 ) -> Result<Field, Error> {
@@ -235,8 +239,8 @@ pub fn evaluate_like(
 
 pub(crate) fn evaluate_to_char(
     schema: &Schema,
-    arg: &Expression,
-    pattern: &Expression,
+    arg: &mut Expression,
+    pattern: &mut Expression,
     record: &Record,
 ) -> Result<Field, Error> {
     let arg_field = arg.evaluate(record, schema)?;
@@ -291,90 +295,90 @@ mod tests {
         let row = Record::new(vec![]);
 
         // Field::String
-        let value = Box::new(Literal(Field::String(format!("Hello{}", s_val))));
-        let pattern = Box::new(Literal(Field::String("Hello%".to_owned())));
+        let mut value = Box::new(Literal(Field::String(format!("Hello{}", s_val))));
+        let mut pattern = Box::new(Literal(Field::String("Hello%".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(true)
         );
 
-        let value = Box::new(Literal(Field::String(format!("Hello, {}orld!", c_val))));
-        let pattern = Box::new(Literal(Field::String("Hello, _orld!".to_owned())));
+        let mut value = Box::new(Literal(Field::String(format!("Hello, {}orld!", c_val))));
+        let mut pattern = Box::new(Literal(Field::String("Hello, _orld!".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(true)
         );
 
-        let value = Box::new(Literal(Field::String(s_val.to_string())));
-        let pattern = Box::new(Literal(Field::String("Hello%".to_owned())));
+        let mut value = Box::new(Literal(Field::String(s_val.to_string())));
+        let mut pattern = Box::new(Literal(Field::String("Hello%".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(false)
         );
 
         let c_value = &s_val[0..0];
-        let value = Box::new(Literal(Field::String(format!("Hello, {}!", c_value))));
-        let pattern = Box::new(Literal(Field::String("Hello, _!".to_owned())));
+        let mut value = Box::new(Literal(Field::String(format!("Hello, {}!", c_value))));
+        let mut pattern = Box::new(Literal(Field::String("Hello, _!".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(false)
         );
 
         // todo: should find the way to generate escape character using proptest
-        // let value = Box::new(Literal(Field::String(format!("Hello, {}%", c_val))));
-        // let pattern = Box::new(Literal(Field::String("Hello, %".to_owned())));
+        // let mut value = Box::new(Literal(Field::String(format!("Hello, {}%", c_val))));
+        // let mut pattern = Box::new(Literal(Field::String("Hello, %".to_owned())));
         // let escape = Some(c_val);
         //
         // assert_eq!(
-        //     evaluate_like(&Schema::default(), &value, &pattern, escape, &row).unwrap(),
+        //     evaluate_like(&Schema::default(), &mut value, &mut pattern, escape, &row).unwrap(),
         //     Field::Boolean(true)
         // );
 
         // Field::Text
-        let value = Box::new(Literal(Field::Text(format!("Hello{}", s_val))));
-        let pattern = Box::new(Literal(Field::Text("Hello%".to_owned())));
+        let mut value = Box::new(Literal(Field::Text(format!("Hello{}", s_val))));
+        let mut pattern = Box::new(Literal(Field::Text("Hello%".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(true)
         );
 
-        let value = Box::new(Literal(Field::Text(format!("Hello, {}orld!", c_val))));
-        let pattern = Box::new(Literal(Field::Text("Hello, _orld!".to_owned())));
+        let mut value = Box::new(Literal(Field::Text(format!("Hello, {}orld!", c_val))));
+        let mut pattern = Box::new(Literal(Field::Text("Hello, _orld!".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(true)
         );
 
-        let value = Box::new(Literal(Field::Text(s_val.to_string())));
-        let pattern = Box::new(Literal(Field::Text("Hello%".to_owned())));
+        let mut value = Box::new(Literal(Field::Text(s_val.to_string())));
+        let mut pattern = Box::new(Literal(Field::Text("Hello%".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(false)
         );
 
         let c_value = &s_val[0..0];
-        let value = Box::new(Literal(Field::Text(format!("Hello, {}!", c_value))));
-        let pattern = Box::new(Literal(Field::Text("Hello, _!".to_owned())));
+        let mut value = Box::new(Literal(Field::Text(format!("Hello, {}!", c_value))));
+        let mut pattern = Box::new(Literal(Field::Text("Hello, _!".to_owned())));
 
         assert_eq!(
-            evaluate_like(&Schema::default(), &value, &pattern, None, &row).unwrap(),
+            evaluate_like(&Schema::default(), &mut value, &mut pattern, None, &row).unwrap(),
             Field::Boolean(false)
         );
 
         // todo: should find the way to generate escape character using proptest
-        // let value = Box::new(Literal(Field::Text(format!("Hello, {}%", c_val))));
-        // let pattern = Box::new(Literal(Field::Text("Hello, %".to_owned())));
+        // let mut value = Box::new(Literal(Field::Text(format!("Hello, {}%", c_val))));
+        // let mut pattern = Box::new(Literal(Field::Text("Hello, %".to_owned())));
         // let escape = Some(c_val);
         //
         // assert_eq!(
-        //     evaluate_like(&Schema::default(), &value, &pattern, escape, &row).unwrap(),
+        //     evaluate_like(&Schema::default(), &mut value, &mut pattern, escape, &row).unwrap(),
         //     Field::Boolean(true)
         // );
     }
@@ -383,28 +387,28 @@ mod tests {
         let row = Record::new(vec![]);
 
         // Field::String
-        let value = Box::new(Literal(Field::String(s_val.to_string())));
+        let mut value = Box::new(Literal(Field::String(s_val.to_string())));
         assert_eq!(
-            evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
+            evaluate_ucase(&Schema::default(), &mut value, &row).unwrap(),
             Field::String(s_val.to_uppercase())
         );
 
-        let value = Box::new(Literal(Field::String(c_val.to_string())));
+        let mut value = Box::new(Literal(Field::String(c_val.to_string())));
         assert_eq!(
-            evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
+            evaluate_ucase(&Schema::default(), &mut value, &row).unwrap(),
             Field::String(c_val.to_uppercase().to_string())
         );
 
         // Field::Text
-        let value = Box::new(Literal(Field::Text(s_val.to_string())));
+        let mut value = Box::new(Literal(Field::Text(s_val.to_string())));
         assert_eq!(
-            evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
+            evaluate_ucase(&Schema::default(), &mut value, &row).unwrap(),
             Field::Text(s_val.to_uppercase())
         );
 
-        let value = Box::new(Literal(Field::Text(c_val.to_string())));
+        let mut value = Box::new(Literal(Field::Text(c_val.to_string())));
         assert_eq!(
-            evaluate_ucase(&Schema::default(), &value, &row).unwrap(),
+            evaluate_ucase(&Schema::default(), &mut value, &row).unwrap(),
             Field::Text(c_val.to_uppercase().to_string())
         );
     }
@@ -418,7 +422,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::String(s_val1.to_string() + s_val2)
             );
         }
@@ -428,7 +432,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::String(s_val2.to_string() + s_val1)
             );
         }
@@ -438,7 +442,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::String(s_val1.to_string() + c_val.to_string().as_str())
             );
         }
@@ -448,7 +452,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::String(c_val.to_string() + s_val1)
             );
         }
@@ -459,7 +463,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::Text(s_val1.to_string() + s_val2)
             );
         }
@@ -469,7 +473,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::Text(s_val2.to_string() + s_val1)
             );
         }
@@ -479,7 +483,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::Text(s_val1.to_string() + c_val.to_string().as_str())
             );
         }
@@ -489,7 +493,7 @@ mod tests {
 
         if validate_concat(&[val1.clone(), val2.clone()], &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_concat(&Schema::default(), &[val1, val2], &row).unwrap(),
+                evaluate_concat(&Schema::default(), &mut [val1, val2], &row).unwrap(),
                 Field::Text(c_val.to_string() + s_val1)
             );
         }
@@ -499,19 +503,19 @@ mod tests {
         let row = Record::new(vec![]);
 
         // Field::String
-        let value = Literal(Field::String(s_val1.to_string()));
+        let mut value = Literal(Field::String(s_val1.to_string()));
         let what = ' ';
 
         if validate_trim(&value, &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_trim(&Schema::default(), &value, &None, &None, &row).unwrap(),
+                evaluate_trim(&Schema::default(), &mut value, &mut None, &None, &row).unwrap(),
                 Field::String(s_val1.trim_matches(what).to_string())
             );
             assert_eq!(
                 evaluate_trim(
                     &Schema::default(),
-                    &value,
-                    &None,
+                    &mut value,
+                    &mut None,
                     &Some(TrimType::Trailing),
                     &row
                 )
@@ -521,8 +525,8 @@ mod tests {
             assert_eq!(
                 evaluate_trim(
                     &Schema::default(),
-                    &value,
-                    &None,
+                    &mut value,
+                    &mut None,
                     &Some(TrimType::Leading),
                     &row
                 )
@@ -532,8 +536,8 @@ mod tests {
             assert_eq!(
                 evaluate_trim(
                     &Schema::default(),
-                    &value,
-                    &None,
+                    &mut value,
+                    &mut None,
                     &Some(TrimType::Both),
                     &row
                 )
@@ -542,19 +546,19 @@ mod tests {
             );
         }
 
-        let value = Literal(Field::String(s_val1.to_string()));
-        let what = Some(Box::new(Literal(Field::String(c_val.to_string()))));
+        let mut value = Literal(Field::String(s_val1.to_string()));
+        let mut what = Some(Box::new(Literal(Field::String(c_val.to_string()))));
 
         if validate_trim(&value, &Schema::default()).is_ok() {
             assert_eq!(
-                evaluate_trim(&Schema::default(), &value, &what, &None, &row).unwrap(),
+                evaluate_trim(&Schema::default(), &mut value, &mut what, &None, &row).unwrap(),
                 Field::String(s_val1.trim_matches(c_val).to_string())
             );
             assert_eq!(
                 evaluate_trim(
                     &Schema::default(),
-                    &value,
-                    &what,
+                    &mut value,
+                    &mut what,
                     &Some(TrimType::Trailing),
                     &row
                 )
@@ -564,8 +568,8 @@ mod tests {
             assert_eq!(
                 evaluate_trim(
                     &Schema::default(),
-                    &value,
-                    &what,
+                    &mut value,
+                    &mut what,
                     &Some(TrimType::Leading),
                     &row
                 )
@@ -575,8 +579,8 @@ mod tests {
             assert_eq!(
                 evaluate_trim(
                     &Schema::default(),
-                    &value,
-                    &what,
+                    &mut value,
+                    &mut what,
                     &Some(TrimType::Both),
                     &row
                 )

--- a/dozer-sql/src/expression/tests/execution.rs
+++ b/dozer-sql/src/expression/tests/execution.rs
@@ -49,21 +49,21 @@ fn test_column_execution() {
     ]);
 
     // Column
-    let e = Expression::Column { index: 0 };
+    let mut e = Expression::Column { index: 0 };
     assert_eq!(
         e.evaluate(&record, &schema)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::Int(1337)
     );
 
-    let e = Expression::Column { index: 1 };
+    let mut e = Expression::Column { index: 1 };
     assert_eq!(
         e.evaluate(&record, &schema)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
         Field::String("test".to_string())
     );
 
-    let e = Expression::Column { index: 2 };
+    let mut e = Expression::Column { index: 2 };
     assert_eq!(
         e.evaluate(&record, &schema)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
@@ -71,7 +71,7 @@ fn test_column_execution() {
     );
 
     // Literal
-    let e = Expression::Literal(Field::Int(1337));
+    let mut e = Expression::Literal(Field::Int(1337));
     assert_eq!(
         e.evaluate(&record, &schema)
             .unwrap_or_else(|e| panic!("{}", e.to_string())),
@@ -79,7 +79,7 @@ fn test_column_execution() {
     );
 
     // UnaryOperator
-    let e = Expression::UnaryOperator {
+    let mut e = Expression::UnaryOperator {
         operator: UnaryOperatorType::Not,
         arg: Box::new(Expression::Literal(Field::Boolean(true))),
     };
@@ -90,7 +90,7 @@ fn test_column_execution() {
     );
 
     // BinaryOperator
-    let e = Expression::BinaryOperator {
+    let mut e = Expression::BinaryOperator {
         left: Box::new(Expression::Literal(Field::Boolean(true))),
         operator: BinaryOperatorType::And,
         right: Box::new(Expression::Literal(Field::Boolean(false))),
@@ -102,7 +102,7 @@ fn test_column_execution() {
     );
 
     // ScalarFunction
-    let e = Expression::ScalarFunction {
+    let mut e = Expression::ScalarFunction {
         fun: ScalarFunctionType::Abs,
         args: vec![Expression::Literal(Field::Int(-1))],
     };

--- a/dozer-sql/src/projection/processor.rs
+++ b/dozer-sql/src/projection/processor.rs
@@ -32,7 +32,7 @@ impl ProjectionProcessor {
     fn delete(&mut self, record: &Record) -> Result<Operation, PipelineError> {
         let mut results = vec![];
 
-        for expr in &self.expressions {
+        for expr in &mut self.expressions {
             results.push(expr.evaluate(record, &self.input_schema)?);
         }
 
@@ -45,7 +45,7 @@ impl ProjectionProcessor {
     fn insert(&mut self, record: &Record) -> Result<Operation, PipelineError> {
         let mut results = vec![];
 
-        for expr in self.expressions.clone() {
+        for expr in &mut self.expressions {
             results.push(expr.evaluate(record, &self.input_schema)?);
         }
 
@@ -54,11 +54,11 @@ impl ProjectionProcessor {
         Ok(Operation::Insert { new: output_record })
     }
 
-    fn update(&self, old: &Record, new: &Record) -> Result<Operation, PipelineError> {
+    fn update(&mut self, old: &Record, new: &Record) -> Result<Operation, PipelineError> {
         let mut old_results = vec![];
         let mut new_results = vec![];
 
-        for expr in &self.expressions {
+        for expr in &mut self.expressions {
             old_results.push(expr.evaluate(old, &self.input_schema)?);
             new_results.push(expr.evaluate(new, &self.input_schema)?);
         }

--- a/dozer-sql/src/table_operator/lifetime.rs
+++ b/dozer-sql/src/table_operator/lifetime.rs
@@ -33,13 +33,13 @@ impl TableOperator for LifetimeTableOperator {
     }
 
     fn execute(
-        &self,
+        &mut self,
         record_store: &ProcessorRecordStore,
         record: &ProcessorRecord,
         schema: &Schema,
     ) -> Result<Vec<ProcessorRecord>, TableOperatorError> {
         let mut ttl_records = vec![];
-        if let Some(operator) = &self.operator {
+        if let Some(operator) = &mut self.operator {
             let operator_records = operator.execute(record_store, record, schema)?;
 
             let schema = operator.get_output_schema(schema)?;

--- a/dozer-sql/src/table_operator/operator.rs
+++ b/dozer-sql/src/table_operator/operator.rs
@@ -9,7 +9,7 @@ use crate::errors::TableOperatorError;
 pub trait TableOperator: Send + Sync {
     fn get_name(&self) -> String;
     fn execute(
-        &self,
+        &mut self,
         record_store: &ProcessorRecordStore,
         record: &ProcessorRecord,
         schema: &Schema,

--- a/dozer-sql/src/table_operator/tests/operator_test.rs
+++ b/dozer-sql/src/table_operator/tests/operator_test.rs
@@ -43,7 +43,7 @@ fn test_lifetime() {
     ]);
     let record = record_store.create_record(&record).unwrap();
 
-    let table_operator = LifetimeTableOperator::new(
+    let mut table_operator = LifetimeTableOperator::new(
         None,
         Expression::Column { index: 1 },
         // Expression::new(


### PR DESCRIPTION
As decided in https://github.com/getdozer/dozer/discussions/2212, functions can be stateful. It follows that the evaluation of the function should take `&mut self`, otherwise the state cannot mutate.

All other changes are just compilation error fixes.