### PR TITLE
feat: Add `JavaScript` UDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "time 0.3.20",
  "url",
 ]
@@ -827,6 +827,17 @@ dependencies = [
  "xz2",
  "zstd",
  "zstd-safe",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2 1.0.63",
+ "quote 1.0.30",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3169,7 +3180,7 @@ dependencies = [
  "log",
  "pin-project",
  "serde",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "tokio",
  "trust-dns-proto 0.22.0",
  "trust-dns-resolver 0.22.0",
@@ -3965,8 +3976,10 @@ dependencies = [
 name = "dozer-sql-expression"
 version = "0.3.0"
 dependencies = [
+ "async-recursion",
  "bigdecimal",
  "bincode",
+ "dozer-deno",
  "dozer-types",
  "half 2.3.1",
  "jsonpath",
@@ -3976,6 +3989,7 @@ dependencies = [
  "ort",
  "proptest",
  "sqlparser 0.35.0",
+ "tokio",
 ]
 
 [[package]]
@@ -6485,14 +6499,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6600,7 +6614,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "thiserror",
  "tokio",
  "tokio-rustls 0.24.0",
@@ -9884,9 +9898,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -10792,9 +10806,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10804,7 +10818,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -10822,9 +10836,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.30",

--- a/dozer-cli/src/lib.rs
+++ b/dozer-cli/src/lib.rs
@@ -4,8 +4,7 @@ pub mod live;
 pub mod pipeline;
 pub mod simple;
 use dozer_api::shutdown::ShutdownSender;
-use dozer_core::{app::AppPipeline, errors::ExecutionError};
-use dozer_sql::{builder::statement_to_pipeline, errors::PipelineError};
+use dozer_core::errors::ExecutionError;
 use dozer_types::log::debug;
 use errors::OrchestrationError;
 
@@ -27,11 +26,6 @@ pub use dozer_ingestion::{
     errors::ConnectorError,
     {get_connector, TableInfo},
 };
-pub use dozer_sql::builder::QueryContext;
-pub fn wrapped_statement_to_pipeline(sql: &str) -> Result<QueryContext, PipelineError> {
-    let mut pipeline = AppPipeline::new_with_default_flags();
-    statement_to_pipeline(sql, &mut pipeline, None, vec![])
-}
 
 pub use dozer_types::models::connection::Connection;
 use dozer_types::tracing::error;

--- a/dozer-cli/src/live/state.rs
+++ b/dozer-cli/src/live/state.rs
@@ -324,7 +324,7 @@ fn get_contract(dozer_and_contract: &Option<DozerAndContract>) -> Result<&Contra
 pub async fn create_contract(dozer: SimpleOrchestrator) -> Result<Contract, OrchestrationError> {
     let dag = create_dag(&dozer).await?;
     let version = dozer.config.version;
-    let schemas = DagSchemas::new(dag)?;
+    let schemas = DagSchemas::new(dag).await?;
     let contract = Contract::new(
         version as usize,
         &schemas,
@@ -393,6 +393,7 @@ fn get_dozer_run_instance(
                 &mut AppPipeline::new(dozer.config.flags.clone().into()),
                 None,
                 dozer.config.udfs.clone(),
+                dozer.runtime.clone(),
             )
             .map_err(LiveError::PipelineError)?;
 

--- a/dozer-cli/src/pipeline/connector_source.rs
+++ b/dozer-cli/src/pipeline/connector_source.rs
@@ -11,7 +11,7 @@ use dozer_ingestion::{IngestionConfig, Ingestor};
 use dozer_tracing::LabelsAndProgress;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::indicatif::ProgressBar;
-use dozer_types::log::info;
+use dozer_types::log::{error, info};
 use dozer_types::models::connection::Connection;
 use dozer_types::models::ingestion_types::IngestionMessage;
 use dozer_types::parking_lot::Mutex;
@@ -286,7 +286,10 @@ impl Source for ConnectorSource {
                             .await;
                     match result {
                         Ok(Ok(_)) => {}
-                        Ok(Err(e)) => std::panic::panic_any(e),
+                        Ok(Err(e)) => {
+                            error!("{}", e);
+                            std::panic::panic_any(e)
+                        }
                         // Aborted means we are shutting down
                         Err(Aborted) => (),
                     }

--- a/dozer-cli/src/simple/orchestrator.rs
+++ b/dozer-cli/src/simple/orchestrator.rs
@@ -377,7 +377,7 @@ impl SimpleOrchestrator {
             .runtime
             .block_on(builder.build(&self.runtime, shutdown))?;
         // Populate schemas.
-        let dag_schemas = DagSchemas::new(dag)?;
+        let dag_schemas = self.runtime.block_on(DagSchemas::new(dag))?;
 
         // Get current contract.
         let enable_token = self.config.api.api_security.is_some();
@@ -470,12 +470,13 @@ impl SimpleOrchestrator {
     }
 }
 
-pub fn validate_sql(sql: String) -> Result<(), PipelineError> {
+pub fn validate_sql(sql: String, runtime: Arc<Runtime>) -> Result<(), PipelineError> {
     statement_to_pipeline(
         &sql,
         &mut AppPipeline::new_with_default_flags(),
         None,
         vec![],
+        runtime,
     )
     .map_or_else(
         |e| {

--- a/dozer-core/src/executor/mod.rs
+++ b/dozer-core/src/executor/mod.rs
@@ -78,7 +78,7 @@ impl DagExecutor {
         checkpoint: OptionCheckpoint,
         options: ExecutorOptions,
     ) -> Result<Self, ExecutionError> {
-        let dag_schemas = DagSchemas::new(dag)?;
+        let dag_schemas = DagSchemas::new(dag).await?;
 
         let builder_dag = BuilderDag::new(&checkpoint, dag_schemas).await?;
 
@@ -89,8 +89,8 @@ impl DagExecutor {
         })
     }
 
-    pub fn validate<T: Clone + Debug>(dag: Dag) -> Result<(), ExecutionError> {
-        DagSchemas::new(dag)?;
+    pub async fn validate<T: Clone + Debug>(dag: Dag) -> Result<(), ExecutionError> {
+        DagSchemas::new(dag).await?;
         Ok(())
     }
 

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -7,6 +7,7 @@ use dozer_log::storage::{Object, Queue};
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::OpIdentifier;
 use dozer_types::serde::{Deserialize, Serialize};
+use dozer_types::tonic::async_trait;
 use dozer_types::types::Schema;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
@@ -63,15 +64,16 @@ pub trait Source: Send + Sync + Debug {
     ) -> Result<(), BoxedError>;
 }
 
+#[async_trait]
 pub trait ProcessorFactory: Send + Sync + Debug {
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
     ) -> Result<Schema, BoxedError>;
     fn get_input_ports(&self) -> Vec<PortHandle>;
     fn get_output_ports(&self) -> Vec<PortHandle>;
-    fn build(
+    async fn build(
         &self,
         input_schemas: HashMap<PortHandle, Schema>,
         output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-core/src/tests/dag_base_create_errors.rs
+++ b/dozer-core/src/tests/dag_base_create_errors.rs
@@ -13,6 +13,7 @@ use dozer_log::tokio;
 use dozer_recordstore::ProcessorRecordStoreDeserializer;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
+use dozer_types::tonic::async_trait;
 use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 
 use std::collections::HashMap;
@@ -169,12 +170,13 @@ impl CreateErrProcessorFactory {
     }
 }
 
+#[async_trait]
 impl ProcessorFactory for CreateErrProcessorFactory {
     fn type_name(&self) -> String {
         "CreateErr".to_owned()
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, Schema>,
@@ -200,7 +202,7 @@ impl ProcessorFactory for CreateErrProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -17,6 +17,7 @@ use dozer_recordstore::{ProcessorRecordStore, ProcessorRecordStoreDeserializer};
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::models::ingestion_types::IngestionMessage;
 use dozer_types::node::{NodeHandle, OpIdentifier};
+use dozer_types::tonic::async_trait;
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
 };
@@ -35,12 +36,13 @@ struct ErrorProcessorFactory {
     panic: bool,
 }
 
+#[async_trait]
 impl ProcessorFactory for ErrorProcessorFactory {
     fn type_name(&self) -> String {
         "Error".to_owned()
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
@@ -56,7 +58,7 @@ impl ProcessorFactory for ErrorProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-core/src/tests/dag_base_run.rs
+++ b/dozer-core/src/tests/dag_base_run.rs
@@ -16,6 +16,7 @@ use dozer_log::tokio;
 use dozer_recordstore::{ProcessorRecordStore, ProcessorRecordStoreDeserializer};
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
+use dozer_types::tonic::async_trait;
 use dozer_types::types::Schema;
 
 use std::collections::HashMap;
@@ -27,12 +28,13 @@ use std::time::Duration;
 #[derive(Debug)]
 pub(crate) struct NoopProcessorFactory {}
 
+#[async_trait]
 impl ProcessorFactory for NoopProcessorFactory {
     fn type_name(&self) -> String {
         "Noop".to_owned()
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
@@ -48,7 +50,7 @@ impl ProcessorFactory for NoopProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
@@ -188,12 +190,13 @@ pub(crate) struct NoopJoinProcessorFactory {}
 pub const NOOP_JOIN_LEFT_INPUT_PORT: u16 = 1;
 pub const NOOP_JOIN_RIGHT_INPUT_PORT: u16 = 2;
 
+#[async_trait]
 impl ProcessorFactory for NoopJoinProcessorFactory {
     fn type_name(&self) -> String {
         "NoopJoin".to_owned()
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
@@ -209,7 +212,7 @@ impl ProcessorFactory for NoopJoinProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-core/src/tests/dag_ports.rs
+++ b/dozer-core/src/tests/dag_ports.rs
@@ -4,6 +4,7 @@ use crate::node::{
 use crate::{Dag, Endpoint, DEFAULT_PORT_HANDLE};
 use dozer_recordstore::ProcessorRecordStoreDeserializer;
 use dozer_types::errors::internal::BoxedError;
+use dozer_types::tonic::async_trait;
 use dozer_types::{node::NodeHandle, types::Schema};
 use std::collections::HashMap;
 
@@ -57,8 +58,9 @@ impl DynPortsProcessorFactory {
     }
 }
 
+#[async_trait]
 impl ProcessorFactory for DynPortsProcessorFactory {
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, Schema>,
@@ -74,7 +76,7 @@ impl ProcessorFactory for DynPortsProcessorFactory {
         self.output_ports.clone()
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-core/src/tests/processors.rs
+++ b/dozer-core/src/tests/processors.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use dozer_recordstore::ProcessorRecordStoreDeserializer;
-use dozer_types::{errors::internal::BoxedError, types::Schema};
+use dozer_types::{errors::internal::BoxedError, tonic::async_trait, types::Schema};
 
 use crate::{
     node::{PortHandle, Processor, ProcessorFactory},
@@ -11,6 +11,7 @@ use crate::{
 #[derive(Debug)]
 pub struct ConnectivityTestProcessorFactory;
 
+#[async_trait]
 impl ProcessorFactory for ConnectivityTestProcessorFactory {
     fn type_name(&self) -> String {
         "ConnectivityTest".to_owned()
@@ -23,7 +24,7 @@ impl ProcessorFactory for ConnectivityTestProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, Schema>,
@@ -33,7 +34,7 @@ impl ProcessorFactory for ConnectivityTestProcessorFactory {
         )
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,
@@ -53,6 +54,7 @@ impl ProcessorFactory for ConnectivityTestProcessorFactory {
 #[derive(Debug)]
 pub struct NoInputPortProcessorFactory;
 
+#[async_trait]
 impl ProcessorFactory for NoInputPortProcessorFactory {
     fn get_input_ports(&self) -> Vec<PortHandle> {
         vec![]
@@ -62,7 +64,7 @@ impl ProcessorFactory for NoInputPortProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         _input_schemas: &HashMap<PortHandle, Schema>,
@@ -72,7 +74,7 @@ impl ProcessorFactory for NoInputPortProcessorFactory {
         )
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-sql/Cargo.toml
+++ b/dozer-sql/Cargo.toml
@@ -21,6 +21,7 @@ linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
 metrics = "0.21.0"
 multimap = "0.9.0"
 regex = "1.10.2"
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/dozer-sql/expression/Cargo.toml
+++ b/dozer-sql/expression/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["getdozer/dozer-dev"]
 
 [dependencies]
 dozer-types = { path = "../../dozer-types" }
+dozer-deno = { path = "../../dozer-deno" }
 num-traits = "0.2.16"
 sqlparser = { git = "https://github.com/getdozer/sqlparser-rs.git" }
 bigdecimal = { version = "0.3", features = ["serde"], optional = true }
@@ -15,6 +16,8 @@ half = { version = "2.3.1", optional = true }
 like = "0.3.1"
 jsonpath = { path = "../jsonpath" }
 bincode = { workspace = true }
+tokio = "1.34.0"
+async-recursion = "1.0.5"
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/dozer-sql/expression/src/error.rs
+++ b/dozer-sql/expression/src/error.rs
@@ -100,6 +100,9 @@ pub enum Error {
     #[error("ONNX UDF is not enabled")]
     OnnxNotEnabled,
 
+    #[error("JavaScript UDF error: {0}")]
+    JavaScript(#[from] crate::javascript::Error),
+
     // Legacy error types.
     #[error("Sql error: {0}")]
     SqlError(#[source] OperationError),

--- a/dozer-sql/expression/src/execution.rs
+++ b/dozer-sql/expression/src/execution.rs
@@ -96,6 +96,7 @@ pub enum Expression {
         session: crate::onnx::DozerSession,
         args: Vec<Expression>,
     },
+    JavaScriptUdf(crate::javascript::Udf),
 }
 
 impl Expression {
@@ -274,6 +275,7 @@ impl Expression {
                         .as_str()
                     + ")"
             }
+            Expression::JavaScriptUdf(udf) => udf.to_string(schema),
         }
     }
 }
@@ -361,6 +363,7 @@ impl Expression {
                 results,
                 else_result,
             } => evaluate_case(schema, operand, conditions, results, else_result, record),
+            Expression::JavaScriptUdf(udf) => udf.evaluate(record, schema),
         }
     }
 
@@ -468,6 +471,7 @@ impl Expression {
                 SourceDefinition::Dynamic,
                 false,
             )),
+            Expression::JavaScriptUdf(udf) => Ok(udf.get_type()),
         }
     }
 }

--- a/dozer-sql/expression/src/javascript/evaluate.rs
+++ b/dozer-sql/expression/src/javascript/evaluate.rs
@@ -1,0 +1,118 @@
+use std::{num::NonZeroI32, sync::Arc};
+
+use dozer_deno::deno_runtime::deno_core::error::AnyError;
+use dozer_types::{
+    errors::types::DeserializationError,
+    json_types::{json_value_to_serde_json, serde_json_to_json_value},
+    thiserror,
+    types::{Field, FieldType, Record, Schema, SourceDefinition},
+};
+use tokio::{runtime::Runtime, sync::Mutex};
+
+use crate::execution::{Expression, ExpressionType};
+
+#[derive(Debug, Clone)]
+pub struct Udf {
+    function_name: String,
+    arg: Box<Expression>,
+    tokio_runtime: Arc<Runtime>,
+    /// Always `Some`. `Arc<Mutex>` to enable `Clone`. Not sure why `Expression` should be `Clone`.
+    deno_runtime: Arc<Mutex<Option<dozer_deno::Runtime>>>,
+    function: NonZeroI32,
+}
+
+impl PartialEq for Udf {
+    fn eq(&self, other: &Self) -> bool {
+        // This is obviously wrong. We have to lift the `PartialEq` constraint.
+        self.function_name == other.function_name && self.arg == other.arg
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to create deno runtime: {0}")]
+    CreateRuntime(#[from] dozer_deno::RuntimeError),
+    #[error("failed to evaluate udf: {0}")]
+    Evaluate(#[source] AnyError),
+    #[error("failed to convert json: {0}")]
+    JsonConversion(#[source] DeserializationError),
+}
+
+impl Udf {
+    pub async fn new(
+        tokio_runtime: Arc<Runtime>,
+        function_name: String,
+        module: String,
+        arg: Expression,
+    ) -> Result<Self, Error> {
+        let (deno_runtime, functions) =
+            dozer_deno::Runtime::new(tokio_runtime.clone(), vec![module]).await?;
+        let function = functions[0];
+        Ok(Self {
+            function_name,
+            arg: Box::new(arg),
+            tokio_runtime,
+            deno_runtime: Arc::new(Mutex::new(Some(deno_runtime))),
+            function,
+        })
+    }
+
+    pub fn get_type(&self) -> ExpressionType {
+        ExpressionType {
+            return_type: FieldType::Json,
+            nullable: false,
+            source: SourceDefinition::Dynamic,
+            is_primary_key: false,
+        }
+    }
+
+    pub fn evaluate(
+        &mut self,
+        record: &Record,
+        schema: &Schema,
+    ) -> Result<Field, crate::error::Error> {
+        self.tokio_runtime.block_on(evaluate_impl(
+            self.function_name.clone(),
+            &mut self.arg,
+            &self.deno_runtime,
+            self.function,
+            record,
+            schema,
+        ))
+    }
+
+    pub fn to_string(&self, schema: &Schema) -> String {
+        format!("{}({})", self.function_name, self.arg.to_string(schema))
+    }
+}
+
+async fn evaluate_impl(
+    function_name: String,
+    arg: &mut Expression,
+    runtime: &Arc<Mutex<Option<dozer_deno::Runtime>>>,
+    function: NonZeroI32,
+    record: &Record,
+    schema: &Schema,
+) -> Result<Field, crate::error::Error> {
+    let arg = arg.evaluate(record, schema)?;
+    let Field::Json(arg) = arg else {
+        return Err(crate::error::Error::InvalidFunctionArgument {
+            function_name,
+            argument_index: 0,
+            argument: arg,
+        });
+    };
+
+    let mut runtime = runtime.lock().await;
+    let result = runtime
+        .take()
+        .unwrap()
+        .call_function(function, vec![json_value_to_serde_json(&arg)])
+        .await;
+    *runtime = Some(result.0);
+    drop(runtime);
+
+    let result = result.1.map_err(Error::Evaluate)?;
+    let result = serde_json_to_json_value(result).map_err(Error::JsonConversion)?;
+    Ok(Field::Json(result))
+}

--- a/dozer-sql/expression/src/javascript/mod.rs
+++ b/dozer-sql/expression/src/javascript/mod.rs
@@ -1,0 +1,5 @@
+mod evaluate;
+mod validate;
+
+pub use evaluate::{Error, Udf};
+pub use validate::validate_args;

--- a/dozer-sql/expression/src/javascript/validate.rs
+++ b/dozer-sql/expression/src/javascript/validate.rs
@@ -1,0 +1,27 @@
+use dozer_types::types::{FieldType, Schema};
+
+use crate::{error::Error, execution::Expression};
+
+pub fn validate_args(
+    function_name: String,
+    args: &[Expression],
+    schema: &Schema,
+) -> Result<(), Error> {
+    if args.len() != 1 {
+        return Err(Error::InvalidNumberOfArguments {
+            function_name,
+            expected: 1..2,
+            actual: args.len(),
+        });
+    }
+    let typ = args[0].get_type(schema)?;
+    if typ.return_type != FieldType::Json {
+        return Err(Error::InvalidFunctionArgumentType {
+            function_name,
+            argument_index: 0,
+            expected: vec![FieldType::Json],
+            actual: typ.return_type,
+        });
+    }
+    Ok(())
+}

--- a/dozer-sql/expression/src/lib.rs
+++ b/dozer-sql/expression/src/lib.rs
@@ -16,6 +16,7 @@ mod mathematical;
 pub mod operator;
 pub mod scalar;
 
+mod javascript;
 #[cfg(feature = "onnx")]
 mod onnx;
 #[cfg(feature = "python")]

--- a/dozer-sql/src/aggregation/tests/aggregation_test_planner.rs
+++ b/dozer-sql/src/aggregation/tests/aggregation_test_planner.rs
@@ -1,6 +1,6 @@
-use crate::aggregation::processor::AggregationProcessor;
 use crate::planner::projection::CommonPlanner;
 use crate::tests::utils::get_select;
+use crate::{aggregation::processor::AggregationProcessor, tests::utils::create_test_runtime};
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
 };
@@ -71,10 +71,13 @@ fn test_planner_with_aggregator() {
         )
         .clone();
 
-    let mut projection_planner = CommonPlanner::new(schema.clone(), &[]);
+    let runtime = create_test_runtime();
+    let mut projection_planner = CommonPlanner::new(schema.clone(), &[], runtime.clone());
     let statement = get_select(sql).unwrap();
 
-    projection_planner.plan(*statement).unwrap();
+    runtime
+        .block_on(projection_planner.plan(*statement))
+        .unwrap();
 
     let mut processor = AggregationProcessor::new(
         "".to_string(),

--- a/dozer-sql/src/aggregation/tests/aggregation_tests_utils.rs
+++ b/dozer-sql/src/aggregation/tests/aggregation_tests_utils.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::aggregation::processor::AggregationProcessor;
 use crate::errors::PipelineError;
 use crate::planner::projection::CommonPlanner;
-use crate::tests::utils::get_select;
+use crate::tests::utils::{create_test_runtime, get_select};
 use dozer_types::arrow::datatypes::ArrowNativeTypeOp;
 use dozer_types::chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use dozer_types::ordered_float::OrderedFloat;
@@ -23,10 +23,13 @@ pub(crate) fn init_processor(
         .get(&DEFAULT_PORT_HANDLE)
         .unwrap_or_else(|| panic!("Error getting Input Schema"));
 
-    let mut projection_planner = CommonPlanner::new(input_schema.clone(), &[]);
+    let runtime = create_test_runtime();
+    let mut projection_planner = CommonPlanner::new(input_schema.clone(), &[], runtime.clone());
     let statement = get_select(sql).unwrap();
 
-    projection_planner.plan(*statement).unwrap();
+    runtime
+        .block_on(projection_planner.plan(*statement))
+        .unwrap();
 
     let processor = AggregationProcessor::new(
         "".to_string(),

--- a/dozer-sql/src/expression/tests/execution.rs
+++ b/dozer-sql/src/expression/tests/execution.rs
@@ -1,5 +1,5 @@
 use crate::projection::factory::ProjectionProcessorFactory;
-use crate::tests::utils::get_select;
+use crate::tests::utils::{create_test_runtime, get_select};
 use dozer_core::node::ProcessorFactory;
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_sql_expression::execution::Expression;
@@ -137,13 +137,18 @@ fn test_alias() {
         .clone();
 
     let select = get_select("SELECT count(fn) AS alias1, ln as alias2 FROM t1").unwrap();
-    let processor_factory =
-        ProjectionProcessorFactory::_new("projection_id".to_owned(), select.projection, vec![]);
-    let r = processor_factory
-        .get_output_schema(
+    let runtime = create_test_runtime();
+    let processor_factory = ProjectionProcessorFactory::_new(
+        "projection_id".to_owned(),
+        select.projection,
+        vec![],
+        runtime.clone(),
+    );
+    let r = runtime
+        .block_on(processor_factory.get_output_schema(
             &DEFAULT_PORT_HANDLE,
             &[(DEFAULT_PORT_HANDLE, schema)].into_iter().collect(),
-        )
+        ))
         .unwrap();
 
     assert_eq!(
@@ -195,13 +200,18 @@ fn test_wildcard() {
         .clone();
 
     let select = get_select("SELECT * FROM t1").unwrap();
-    let processor_factory =
-        ProjectionProcessorFactory::_new("projection_id".to_owned(), select.projection, vec![]);
-    let r = processor_factory
-        .get_output_schema(
+    let runtime = create_test_runtime();
+    let processor_factory = ProjectionProcessorFactory::_new(
+        "projection_id".to_owned(),
+        select.projection,
+        vec![],
+        runtime.clone(),
+    );
+    let r = runtime
+        .block_on(processor_factory.get_output_schema(
             &DEFAULT_PORT_HANDLE,
             &[(DEFAULT_PORT_HANDLE, schema)].into_iter().collect(),
-        )
+        ))
         .unwrap();
 
     assert_eq!(

--- a/dozer-sql/src/expression/tests/expression_builder_test.rs
+++ b/dozer-sql/src/expression/tests/expression_builder_test.rs
@@ -1,4 +1,4 @@
-use crate::tests::utils::get_select;
+use crate::tests::utils::{create_test_runtime, get_select};
 use dozer_sql_expression::execution::Expression;
 use dozer_sql_expression::operator::BinaryOperatorType;
 use dozer_sql_expression::scalar::common::ScalarFunctionType;
@@ -31,19 +31,17 @@ fn test_simple_function() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
-    assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![]
-        }
-    );
+    assert_eq!(builder.offset, schema.fields.len());
+    assert_eq!(builder.aggregations, vec![]);
     assert_eq!(
         e,
         Expression::ScalarFunction {
@@ -71,21 +69,22 @@ fn test_simple_aggr_function() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
+    assert_eq!(builder.offset, schema.fields.len());
     assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![Expression::AggregateFunction {
-                fun: AggregateFunctionType::Sum,
-                args: vec![Expression::Column { index: 0 }]
-            }]
-        }
+        builder.aggregations,
+        vec![Expression::AggregateFunction {
+            fun: AggregateFunctionType::Sum,
+            args: vec![Expression::Column { index: 0 }]
+        }]
     );
     assert_eq!(e, Expression::Column { index: 1 });
 }
@@ -114,27 +113,28 @@ fn test_2_nested_aggr_function() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
+    assert_eq!(builder.offset, schema.fields.len());
     assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![Expression::AggregateFunction {
-                fun: AggregateFunctionType::Sum,
-                args: vec![Expression::ScalarFunction {
-                    fun: ScalarFunctionType::Round,
-                    args: vec![
-                        Expression::Column { index: 1 },
-                        Expression::Literal(Field::Int(2))
-                    ]
-                }]
+        builder.aggregations,
+        vec![Expression::AggregateFunction {
+            fun: AggregateFunctionType::Sum,
+            args: vec![Expression::ScalarFunction {
+                fun: ScalarFunctionType::Round,
+                args: vec![
+                    Expression::Column { index: 1 },
+                    Expression::Literal(Field::Int(2))
+                ]
             }]
-        }
+        }]
     );
     assert_eq!(e, Expression::Column { index: 2 });
 }
@@ -163,27 +163,28 @@ fn test_3_nested_aggr_function() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
+    assert_eq!(builder.offset, schema.fields.len());
     assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![Expression::AggregateFunction {
-                fun: AggregateFunctionType::Sum,
-                args: vec![Expression::ScalarFunction {
-                    fun: ScalarFunctionType::Round,
-                    args: vec![
-                        Expression::Column { index: 1 },
-                        Expression::Literal(Field::Int(2))
-                    ]
-                }]
+        builder.aggregations,
+        vec![Expression::AggregateFunction {
+            fun: AggregateFunctionType::Sum,
+            args: vec![Expression::ScalarFunction {
+                fun: ScalarFunctionType::Round,
+                args: vec![
+                    Expression::Column { index: 1 },
+                    Expression::Literal(Field::Int(2))
+                ]
             }]
-        }
+        }]
     );
     assert_eq!(
         e,
@@ -218,27 +219,28 @@ fn test_3_nested_aggr_function_dup() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
+    assert_eq!(builder.offset, schema.fields.len());
     assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![Expression::AggregateFunction {
-                fun: AggregateFunctionType::Sum,
-                args: vec![Expression::ScalarFunction {
-                    fun: ScalarFunctionType::Round,
-                    args: vec![
-                        Expression::Column { index: 1 },
-                        Expression::Literal(Field::Int(2))
-                    ]
-                }]
+        builder.aggregations,
+        vec![Expression::AggregateFunction {
+            fun: AggregateFunctionType::Sum,
+            args: vec![Expression::ScalarFunction {
+                fun: ScalarFunctionType::Round,
+                args: vec![
+                    Expression::Column { index: 1 },
+                    Expression::Literal(Field::Int(2))
+                ]
             }]
-        }
+        }]
     );
     assert_eq!(
         e,
@@ -276,33 +278,34 @@ fn test_3_nested_aggr_function_and_sum() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
+    assert_eq!(builder.offset, schema.fields.len());
     assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![
-                Expression::AggregateFunction {
-                    fun: AggregateFunctionType::Sum,
-                    args: vec![Expression::ScalarFunction {
-                        fun: ScalarFunctionType::Round,
-                        args: vec![
-                            Expression::Column { index: 1 },
-                            Expression::Literal(Field::Int(2))
-                        ]
-                    }]
-                },
-                Expression::AggregateFunction {
-                    fun: AggregateFunctionType::Sum,
-                    args: vec![Expression::Column { index: 0 }]
-                }
-            ]
-        }
+        builder.aggregations,
+        vec![
+            Expression::AggregateFunction {
+                fun: AggregateFunctionType::Sum,
+                args: vec![Expression::ScalarFunction {
+                    fun: ScalarFunctionType::Round,
+                    args: vec![
+                        Expression::Column { index: 1 },
+                        Expression::Literal(Field::Int(2))
+                    ]
+                }]
+            },
+            Expression::AggregateFunction {
+                fun: AggregateFunctionType::Sum,
+                args: vec![Expression::Column { index: 0 }]
+            }
+        ]
     );
     assert_eq!(
         e,
@@ -341,33 +344,34 @@ fn test_3_nested_aggr_function_and_sum_3() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
+    assert_eq!(builder.offset, schema.fields.len());
     assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![
-                Expression::AggregateFunction {
-                    fun: AggregateFunctionType::Sum,
-                    args: vec![Expression::ScalarFunction {
-                        fun: ScalarFunctionType::Round,
-                        args: vec![
-                            Expression::Column { index: 1 },
-                            Expression::Literal(Field::Int(2))
-                        ]
-                    }]
-                },
-                Expression::AggregateFunction {
-                    fun: AggregateFunctionType::Sum,
-                    args: vec![Expression::Column { index: 0 }]
-                }
-            ]
-        }
+        builder.aggregations,
+        vec![
+            Expression::AggregateFunction {
+                fun: AggregateFunctionType::Sum,
+                args: vec![Expression::ScalarFunction {
+                    fun: ScalarFunctionType::Round,
+                    args: vec![
+                        Expression::Column { index: 1 },
+                        Expression::Literal(Field::Int(2))
+                    ]
+                }]
+            },
+            Expression::AggregateFunction {
+                fun: AggregateFunctionType::Sum,
+                args: vec![Expression::Column { index: 0 }]
+            }
+        ]
     );
     assert_eq!(
         e,
@@ -403,9 +407,12 @@ fn test_wrong_nested_aggregations() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let _e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 }
@@ -440,19 +447,17 @@ fn test_name_resolution() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
-    assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![]
-        }
-    );
+    assert_eq!(builder.offset, schema.fields.len());
+    assert_eq!(builder.aggregations, vec![]);
     assert_eq!(
         e,
         Expression::ScalarFunction {
@@ -483,19 +488,17 @@ fn test_alias_resolution() {
         )
         .to_owned();
 
-    let mut builder = ExpressionBuilder::new(schema.fields.len());
+    let runtime = create_test_runtime();
+    let mut builder = ExpressionBuilder::new(schema.fields.len(), runtime.clone());
     let e = match &get_select(sql).unwrap().projection[0] {
-        SelectItem::UnnamedExpr(e) => builder.build(true, e, &schema, &[]).unwrap(),
+        SelectItem::UnnamedExpr(e) => runtime
+            .block_on(builder.build(true, e, &schema, &[]))
+            .unwrap(),
         _ => panic!("Invalid expr"),
     };
 
-    assert_eq!(
-        builder,
-        ExpressionBuilder {
-            offset: schema.fields.len(),
-            aggregations: vec![]
-        }
-    );
+    assert_eq!(builder.offset, schema.fields.len());
+    assert_eq!(builder.aggregations, vec![]);
     assert_eq!(
         e,
         Expression::ScalarFunction {

--- a/dozer-sql/src/pipeline_builder/from_builder.rs
+++ b/dozer-sql/src/pipeline_builder/from_builder.rs
@@ -159,6 +159,7 @@ pub fn insert_table_operator_processor_to_pipeline(
             processor_name.clone(),
             operator.clone(),
             query_context.udfs.to_owned(),
+            query_context.runtime.clone(),
         );
 
         if let Some(table) = operator.args.get(0) {

--- a/dozer-sql/src/pipeline_builder/join_builder.rs
+++ b/dozer-sql/src/pipeline_builder/join_builder.rs
@@ -204,6 +204,7 @@ fn insert_table_operator_to_pipeline(
             processor_name.clone(),
             operator.clone(),
             query_context.udfs.to_owned(),
+            query_context.runtime.clone(),
         );
 
         if let Some(table) = operator.args.get(0) {

--- a/dozer-sql/src/planner/tests/projection_tests.rs
+++ b/dozer-sql/src/planner/tests/projection_tests.rs
@@ -1,6 +1,6 @@
 use dozer_sql_expression::aggregate::AggregateFunctionType;
 
-use crate::planner::projection::CommonPlanner;
+use crate::{planner::projection::CommonPlanner, tests::utils::create_test_runtime};
 use dozer_sql_expression::execution::Expression;
 use dozer_sql_expression::operator::BinaryOperatorType;
 use dozer_sql_expression::scalar::common::ScalarFunctionType;
@@ -39,10 +39,13 @@ fn test_basic_projection() {
         )
         .to_owned();
 
-    let mut projection_planner = CommonPlanner::new(schema, &[]);
+    let runtime = create_test_runtime();
+    let mut projection_planner = CommonPlanner::new(schema, &[], runtime.clone());
     let statement = get_select(sql).unwrap();
 
-    projection_planner.plan(*statement).unwrap();
+    runtime
+        .block_on(projection_planner.plan(*statement))
+        .unwrap();
 
     assert_eq!(
         projection_planner.aggregation_output,

--- a/dozer-sql/src/planner/tests/schema_tests.rs
+++ b/dozer-sql/src/planner/tests/schema_tests.rs
@@ -1,5 +1,5 @@
-use crate::planner::projection::CommonPlanner;
 use crate::tests::utils::get_select;
+use crate::{planner::projection::CommonPlanner, tests::utils::create_test_runtime};
 use dozer_types::types::{FieldDefinition, FieldType, Schema, SourceDefinition};
 
 #[test]
@@ -44,10 +44,13 @@ fn test_schema_index_partial_group_by() {
         )
         .to_owned();
 
-    let mut projection_planner = CommonPlanner::new(schema, &[]);
+    let runtime = create_test_runtime();
+    let mut projection_planner = CommonPlanner::new(schema, &[], runtime.clone());
     let statement = get_select(sql).unwrap();
 
-    projection_planner.plan(*statement).unwrap();
+    runtime
+        .block_on(projection_planner.plan(*statement))
+        .unwrap();
 
     assert!(projection_planner
         .post_projection_schema
@@ -97,10 +100,13 @@ fn test_schema_index_full_group_by() {
         )
         .to_owned();
 
-    let mut projection_planner = CommonPlanner::new(schema, &[]);
+    let runtime = create_test_runtime();
+    let mut projection_planner = CommonPlanner::new(schema, &[], runtime.clone());
     let statement = get_select(sql).unwrap();
 
-    projection_planner.plan(*statement).unwrap();
+    runtime
+        .block_on(projection_planner.plan(*statement))
+        .unwrap();
 
     assert_eq!(
         projection_planner.post_projection_schema.primary_index,

--- a/dozer-sql/src/product/join/factory.rs
+++ b/dozer-sql/src/product/join/factory.rs
@@ -15,6 +15,7 @@ use dozer_sql_expression::{
 use dozer_recordstore::ProcessorRecordStoreDeserializer;
 use dozer_types::{
     errors::internal::BoxedError,
+    tonic::async_trait,
     types::{FieldDefinition, Schema},
 };
 
@@ -57,6 +58,7 @@ impl JoinProcessorFactory {
     }
 }
 
+#[async_trait]
 impl ProcessorFactory for JoinProcessorFactory {
     fn id(&self) -> String {
         self.id.clone()
@@ -73,7 +75,7 @@ impl ProcessorFactory for JoinProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
@@ -105,7 +107,7 @@ impl ProcessorFactory for JoinProcessorFactory {
         Ok(output_schema)
     }
 
-    fn build(
+    async fn build(
         &self,
         input_schemas: HashMap<PortHandle, dozer_types::types::Schema>,
         _output_schemas: HashMap<PortHandle, dozer_types::types::Schema>,

--- a/dozer-sql/src/product/join/processor.rs
+++ b/dozer-sql/src/product/join/processor.rs
@@ -251,7 +251,7 @@ mod tests {
     }
 
     impl Executor {
-        fn new(kind: JoinType) -> Self {
+        async fn new(kind: JoinType) -> Self {
             let record_store =
                 ProcessorRecordStoreDeserializer::new(RecordStore::InMemory).unwrap();
             let left_schema = create_schema("left");
@@ -287,6 +287,7 @@ mod tests {
             .collect();
             let processor = factory
                 .build(schemas, HashMap::new(), &record_store, None)
+                .await
                 .unwrap();
 
             let record_store = record_store.into_record_store();
@@ -352,9 +353,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_inner_join() {
-        let mut exec = Executor::new(JoinType::Inner);
+    #[tokio::test]
+    async fn test_inner_join() {
+        let mut exec = Executor::new(JoinType::Inner).await;
 
         let (left_record, ops) = exec.insert(JoinSide::Left, &[Field::UInt(0), Field::UInt(1)]);
         assert_eq!(ops, &[]);
@@ -400,9 +401,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_left_outer_join() {
-        let mut exec = Executor::new(JoinType::LeftOuter);
+    #[tokio::test]
+    async fn test_left_outer_join() {
+        let mut exec = Executor::new(JoinType::LeftOuter).await;
 
         let null_record = exec
             .record_store
@@ -485,9 +486,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_right_outer_join() {
-        let mut exec = Executor::new(JoinType::RightOuter);
+    #[tokio::test]
+    async fn test_right_outer_join() {
+        let mut exec = Executor::new(JoinType::RightOuter).await;
 
         let null_record = exec
             .record_store

--- a/dozer-sql/src/product/set/set_factory.rs
+++ b/dozer-sql/src/product/set/set_factory.rs
@@ -10,6 +10,7 @@ use dozer_core::{
 use dozer_recordstore::ProcessorRecordStoreDeserializer;
 use dozer_sql_expression::sqlparser::ast::{SetOperator, SetQuantifier};
 use dozer_types::errors::internal::BoxedError;
+use dozer_types::tonic::async_trait;
 use dozer_types::types::{FieldDefinition, Schema, SourceDefinition};
 
 use super::operator::SetOperation;
@@ -37,6 +38,7 @@ impl SetProcessorFactory {
     }
 }
 
+#[async_trait]
 impl ProcessorFactory for SetProcessorFactory {
     fn id(&self) -> String {
         self.id.clone()
@@ -53,7 +55,7 @@ impl ProcessorFactory for SetProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
@@ -73,7 +75,7 @@ impl ProcessorFactory for SetProcessorFactory {
         Ok(output_schema)
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, Schema>,
         _output_schemas: HashMap<PortHandle, Schema>,

--- a/dozer-sql/src/product/table/factory.rs
+++ b/dozer-sql/src/product/table/factory.rs
@@ -9,7 +9,7 @@ use dozer_sql_expression::{
     builder::{extend_schema_source_def, NameOrAlias},
     sqlparser::ast::TableFactor,
 };
-use dozer_types::{errors::internal::BoxedError, types::Schema};
+use dozer_types::{errors::internal::BoxedError, tonic::async_trait, types::Schema};
 
 use crate::errors::{PipelineError, ProductError};
 use crate::window::builder::string_from_sql_object_name;
@@ -28,6 +28,7 @@ impl TableProcessorFactory {
     }
 }
 
+#[async_trait]
 impl ProcessorFactory for TableProcessorFactory {
     fn id(&self) -> String {
         self.id.clone()
@@ -45,7 +46,7 @@ impl ProcessorFactory for TableProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
@@ -59,7 +60,7 @@ impl ProcessorFactory for TableProcessorFactory {
         }
     }
 
-    fn build(
+    async fn build(
         &self,
         _input_schemas: HashMap<PortHandle, dozer_types::types::Schema>,
         _output_schemas: HashMap<PortHandle, dozer_types::types::Schema>,

--- a/dozer-sql/src/tests/utils.rs
+++ b/dozer-sql/src/tests/utils.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use crate::errors::PipelineError;
 use dozer_sql_expression::sqlparser::{
     ast::{Query, Select, SetExpr, Statement},
     dialect::DozerDialect,
     parser::Parser,
 };
+use tokio::runtime::Runtime;
 
 pub fn get_select(sql: &str) -> Result<Box<Select>, PipelineError> {
     let dialect = DozerDialect {};
@@ -24,4 +27,13 @@ pub fn get_query_select(query: &Query) -> Box<Select> {
         SetExpr::Query(query) => get_query_select(&query),
         _ => panic!("Only select queries are supported"),
     }
+}
+
+pub fn create_test_runtime() -> Arc<Runtime> {
+    Arc::new(
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap(),
+    )
 }

--- a/dozer-sql/src/window/factory.rs
+++ b/dozer-sql/src/window/factory.rs
@@ -5,7 +5,7 @@ use dozer_core::{
     DEFAULT_PORT_HANDLE,
 };
 use dozer_recordstore::ProcessorRecordStoreDeserializer;
-use dozer_types::{errors::internal::BoxedError, types::Schema};
+use dozer_types::{errors::internal::BoxedError, tonic::async_trait, types::Schema};
 
 use crate::{
     errors::{PipelineError, WindowError},
@@ -26,6 +26,7 @@ impl WindowProcessorFactory {
     }
 }
 
+#[async_trait]
 impl ProcessorFactory for WindowProcessorFactory {
     fn id(&self) -> String {
         self.id.clone()
@@ -43,7 +44,7 @@ impl ProcessorFactory for WindowProcessorFactory {
         vec![DEFAULT_PORT_HANDLE]
     }
 
-    fn get_output_schema(
+    async fn get_output_schema(
         &self,
         _output_port: &PortHandle,
         input_schemas: &HashMap<PortHandle, Schema>,
@@ -67,7 +68,7 @@ impl ProcessorFactory for WindowProcessorFactory {
         Ok(output_schema)
     }
 
-    fn build(
+    async fn build(
         &self,
         input_schemas: HashMap<PortHandle, dozer_types::types::Schema>,
         _output_schemas: HashMap<PortHandle, dozer_types::types::Schema>,

--- a/dozer-types/src/models/udf_config.rs
+++ b/dozer-types/src/models/udf_config.rs
@@ -15,6 +15,7 @@ pub struct UdfConfig {
 #[serde(deny_unknown_fields)]
 pub enum UdfType {
     Onnx(OnnxConfig),
+    JavaScript(JavaScriptConfig),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]
@@ -22,4 +23,11 @@ pub enum UdfType {
 pub struct OnnxConfig {
     /// path to the model file
     pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct JavaScriptConfig {
+    /// path to the module file
+    pub module: String,
 }

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -1073,6 +1073,19 @@
         }
       }
     },
+    "JavaScriptConfig2": {
+      "type": "object",
+      "required": [
+        "module"
+      ],
+      "properties": {
+        "module": {
+          "description": "path to the module file",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "JavaScriptLambda": {
       "type": "object",
       "required": [
@@ -1876,6 +1889,18 @@
           "properties": {
             "Onnx": {
               "$ref": "#/definitions/OnnxConfig"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "JavaScript"
+          ],
+          "properties": {
+            "JavaScript": {
+              "$ref": "#/definitions/JavaScriptConfig2"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Example:

- dozer-config.yaml

```yaml
app_name: js_udf
version: 1

connections:
  - name: input
    config: !JavaScript
      bootstrap_path: ./ingest.js

sql: SELECT square(value) as value INTO output FROM json_records;

endpoints:
  - name: input
    path: /input
    table_name: json_records

  - name: output
    path: /output
    table_name: output

udfs:
  - name: square
    config: !JavaScript
      module: ./square.js
```

- ingest.js

```javascript
(async function () {
    for (const value of [1, 2, 3]) {
        await Deno[Deno.internal].core.ops.ingest({
            typ: 'Insert',
            old_val: null,
            new_val: value,
        });
    }
}());
```

- square.js

```javascript
export default function (input) {
    return input * input;
}
```

Unit tests is not added yet.

The implementation itself is not complicated, however, we have to pass `runtime` around and change some functions to `async`, hence the 1000 lines change.