### PR TITLE
feat: Add casting from timestamp to date

### DIFF
--- a/dozer-sql/expression/src/cast.rs
+++ b/dozer-sql/expression/src/cast.rs
@@ -177,7 +177,10 @@ impl CastOperatorType {
                 vec![FieldType::String, FieldType::Timestamp],
                 FieldType::Timestamp,
             ),
-            FieldType::Date => (vec![FieldType::Date, FieldType::String], FieldType::Date),
+            FieldType::Date => (
+                vec![FieldType::Date, FieldType::Timestamp, FieldType::String],
+                FieldType::Date,
+            ),
             FieldType::Json => (
                 vec![
                     FieldType::Boolean,

--- a/dozer-sql/expression/src/datetime.rs
+++ b/dozer-sql/expression/src/datetime.rs
@@ -178,6 +178,10 @@ pub(crate) fn evaluate_interval(
         DateTimeField::Nanoseconds | DateTimeField::Nanosecond => Ok(Field::Duration(
             DozerDuration(std::time::Duration::from_nanos(dur), TimeUnit::Nanoseconds),
         )),
+        DateTimeField::Day => Ok(Field::Duration(DozerDuration(
+            std::time::Duration::from_secs(dur * 24 * 60 * 60),
+            TimeUnit::Nanoseconds,
+        ))),
         DateTimeField::Isodow
         | DateTimeField::Timezone
         | DateTimeField::Dow
@@ -189,7 +193,6 @@ pub(crate) fn evaluate_interval(
         | DateTimeField::TimezoneMinute
         | DateTimeField::Date
         | DateTimeField::NoDateTime
-        | DateTimeField::Day
         | DateTimeField::Month
         | DateTimeField::Year
         | DateTimeField::Hour

--- a/dozer-sql/src/expression/tests/cast.rs
+++ b/dozer-sql/src/expression/tests/cast.rs
@@ -758,3 +758,29 @@ fn test_text() {
     );
     assert_eq!(f, Field::Text("42".to_string()));
 }
+
+#[test]
+fn test_date() {
+    let date = "2023-11-22";
+    let date_time = DateTime::parse_from_rfc3339(&format!("{}T10:00:00+00:00", date)).unwrap();
+    let f = run_fct(
+        "SELECT CAST(field AS DATE) FROM users",
+        Schema::default()
+            .field(
+                FieldDefinition::new(
+                    String::from("field"),
+                    FieldType::Timestamp,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .clone(),
+        vec![Field::Timestamp(date_time)],
+    );
+
+    assert_eq!(
+        f,
+        Field::Date(NaiveDate::parse_from_str(date, "%Y-%m-%d").unwrap())
+    );
+}

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -729,6 +729,7 @@ impl Field {
     pub fn to_date(&self) -> Option<NaiveDate> {
         match self {
             Field::String(s) => NaiveDate::parse_from_str(s, DATE_FORMAT).ok(),
+            Field::Timestamp(t) => Some(t.date_naive()),
             Field::Date(d) => Some(*d),
             _ => None,
         }

--- a/dozer-types/src/types/tests.rs
+++ b/dozer-types/src/types/tests.rs
@@ -476,7 +476,7 @@ fn test_to_conversion() {
     assert!(field.to_binary().is_none());
     assert!(field.to_decimal().is_none());
     assert!(field.to_timestamp().is_some());
-    assert!(field.to_date().is_none());
+    assert!(field.to_date().is_some());
     assert!(field.to_json().is_none());
     assert!(field.to_point().is_none());
     assert!(field.to_duration().is_none());


### PR DESCRIPTION
Changes to support SQL timestamp to date casting and usage of days interval

```sql
SELECT CAST((NOW() - INTERVAL '365' day) as date) ....
```