### PR TITLE
Fix: make postgres connector schema and table names case-sensitive

### DIFF
--- a/dozer-ingestion/postgres/src/connector.rs
+++ b/dozer-ingestion/postgres/src/connector.rs
@@ -240,7 +240,7 @@ impl PostgresConnector {
                     .iter()
                     .map(|table_identifier| {
                         format!(
-                            "{}.{}",
+                            r#""{}"."{}""#,
                             table_identifier
                                 .schema
                                 .as_deref()

--- a/dozer-ingestion/postgres/src/snapshotter.rs
+++ b/dozer-ingestion/postgres/src/snapshotter.rs
@@ -51,7 +51,7 @@ impl<'a> PostgresSnapshotter<'a> {
             .collect();
 
         let column_str = column_str.join(",");
-        let query = format!("select {column_str} from {schema_name}.{table_name}");
+        let query = format!(r#"select {column_str} from "{schema_name}"."{table_name}""#);
         let stmt = client_plain
             .prepare(&query)
             .await


### PR DESCRIPTION
Previously, it was not possible to ingest from postgres tables with a
name containing uppercase characters, because in SQL, unquoted names are
normalized.
