### PR TITLE
feat: partial predicate pushdown for LIKE on cache SQL layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,6 +3684,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing-actix-web",
+ "unicode-segmentation",
  "uuid",
 ]
 

--- a/dozer-api/Cargo.toml
+++ b/dozer-api/Cargo.toml
@@ -58,3 +58,4 @@ datafusion-expr = "32.0.0"
 serde_json = { version = "1.0.108", features = ["arbitrary_precision"] }
 pgwire = "0.16.1"
 tempdir = "0.3.7"
+unicode-segmentation = "1.10.1"


### PR DESCRIPTION
Speed improvement is very significant. 380ms with predicate pushdown compared to 3s 540ms without, in a 280MB dataset of 230K records. (Note the predicate pushdown case, while faster, incorrectly returns 25699 records only, while the non-pushdown case correctly returns 62813 records).
The lack of projection pushdown in the cache means that all 230K records, with all fields included, must be read from LMDB, converted to JSON, converted from JSON to Arrow format, then fed to Datafusion for filtering. Predicate pushdown for LIKE demonstrably reduces this overhead (although the cache doesn't do substring search, which makes this comparison inconclusive).

This pull-request is marked as a draft because the implementation is only partially correct. The `$contains` filtering option of the cache currently doesn't support substring search, making it insufficient for correct pushdown of `LIKE %word%` as `"$contains": "word"`.