### PR TITLE
feat: handle breaking and non-breaking schema changes for MySQL connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,6 +3902,7 @@ dependencies = [
  "mysql_common",
  "rand 0.8.5",
  "serial_test 1.0.0",
+ "sqlparser 0.40.0",
 ]
 
 [[package]]
@@ -10161,6 +10162,15 @@ checksum = "0272b7bb0a225320170c99901b4b5fb3a4384e255a7f2cc228f61e2ba3893e75"
 dependencies = [
  "log",
  "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c80afe31cdb649e56c0d9bb5503be9166600d68a852c38dd445636d126858e5"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/dozer-ingestion/mysql/Cargo.toml
+++ b/dozer-ingestion/mysql/Cargo.toml
@@ -18,6 +18,7 @@ geozero = { version = "0.11.0", default-features = false, features = [
     "with-wkb",
 ] }
 rand = "0.8.5"
+sqlparser = "0.40.0"
 
 [dev-dependencies]
 serial_test = "1.0.0"

--- a/dozer-ingestion/mysql/src/binlog.rs
+++ b/dozer-ingestion/mysql/src/binlog.rs
@@ -1,4 +1,7 @@
-use crate::{connection::is_network_failure, MySQLConnectorError};
+use crate::{
+    connection::is_network_failure, conversion::get_field_type_for_sql_type, schema::SchemaHelper,
+    MySQLConnectorError,
+};
 
 use super::{
     connection::Conn,
@@ -8,7 +11,7 @@ use super::{
 use dozer_ingestion_connector::{
     dozer_types::{
         json_types::{JsonArray, JsonObject, JsonValue},
-        log::trace,
+        log::{trace, warn},
         models::ingestion_types::IngestionMessage,
         types::Field,
         types::{FieldType, Operation, Record},
@@ -27,7 +30,10 @@ use mysql_common::{
     },
     Row,
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Deref,
+};
 
 #[derive(Debug, Clone)]
 pub struct BinlogPosition {
@@ -60,23 +66,20 @@ pub async fn get_binlog_format(conn: &mut Conn) -> Result<String, MySQLConnector
     Ok(binlog_logging_format)
 }
 
-pub struct BinlogIngestor<'a, 'b, 'd, 'e> {
+pub struct BinlogIngestor<'a, 'd, 'e> {
     ingestor: &'a Ingestor,
     binlog_stream: Option<BinlogStream>,
-    tables: &'b [TableDefinition],
     next_position: BinlogPosition,
     stop_position: Option<BinlogPosition>,
     local_stop_position: Option<u64>,
     server_id: u32,
     conn_pool: &'d Pool,
     conn_url: &'e String,
-    column_definitions_cache: ColumnDefinitionsCache<'b>,
 }
 
-impl<'a, 'b, 'd, 'e> BinlogIngestor<'a, 'b, 'd, 'e> {
+impl<'a, 'd, 'e> BinlogIngestor<'a, 'd, 'e> {
     pub fn new(
         ingestor: &'a Ingestor,
-        tables: &'b [TableDefinition],
         start_position: BinlogPosition,
         stop_position: Option<BinlogPosition>,
         server_id: u32,
@@ -85,19 +88,17 @@ impl<'a, 'b, 'd, 'e> BinlogIngestor<'a, 'b, 'd, 'e> {
         Self {
             ingestor,
             binlog_stream: None,
-            tables,
             next_position: start_position,
             stop_position,
             local_stop_position: None,
             server_id,
             conn_pool,
             conn_url,
-            column_definitions_cache: ColumnDefinitionsCache::new(tables),
         }
     }
 }
 
-impl BinlogIngestor<'_, '_, '_, '_> {
+impl BinlogIngestor<'_, '_, '_> {
     async fn connect(&self) -> Result<Conn, MySQLConnectorError> {
         Conn::new(self.conn_pool.clone())
             .await
@@ -129,12 +130,17 @@ impl BinlogIngestor<'_, '_, '_, '_> {
         Ok(())
     }
 
-    pub async fn ingest(&mut self) -> Result<(), MySQLConnectorError> {
+    pub async fn ingest(
+        &mut self,
+        tables: &mut [TableDefinition],
+        schema_helper: SchemaHelper<'_>,
+    ) -> Result<(), MySQLConnectorError> {
         if self.binlog_stream.is_none() {
             self.open_binlog().await?;
         }
 
-        let mut table_cache = BinlogTableCache::new(self.tables);
+        let mut table_cache = TableManager::new(tables);
+        let mut schema_change_tracker = SchemaChangeTracker::new();
 
         'binlog_read: while let Some(result) = self.binlog_stream.as_mut().unwrap().next().await {
             match self.local_stop_position {
@@ -192,7 +198,7 @@ impl BinlogIngestor<'_, '_, '_, '_> {
                         self.open_binlog().await?;
                     }
 
-                    table_cache.binlog_rotate();
+                    table_cache.handle_binlog_rotate();
                 }
 
                 QUERY_EVENT => {
@@ -202,7 +208,9 @@ impl BinlogIngestor<'_, '_, '_, '_> {
                             _ => unreachable!(),
                         };
 
-                    if query_event.query_raw() == b"BEGIN"
+                    let query = query_event.query_raw().trim_start();
+
+                    if query == b"BEGIN"
                         && self
                             .ingestor
                             .handle_message(IngestionMessage::SnapshottingStarted)
@@ -211,6 +219,154 @@ impl BinlogIngestor<'_, '_, '_, '_> {
                     {
                         // If receiving side is closed, we can stop ingesting.
                         return Ok(());
+                    } else if query.starts_with_case_insensitive(b"ALTER")
+                        || query.starts_with_case_insensitive(b"DROP")
+                    {
+                        if schema_change_tracker.unknown_schema_change_occured {
+                            // An unknown schema change has occured before, so granular checks might be inaccurate.
+                            // The pending full schema check should suffice.
+                        } else {
+                            let query = String::from_utf8_lossy(query);
+                            let dialect = &sqlparser::dialect::MySqlDialect {};
+                            let result = sqlparser::parser::Parser::parse_sql(dialect, &query);
+                            let schema = query_event.schema_raw();
+                            match result {
+                                Err(err) => {
+                                    warn!("Failed to parse MySQL query {query:?}: {err}");
+                                    // resort to manual schema verification
+                                    schema_change_tracker.unknown_schema_change_occured();
+                                }
+                                Ok(statements) => {
+                                    for statement in statements {
+                                        use sqlparser::ast::{
+                                            AlterTableOperation, ObjectType, Statement,
+                                        };
+                                        match statement {
+                                            Statement::Drop {
+                                                object_type: ObjectType::Schema,
+                                                names,
+                                                ..
+                                            } => {
+                                                for name in names {
+                                                    let database_name =
+                                                        object_name_to_string(&name);
+                                                    if table_cache
+                                                        .databases()
+                                                        .contains(&database_name)
+                                                    {
+                                                        Err(MySQLConnectorError::BreakingSchemaChange(format!("Database \"{}\" was dropped", database_name)))?
+                                                    }
+                                                }
+                                            }
+                                            Statement::Drop {
+                                                object_type: ObjectType::Table,
+                                                names,
+                                                ..
+                                            } => {
+                                                for name in names {
+                                                    if let Some(table) = table_cache
+                                                        .find_table_by_object_name(&name, schema)
+                                                    {
+                                                        Err(MySQLConnectorError::BreakingSchemaChange(format!("Table \"{}\" was dropped", table)))?
+                                                    }
+                                                }
+                                            }
+                                            Statement::AlterTable {
+                                                name, operations, ..
+                                            } => {
+                                                if let Some(table) = table_cache
+                                                    .find_table_by_object_name(&name, schema)
+                                                {
+                                                    let find_column =
+                                                        |name: &sqlparser::ast::Ident| {
+                                                            table.columns.iter().find(|cd| {
+                                                                cd.name.eq_ignore_ascii_case(
+                                                                    &name.value,
+                                                                )
+                                                            })
+                                                        };
+                                                    for operation in operations.iter() {
+                                                        match operation {
+                                                        AlterTableOperation::AddColumn {
+                                                            ..
+                                                        } => {
+                                                            schema_change_tracker.column_order_changed_in(table.table_index);
+                                                        }
+                                                        AlterTableOperation::DropColumn {
+                                                            column_name,
+                                                            ..
+                                                        } => {
+                                                            if let Some(column) =
+                                                                find_column(column_name)
+                                                            {
+                                                                Err(MySQLConnectorError::BreakingSchemaChange(format!("Column \"{}\" from table \"{}\" was dropped", column, table)))?
+                                                            }
+                                                            schema_change_tracker.column_order_changed_in(table.table_index);
+                                                        }
+                                                        AlterTableOperation::RenameColumn {
+                                                            old_column_name,
+                                                            new_column_name,
+                                                        } => {
+                                                            if !old_column_name
+                                                                .value
+                                                                .eq_ignore_ascii_case(
+                                                                    &new_column_name.value,
+                                                                )
+                                                            {
+                                                                if let Some(column) =
+                                                                    find_column(old_column_name)
+                                                                {
+                                                                    Err(MySQLConnectorError::BreakingSchemaChange(format!("Column \"{}\" from table \"{}\" was renamed to \"{}\"", column, table, new_column_name.value)))?
+                                                                }
+                                                            }
+                                                        }
+                                                        AlterTableOperation::RenameTable {
+                                                            table_name,
+                                                        } => {
+                                                            Err(MySQLConnectorError::BreakingSchemaChange(format!("Table \"{}\" was renamed to \"{}\"", table, object_name_to_string(table_name))))?
+                                                        }
+                                                        AlterTableOperation::ChangeColumn {
+                                                            old_name,
+                                                            new_name,
+                                                            data_type,
+                                                            options: _, // TODO: handle options changes
+                                                        } => {
+                                                            if let Some(column) = find_column(old_name) {
+                                                                if !old_name.value.eq_ignore_ascii_case(&new_name.value) {
+                                                                    Err(MySQLConnectorError::BreakingSchemaChange(format!("Column \"{}\" from table \"{}\" was renamed to \"{}\"", column, table, new_name.value)))?
+                                                                }
+                                                                let new_type = get_field_type_for_sql_type(data_type);
+                                                                if new_type != column.typ {
+                                                                    Err(MySQLConnectorError::BreakingSchemaChange(format!("Column \"{}\" from table \"{}\" changed data type from \"{}\" to \"{}\"", column, table, column.typ, new_type)))?
+                                                                }
+                                                            }
+                                                        }
+                                                        AlterTableOperation::AlterColumn {
+                                                            column_name,
+                                                            op,
+                                                        } => {
+                                                            if let Some(_column) = find_column(column_name) {
+                                                                use sqlparser::ast::AlterColumnOperation;
+                                                                match op {
+                                                                    AlterColumnOperation::SetDefault { .. } |
+                                                                    AlterColumnOperation::DropDefault => (), // TODO: handle options changes
+                                                                    AlterColumnOperation::SetNotNull |
+                                                                    AlterColumnOperation::DropNotNull |
+                                                                    AlterColumnOperation::SetDataType {..} => unreachable!("MySQL does not support this statement {}", operation),
+                                                                }
+                                                            }
+                                                        }
+                                                        _ => (),
+                                                    }
+                                                    }
+                                                }
+                                            }
+                                            _ => (),
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -240,8 +396,25 @@ impl BinlogIngestor<'_, '_, '_, '_> {
 
                     let tme = self.get_tme(binlog_table_id)?;
 
-                    if let Some(table) = table_cache.get_corresponding_table(tme) {
-                        self.handle_rows_event(&rows_event, table, tme).await?;
+                    if schema_change_tracker.unknown_schema_change_occured {
+                        table_cache.refresh_full_schema(schema_helper).await?;
+                        schema_change_tracker.clear();
+                    }
+
+                    if let Some(table_index) = table_cache.get_corresponding_table_index(tme) {
+                        if schema_change_tracker
+                            .column_order_changed
+                            .contains(&table_index)
+                        {
+                            let tables = &schema_change_tracker.column_order_changed;
+                            table_cache
+                                .refresh_column_ordinals(schema_helper, tables)
+                                .await?;
+                            schema_change_tracker.clear();
+                        }
+
+                        let table = table_cache.get_table_details(table_index).unwrap();
+                        self.handle_rows_event(&rows_event, &table, tme).await?;
                     }
                 }
 
@@ -257,14 +430,14 @@ impl BinlogIngestor<'_, '_, '_, '_> {
     async fn handle_rows_event<'a>(
         &self,
         rows_event: &BinlogRowsEvent<'_>,
-        table: &TableDefinition,
+        table: &TableDetails<'_>,
         tme: &TableMapEvent<'a>,
     ) -> Result<(), MySQLConnectorError> {
         for op in self.make_rows_operations(rows_event, table, tme) {
             if self
                 .ingestor
                 .handle_message(IngestionMessage::OperationEvent {
-                    table_index: table.table_index,
+                    table_index: table.def.table_index,
                     op: op?,
                     id: None,
                 })
@@ -298,19 +471,15 @@ impl BinlogIngestor<'_, '_, '_, '_> {
     // # Parameters
     // - `row_columns`: The zero-based indexes of columns present in the binlog row.
     // - `table_definition`: The table definition.
-    fn select_columns(
+    fn select_columns<'a>(
         &self,
         row_columns: Vec<usize>,
-        table_definition: &TableDefinition,
-    ) -> Vec<(usize, &FieldType)> {
-        let table_columns = self
-            .column_definitions_cache
-            .get_columns_of_table(table_definition.table_index)
-            .unwrap();
+        table: &TableDetails<'a>,
+    ) -> Vec<(usize, &'a FieldType)> {
         let columns = row_columns
             .iter()
             .enumerate()
-            .filter_map(|(i, col)| table_columns.get(col).map(|cd| (i, &cd.typ)))
+            .filter_map(|(i, col)| table.columns.get(col).map(|cd| (i, &cd.typ)))
             .collect::<Vec<_>>();
 
         columns
@@ -319,7 +488,7 @@ impl BinlogIngestor<'_, '_, '_, '_> {
     fn rows_iter<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
         &'a self,
         rows_event: &'b BinlogRowsEvent<'_>,
-        table: &'c TableDefinition,
+        table: &TableDetails<'c>,
         tme: &'d TableMapEvent,
     ) -> impl Iterator<Item = Result<RowValues, MySQLConnectorError>> + 'r {
         let rows = rows_event.rows(tme);
@@ -360,7 +529,7 @@ impl BinlogIngestor<'_, '_, '_, '_> {
     fn make_rows_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
         &'a self,
         rows_event: &'b BinlogRowsEvent<'_>,
-        table: &'c TableDefinition,
+        table: &TableDetails<'c>,
         tme: &'d TableMapEvent,
     ) -> impl Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r {
         if rows_event.is_write() {
@@ -377,7 +546,7 @@ impl BinlogIngestor<'_, '_, '_, '_> {
     fn make_insert_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
         &'a self,
         rows_event: &'b BinlogRowsEvent<'_>,
-        table: &'c TableDefinition,
+        table: &TableDetails<'c>,
         tme: &'d TableMapEvent,
     ) -> impl Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r {
         self.rows_iter(rows_event, table, tme).map(|row| {
@@ -394,7 +563,7 @@ impl BinlogIngestor<'_, '_, '_, '_> {
     fn make_update_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
         &'a self,
         rows_event: &'b BinlogRowsEvent<'_>,
-        table: &'c TableDefinition,
+        table: &TableDetails<'c>,
         tme: &'d TableMapEvent,
     ) -> impl Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r {
         self.rows_iter(rows_event, table, tme).map(|row| {
@@ -415,7 +584,7 @@ impl BinlogIngestor<'_, '_, '_, '_> {
     fn make_delete_operations<'a: 'r, 'b: 'r, 'c: 'r, 'd: 'r, 'r>(
         &'a self,
         rows_event: &'b BinlogRowsEvent<'_>,
-        table: &'c TableDefinition,
+        table: &TableDetails<'c>,
         tme: &'d TableMapEvent,
     ) -> impl Iterator<Item = Result<Operation, MySQLConnectorError>> + 'r {
         self.rows_iter(rows_event, table, tme).map(|row| {
@@ -427,6 +596,35 @@ impl BinlogIngestor<'_, '_, '_, '_> {
 
             Ok(op)
         })
+    }
+}
+
+struct SchemaChangeTracker {
+    /// Table indexes for tables which had a column order change, usually caused by column addition or dropping.
+    pub column_order_changed: HashSet<usize>,
+    /// Some unkown schema change has occured. A a full schema refresh is needed and a rigourous check for breaking changes.
+    pub unknown_schema_change_occured: bool,
+}
+
+impl SchemaChangeTracker {
+    fn new() -> Self {
+        Self {
+            column_order_changed: HashSet::new(),
+            unknown_schema_change_occured: false,
+        }
+    }
+
+    fn column_order_changed_in(&mut self, table_index: usize) {
+        self.column_order_changed.insert(table_index);
+    }
+
+    fn unknown_schema_change_occured(&mut self) {
+        self.unknown_schema_change_occured = true;
+    }
+
+    fn clear(&mut self) {
+        self.column_order_changed.clear();
+        self.unknown_schema_change_occured = false;
     }
 }
 
@@ -458,30 +656,36 @@ struct RowValues {
     pub new_values: Option<Vec<Field>>, // present in Update and Insert operations
 }
 
-struct ColumnDefinitionsCache<'a> {
-    cache: Vec<HashMap<usize, &'a ColumnDefinition>>,
+struct ColumnDefinitionsCache {
+    cache: Vec<HashMap<usize, usize>>,
 }
 
-impl<'a> ColumnDefinitionsCache<'a> {
-    pub fn new(table_definitions: &'a [TableDefinition]) -> Self {
+impl ColumnDefinitionsCache {
+    pub fn new(table_definitions: &[TableDefinition]) -> Self {
         Self {
             cache: table_definitions
                 .iter()
                 .map(|td| {
                     td.columns
                         .iter()
-                        .map(|c| ((c.ordinal_position - 1) as usize, c))
+                        .enumerate()
+                        .map(|(i, c)| ((c.ordinal_position - 1) as usize, i))
                         .collect()
                 })
                 .collect(),
         }
     }
 
-    pub fn get_columns_of_table(
+    pub fn get_columns_of_table<'a>(
         &self,
-        table_index: usize,
-    ) -> Option<&HashMap<usize, &ColumnDefinition>> {
-        self.cache.get(table_index)
+        td: &'a TableDefinition,
+    ) -> Option<HashMap<usize, &'a ColumnDefinition>> {
+        self.cache.get(td.table_index).map(|hashmap| {
+            hashmap
+                .iter()
+                .map(|(&zero_based_ordinal, &i)| (zero_based_ordinal, &td.columns[i]))
+                .collect()
+        })
     }
 }
 
@@ -580,36 +784,97 @@ impl<'a, T: StorageFormat> IntoJsonValue for ComplexValue<'a, T, Object> {
     }
 }
 
-pub struct BinlogTableCache<'a> {
-    tables: &'a [TableDefinition],
-    binlog_table_id_to_table_map: HashMap<u64, &'a TableDefinition>,
-    known_missing: HashSet<u64>,
+#[derive(Debug, Clone)]
+pub struct TableDetails<'a> {
+    pub def: &'a TableDefinition,
+    pub columns: HashMap<usize, &'a ColumnDefinition>,
 }
 
-impl BinlogTableCache<'_> {
-    pub fn new(tables: &[TableDefinition]) -> BinlogTableCache<'_> {
-        BinlogTableCache {
+pub struct TableManager<'a> {
+    tables: &'a mut [TableDefinition],
+    binlog_table_id_to_table_index_map: HashMap<u64, usize>,
+    known_missing_tme_table_ids: HashSet<u64>,
+    column_definitions_cache: ColumnDefinitionsCache,
+    databases: HashSet<String>,
+}
+
+impl TableManager<'_> {
+    pub fn new(tables: &mut [TableDefinition]) -> TableManager<'_> {
+        let column_definitions_cache = ColumnDefinitionsCache::new(tables);
+        let databases = Self::get_unique_databases_set(tables);
+        TableManager {
             tables,
-            binlog_table_id_to_table_map: HashMap::new(),
-            known_missing: HashSet::new(),
+            binlog_table_id_to_table_index_map: HashMap::new(),
+            known_missing_tme_table_ids: HashSet::new(),
+            column_definitions_cache,
+            databases,
         }
     }
 
-    pub fn binlog_rotate(&mut self) {
+    pub fn handle_binlog_rotate(&mut self) {
         // binlog table ids are not guranteed to be consistent across binlog rotates
-        self.binlog_table_id_to_table_map.clear();
-        self.known_missing.clear();
+        self.binlog_table_id_to_table_index_map.clear();
+        self.known_missing_tme_table_ids.clear();
     }
 
-    pub fn get_corresponding_table(&mut self, tme: &TableMapEvent<'_>) -> Option<&TableDefinition> {
+    /// Reload column ordinals after ALTER TABLE ADD COLUMN or DROP COLUMN.
+    pub async fn refresh_column_ordinals(
+        &mut self,
+        schema_helper: SchemaHelper<'_>,
+        table_indexes: &HashSet<usize>,
+    ) -> Result<(), MySQLConnectorError> {
+        let mut tables_to_refresh = self
+            .tables
+            .iter_mut()
+            .filter(|td| table_indexes.contains(&td.table_index))
+            .collect::<Vec<_>>();
+
+        schema_helper
+            .refresh_column_ordinals(tables_to_refresh.as_mut_slice())
+            .await?;
+
+        self.column_definitions_cache = ColumnDefinitionsCache::new(self.tables);
+
+        Ok(())
+    }
+
+    // Refresh the entire schema after an ALTER TABLE.
+    // This is a last resort when granular schema changes are not known.
+    pub async fn refresh_full_schema(
+        &mut self,
+        schema_helper: SchemaHelper<'_>,
+    ) -> Result<(), MySQLConnectorError> {
+        schema_helper
+            .refresh_schema_and_check_for_breaking_changes(self.tables)
+            .await?;
+
+        self.column_definitions_cache = ColumnDefinitionsCache::new(self.tables);
+
+        Ok(())
+    }
+
+    pub fn get_table_details(&self, table_index: usize) -> Option<TableDetails> {
+        self.tables.get(table_index).map(|td| TableDetails {
+            def: td,
+            columns: self
+                .column_definitions_cache
+                .get_columns_of_table(td)
+                .unwrap(),
+        })
+    }
+
+    pub fn get_corresponding_table_index(&mut self, tme: &TableMapEvent<'_>) -> Option<usize> {
         let binlog_table_id = tme.table_id();
-        if let Some(found) = self.binlog_table_id_to_table_map.get(&binlog_table_id) {
+        if let Some(&found) = self
+            .binlog_table_id_to_table_index_map
+            .get(&binlog_table_id)
+        {
             Some(found)
-        } else if self.known_missing.contains(&binlog_table_id) {
+        } else if self.known_missing_tme_table_ids.contains(&binlog_table_id) {
             None
         } else {
             // see if we can find it
-            if let Some(value) = self.tables.iter().find(
+            if let Some(&TableDefinition { table_index, .. }) = self.tables.iter().find(
                 |TableDefinition {
                      table_name,
                      database_name,
@@ -619,14 +884,44 @@ impl BinlogTableCache<'_> {
                         && table_name.as_bytes() == tme.table_name_raw()
                 },
             ) {
-                self.binlog_table_id_to_table_map
-                    .insert(binlog_table_id, value);
-                Some(value)
+                self.binlog_table_id_to_table_index_map
+                    .insert(binlog_table_id, table_index);
+                Some(table_index)
             } else {
-                self.known_missing.insert(binlog_table_id);
+                self.known_missing_tme_table_ids.insert(binlog_table_id);
                 None
             }
         }
+    }
+
+    pub fn find_table_by_object_name(
+        &self,
+        object_name: &sqlparser::ast::ObjectName,
+        fallback_schema: &[u8],
+    ) -> Option<&TableDefinition> {
+        let object_name = &object_name.0;
+        if object_name.is_empty() || object_name.len() > 2 {
+            return None;
+        }
+        let table_name = &object_name.last().unwrap().value;
+        let database_name = if object_name.len() > 1 {
+            object_name.first().unwrap().value.as_str().into()
+        } else {
+            String::from_utf8_lossy(fallback_schema)
+        };
+        let database_name = database_name.deref();
+        self.tables.iter().find(|td| {
+            td.table_name.eq_ignore_ascii_case(table_name)
+                && td.database_name.eq_ignore_ascii_case(database_name)
+        })
+    }
+
+    pub fn databases(&self) -> &HashSet<String> {
+        &self.databases
+    }
+
+    fn get_unique_databases_set(tables: &[TableDefinition]) -> HashSet<String> {
+        tables.iter().map(|td| td.database_name.clone()).collect()
     }
 }
 
@@ -870,4 +1165,37 @@ mod tests {
             None::<BinlogValue<'_>>.into_field(&FieldType::Int).unwrap(),
         );
     }
+}
+
+trait ByteSliceExt {
+    fn trim_start(&self) -> &[u8];
+    fn starts_with_case_insensitive(&self, prefix: &[u8]) -> bool;
+}
+
+impl ByteSliceExt for [u8] {
+    fn trim_start(&self) -> &[u8] {
+        for i in 0..self.len() {
+            if !self[i].is_ascii_whitespace() {
+                return &self[i..];
+            }
+        }
+        &[]
+    }
+
+    fn starts_with_case_insensitive(&self, prefix: &[u8]) -> bool {
+        if self.len() < prefix.len() {
+            false
+        } else {
+            self[..prefix.len()].eq_ignore_ascii_case(prefix)
+        }
+    }
+}
+
+fn object_name_to_string(object_name: &sqlparser::ast::ObjectName) -> String {
+    object_name
+        .0
+        .iter()
+        .map(|ident| ident.value.as_str())
+        .collect::<Vec<_>>()
+        .join(".")
 }

--- a/dozer-ingestion/mysql/src/conversion.rs
+++ b/dozer-ingestion/mysql/src/conversion.rs
@@ -72,6 +72,71 @@ pub fn get_field_type_for_mysql_column_type(
     Ok(field_type)
 }
 
+pub fn get_field_type_for_sql_type(sql_data_type: &sqlparser::ast::DataType) -> FieldType {
+    use sqlparser::ast::DataType;
+    match sql_data_type {
+        DataType::Character(_)
+        | DataType::Char(_)
+        | DataType::String(_)
+        | DataType::Enum(_)
+        | DataType::Set(_) => FieldType::String,
+        DataType::CharacterVarying(_)
+        | DataType::CharVarying(_)
+        | DataType::Varchar(_)
+        | DataType::Nvarchar(_)
+        | DataType::Text => FieldType::Text,
+        DataType::Uuid
+        | DataType::CharacterLargeObject(_)
+        | DataType::CharLargeObject(_)
+        | DataType::Clob(_)
+        | DataType::Regclass
+        | DataType::Custom(_, _)
+        | DataType::Array(_)
+        | DataType::Struct(_) => unreachable!("MySQL does not support this type: {sql_data_type}"),
+        DataType::Binary(_)
+        | DataType::Varbinary(_)
+        | DataType::Blob(_)
+        | DataType::Bytes(_)
+        | DataType::Bytea => FieldType::Binary,
+        DataType::Numeric(_)
+        | DataType::Decimal(_)
+        | DataType::BigNumeric(_)
+        | DataType::BigDecimal(_)
+        | DataType::Dec(_) => FieldType::Decimal,
+        DataType::Float(_)
+        | DataType::Float4
+        | DataType::Float64
+        | DataType::Real
+        | DataType::Float8
+        | DataType::Double
+        | DataType::DoublePrecision => FieldType::Float,
+        DataType::TinyInt(_)
+        | DataType::Int2(_)
+        | DataType::SmallInt(_)
+        | DataType::MediumInt(_)
+        | DataType::Int(_)
+        | DataType::Int4(_)
+        | DataType::Int64
+        | DataType::Integer(_)
+        | DataType::BigInt(_)
+        | DataType::Int8(_) => FieldType::Int,
+        DataType::UnsignedTinyInt(_)
+        | DataType::UnsignedInt2(_)
+        | DataType::UnsignedSmallInt(_)
+        | DataType::UnsignedMediumInt(_)
+        | DataType::UnsignedInt(_)
+        | DataType::UnsignedInt4(_)
+        | DataType::UnsignedInteger(_)
+        | DataType::UnsignedBigInt(_)
+        | DataType::UnsignedInt8(_) => FieldType::UInt,
+        DataType::Bool | DataType::Boolean => FieldType::Boolean,
+        DataType::Date => FieldType::Date,
+        DataType::Time(_, _) | DataType::Interval => FieldType::Duration,
+        DataType::Datetime(_) | DataType::Timestamp(_, _) => FieldType::Timestamp,
+        DataType::JSON => FieldType::Json,
+    }
+}
+
 pub trait IntoFields<'a> {
     type Ctx: 'a;
 

--- a/dozer-ingestion/mysql/src/lib.rs
+++ b/dozer-ingestion/mysql/src/lib.rs
@@ -1,6 +1,7 @@
 use dozer_ingestion_connector::dozer_types::{
     errors::types::DeserializationError,
     thiserror::{self, Error},
+    types::FieldType,
 };
 use geozero::error::GeozeroError;
 
@@ -49,5 +50,50 @@ pub enum MySQLConnectorError {
     QueryResultError(#[source] mysql_async::Error),
 
     #[error("Schema had a breaking change: {0}")]
-    BreakingSchemaChange(String),
+    BreakingSchemaChange(#[from] BreakingSchemaChange),
+}
+
+#[derive(Error, Debug)]
+pub enum BreakingSchemaChange {
+    #[error("Database \"{0}\" was dropped")]
+    DatabaseDropped(String),
+    #[error("Table \"{0}\" was dropped")]
+    TableDropped(String),
+    #[error("Table \"{0}\" has been dropped or renamed")]
+    TableDroppedOrRenamed(String),
+    #[error("Multiple tables have been dropped or renamed: {}", .0.join(", "))]
+    MultipleTablesDroppedOrRenamed(Vec<String>),
+    #[error("Table \"{old_table_name}\" was renamed to \"{new_table_name}\"")]
+    TableRenamed {
+        old_table_name: String,
+        new_table_name: String,
+    },
+    #[error("Column \"{column_name}\" from table \"{table_name}\" was dropped")]
+    ColumnDropped {
+        table_name: String,
+        column_name: String,
+    },
+    #[error("Column \"{old_column_name}\" from table \"{table_name}\" was renamed to \"{new_column_name}\"")]
+    ColumnRenamed {
+        table_name: String,
+        old_column_name: String,
+        new_column_name: String,
+    },
+    #[error("Column \"{column_name}\" from table \"{table_name}\" has been dropped or renamed")]
+    ColumnDroppedOrRenamed {
+        table_name: String,
+        column_name: String,
+    },
+    #[error("Multiple columns from table \"{table_name}\" have been dropped or renamed: {}", .columns.join(", "))]
+    MultipleColumnsDroppedOrRenamed {
+        table_name: String,
+        columns: Vec<String>,
+    },
+    #[error("Column \"{column_name}\" from table \"{table_name}\" changed data type from \"{old_data_type}\" to \"{new_column_name}\"")]
+    ColumnDataTypeChanged {
+        table_name: String,
+        column_name: String,
+        old_data_type: FieldType,
+        new_column_name: FieldType,
+    },
 }

--- a/dozer-ingestion/mysql/src/lib.rs
+++ b/dozer-ingestion/mysql/src/lib.rs
@@ -47,4 +47,7 @@ pub enum MySQLConnectorError {
 
     #[error("Failed to fetch query result. {0}")]
     QueryResultError(#[source] mysql_async::Error),
+
+    #[error("Schema had a breaking change: {0}")]
+    BreakingSchemaChange(String),
 }

--- a/dozer-ingestion/mysql/src/schema.rs
+++ b/dozer-ingestion/mysql/src/schema.rs
@@ -25,14 +25,32 @@ pub struct ColumnDefinition {
     pub primary_key: bool,
 }
 
-#[derive(Clone, Debug)]
-pub struct SchemaHelper<'a, 'b> {
+#[derive(Debug, Clone, Copy)]
+pub struct SchemaHelper<'a> {
     conn_url: &'a String,
-    conn_pool: &'b Pool,
+    conn_pool: &'a Pool,
 }
 
-impl SchemaHelper<'_, '_> {
-    pub fn new<'a, 'b>(conn_url: &'a String, conn_pool: &'b Pool) -> SchemaHelper<'a, 'b> {
+impl TableDefinition {
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", self.database_name, self.table_name)
+    }
+}
+
+impl std::fmt::Display for TableDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.qualified_name().as_str())
+    }
+}
+
+impl std::fmt::Display for ColumnDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name.as_str())
+    }
+}
+
+impl SchemaHelper<'_> {
+    pub fn new<'a>(conn_url: &'a String, conn_pool: &'a Pool) -> SchemaHelper<'a> {
         SchemaHelper {
             conn_url,
             conn_pool,
@@ -115,10 +133,13 @@ impl SchemaHelper<'_, '_> {
         Ok(table_infos)
     }
 
-    pub async fn get_table_definitions(
+    pub async fn get_table_definitions<'a, T>(
         &self,
-        table_infos: &[TableInfo],
-    ) -> Result<Vec<TableDefinition>, MySQLConnectorError> {
+        table_infos: &'a [T],
+    ) -> Result<Vec<TableDefinition>, MySQLConnectorError>
+    where
+        TableInfoRef<'a>: From<&'a T>,
+    {
         if table_infos.is_empty() {
             return Ok(Vec::new());
         }
@@ -190,6 +211,150 @@ impl SchemaHelper<'_, '_> {
         Ok(table_definitions)
     }
 
+    pub async fn refresh_column_ordinals(
+        &self,
+        tables: &mut [&mut TableDefinition],
+    ) -> Result<(), MySQLConnectorError> {
+        if tables.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = self.connect().await?;
+
+        let mut query_params: Vec<Value> = Vec::new();
+        let query = format!(
+            "
+            SELECT {} AS table_index, {} as column_index, ordinal_position
+            FROM information_schema.columns
+            WHERE {}
+            ",
+            SqlHelper::table_index_case_expression(tables, &mut query_params),
+            SqlHelper::column_index_case_expression(tables, &mut query_params),
+            SqlHelper::select_columns_filter_predicate(tables, &mut query_params),
+        );
+
+        let mut rows = conn.exec_iter(query, query_params);
+
+        while let Some(result) = rows.next().await {
+            let row = result.map_err(MySQLConnectorError::QueryResultError)?;
+            let (table_index, column_index, ordinal_position) =
+                from_row::<(usize, usize, u32)>(row);
+
+            let table = &mut tables[table_index];
+            let column = &mut table.columns[column_index];
+            column.ordinal_position = ordinal_position;
+        }
+
+        tables.iter_mut().for_each(|table| {
+            table
+                .columns
+                .sort_unstable_by_key(|column| column.ordinal_position)
+        });
+
+        Ok(())
+    }
+
+    pub async fn refresh_schema_and_check_for_breaking_changes(
+        &self,
+        tables: &mut [TableDefinition],
+    ) -> Result<(), MySQLConnectorError> {
+        let new_schema = self.get_table_definitions(tables).await?;
+
+        // Check missing tables
+        if new_schema.len() != tables.len() {
+            let missing = tables
+                .iter()
+                .filter(
+                    |TableDefinition {
+                         table_name,
+                         database_name,
+                         ..
+                     }| {
+                        !new_schema.iter().any(|td| {
+                            td.table_name.eq(table_name) && td.database_name.eq(database_name)
+                        })
+                    },
+                )
+                .collect::<Vec<_>>();
+            if missing.len() == 1 {
+                Err(MySQLConnectorError::BreakingSchemaChange(format!(
+                    "Table \"{}\" has been dropped or renamed",
+                    missing[0]
+                )))?
+            } else {
+                Err(MySQLConnectorError::BreakingSchemaChange(format!(
+                    "Multiple tables have been dropped or renamed: {}",
+                    missing
+                        .iter()
+                        .map(|td| td.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )))?
+            }
+        }
+
+        // Check missing columns and data type changes
+        for (old, new) in tables.iter_mut().zip(new_schema) {
+            debug_assert_eq!(old.table_index, new.table_index);
+            debug_assert_eq!(old.table_name, new.table_name);
+            debug_assert_eq!(old.database_name, new.database_name);
+
+            // Check missing columns
+            if old.columns.len() != new.columns.len() {
+                let missing = old
+                    .columns
+                    .iter()
+                    .filter(
+                        |ColumnDefinition {
+                             name: column_name, ..
+                         }| {
+                            !new.columns.iter().any(|cd| cd.name.eq(column_name))
+                        },
+                    )
+                    .collect::<Vec<_>>();
+                if missing.len() == 1 {
+                    Err(MySQLConnectorError::BreakingSchemaChange(format!(
+                        "Column \"{}\" from table \"{}\" has been dropped or renamed",
+                        missing[0], old
+                    )))?
+                } else {
+                    Err(MySQLConnectorError::BreakingSchemaChange(format!(
+                        "Multiple columns from table \"{}\" have been dropped or renamed: {}",
+                        old,
+                        missing
+                            .iter()
+                            .map(|cd| cd.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )))?
+                }
+            }
+
+            // Check data type change
+            for old_column in old.columns.iter() {
+                let new_column = new
+                    .columns
+                    .iter()
+                    .find(|cd| cd.name == old_column.name)
+                    .unwrap();
+
+                if old_column.typ != new_column.typ {
+                    Err(MySQLConnectorError::BreakingSchemaChange(format!(
+                        "Column \"{}\" from table \"{}\" has changed data type from \"{}\" to \"{}\"",
+                        old_column, old, old_column.typ, new_column.typ
+                    )))?
+                }
+            }
+
+            // TODO: check nullable and primary key change
+
+            // Checks passed; update schema
+            *old = new;
+        }
+
+        Ok(())
+    }
+
     const MARIADB_JSON_CHECK: &'static str = "(column_type = 'longtext'
         AND (
             SELECT COUNT(*) > 0
@@ -235,65 +400,14 @@ impl SchemaHelper<'_, '_> {
 
                 select
             },
-            // where clause: filter by table name and table schema
-            table_infos
-                .iter()
-                .map(Into::into)
-                .map(
-                    |TableInfoRef {
-                         schema,
-                         name,
-                         column_names,
-                     }| {
-                        query_params.push(name.into());
-                        let mut condition = "(table_name = ? AND table_schema = ".to_string();
-                        if let Some(schema) = schema {
-                            query_params.push(schema.into());
-                            condition.push('?');
-                        } else {
-                            condition.push_str("DATABASE()");
-                        }
-                        if !column_names.is_empty() {
-                            condition.push_str(" AND column_name IN (");
-                            for (i, column) in column_names.iter().enumerate() {
-                                query_params.push(column.into());
-                                if i == 0 {
-                                    condition.push('?');
-                                } else {
-                                    condition.push_str(", ?");
-                                }
-                            }
-                            condition.push(')');
-                        }
-                        condition.push(')');
-                        condition
-                    }
-                )
-                .collect::<Vec<String>>()
-                .join(" OR "),
+            // where clause: filter by table name and table schema and column names
+            SqlHelper::select_columns_filter_predicate(table_infos, &mut query_params),
             // order by clause: preserve the order of the input tables in the output
             {
-                let mut case = String::from("CASE ");
-
-                table_infos.iter().map(Into::into).enumerate().for_each(
-                    |(i, TableInfoRef { schema, name, .. })| {
-                        case.push_str("WHEN (table_name = ? AND table_schema = ");
-                        query_params.push(name.into());
-
-                        if let Some(schema) = schema {
-                            query_params.push(schema.into());
-                            case.push('?');
-                        } else {
-                            case.push_str("DATABASE()");
-                        }
-                        case.push(')');
-                        case.push_str(" THEN ? ");
-                        query_params.push(i.into());
-                    },
-                );
-
-                case.push_str("END ASC");
-                case
+                let table_index_expression =
+                    SqlHelper::table_index_case_expression(table_infos, &mut query_params);
+                let order_by = format!("{} ASC", table_index_expression);
+                order_by
             }
         );
 
@@ -309,10 +423,125 @@ impl SchemaHelper<'_, '_> {
     }
 }
 
-struct TableInfoRef<'a> {
+struct SqlHelper;
+
+impl SqlHelper {
+    fn table_index_case_expression<'a, T>(tables: &'a [T], query_params: &mut Vec<Value>) -> String
+    where
+        TableInfoRef<'a>: From<&'a T>,
+    {
+        let mut case = String::from("CASE ");
+
+        tables.iter().map(Into::into).enumerate().for_each(
+            |(i, TableInfoRef { schema, name, .. })| {
+                case.push_str("WHEN (table_name = ? AND table_schema = ");
+                query_params.push(name.into());
+
+                if let Some(schema) = schema {
+                    query_params.push(schema.into());
+                    case.push('?');
+                } else {
+                    case.push_str("DATABASE()");
+                }
+                case.push(')');
+                case.push_str(" THEN ? ");
+                query_params.push(i.into());
+            },
+        );
+
+        case.push_str("END");
+        case
+    }
+
+    fn column_index_case_expression<'a, T>(tables: &'a [T], query_params: &mut Vec<Value>) -> String
+    where
+        TableInfoRef<'a>: From<&'a T>,
+    {
+        let mut case = String::from("CASE ");
+
+        tables.iter().map(Into::into).for_each(
+            |TableInfoRef {
+                 column_names,
+                 schema,
+                 name: table_name,
+             }| {
+                column_names
+                    .iter()
+                    .enumerate()
+                    .for_each(|(i, &column_name)| {
+                        case.push_str("WHEN (table_name = ? AND table_schema = ");
+                        query_params.push(table_name.into());
+
+                        if let Some(schema) = schema {
+                            query_params.push(schema.into());
+                            case.push('?');
+                        } else {
+                            case.push_str("DATABASE()");
+                        }
+                        case.push_str(" AND column_name = ?");
+                        query_params.push(column_name.into());
+                        case.push(')');
+
+                        case.push_str(" THEN ? ");
+                        query_params.push(i.into());
+                    })
+            },
+        );
+
+        case.push_str("END");
+        case
+    }
+
+    fn select_columns_filter_predicate<'a, T>(
+        tables: &'a [T],
+        query_params: &mut Vec<Value>,
+    ) -> String
+    where
+        TableInfoRef<'a>: From<&'a T>,
+    {
+        let predicate = tables
+            .iter()
+            .map(Into::into)
+            .map(
+                |TableInfoRef {
+                     schema,
+                     name,
+                     column_names,
+                 }| {
+                    query_params.push(name.into());
+                    let mut condition = "(table_name = ? AND table_schema = ".to_string();
+                    if let Some(schema) = schema {
+                        query_params.push(schema.into());
+                        condition.push('?');
+                    } else {
+                        condition.push_str("DATABASE()");
+                    }
+                    if !column_names.is_empty() {
+                        condition.push_str(" AND column_name IN (");
+                        for (i, column) in column_names.iter().enumerate() {
+                            query_params.push(column.into());
+                            if i == 0 {
+                                condition.push('?');
+                            } else {
+                                condition.push_str(", ?");
+                            }
+                        }
+                        condition.push(')');
+                    }
+                    condition.push(')');
+                    condition
+                },
+            )
+            .collect::<Vec<String>>()
+            .join(" OR ");
+        predicate
+    }
+}
+
+pub struct TableInfoRef<'a> {
     pub schema: Option<&'a str>,
     pub name: &'a str,
-    pub column_names: &'a [String],
+    pub column_names: Vec<&'a String>,
 }
 
 impl<'a> From<&'a TableIdentifier> for TableInfoRef<'a> {
@@ -320,7 +549,7 @@ impl<'a> From<&'a TableIdentifier> for TableInfoRef<'a> {
         Self {
             schema: value.schema.as_deref(),
             name: &value.name,
-            column_names: &[],
+            column_names: vec![],
         }
     }
 }
@@ -330,7 +559,27 @@ impl<'a> From<&'a TableInfo> for TableInfoRef<'a> {
         Self {
             schema: value.schema.as_deref(),
             name: &value.name,
-            column_names: &value.column_names,
+            column_names: value.column_names.iter().collect(),
+        }
+    }
+}
+
+impl<'a> From<&'a TableDefinition> for TableInfoRef<'a> {
+    fn from(value: &'a TableDefinition) -> Self {
+        Self {
+            schema: Some(value.database_name.as_str()),
+            name: &value.table_name,
+            column_names: value.columns.iter().map(|cd| &cd.name).collect(),
+        }
+    }
+}
+
+impl<'a> From<&'a &mut TableDefinition> for TableInfoRef<'a> {
+    fn from(value: &'a &mut TableDefinition) -> Self {
+        Self {
+            schema: Some(value.database_name.as_str()),
+            name: &value.table_name,
+            column_names: value.columns.iter().map(|cd| &cd.name).collect(),
         }
     }
 }


### PR DESCRIPTION
Handle schema changes in MySQL connector.
Breaking schema changes stop the ingestion with an error. Non-breaking schema changes do not affect ingestion.

Breaking changes are:
- Dropping or renaming a database, table, or a column in a table that is being ingested
- Change in the data-type of a column that is being ingested that results in a different dozer field data-type.

Non-breaking changes are:
- Column reordering
- Addition of columns
- Dropping or renaming databases, columns, and tables that are not being ingested
- Superficial change in column data-type such that the dozer field data-type is unchanged

Implementation notes:
`sqlparser` is used for parsing `ALTER TABLE` SQL queries from MySQL Binlog to determine the type of schema change that occurred, and choose an appropriate action, based on whether the schema change is breaking or non-breaking. However, `sqlparser` fails to parse some `ALTER TABLE` statements because MySQL dialect support is incomplete. For this reason, there is a fall-back mode that reloads the entire schema and manually discovers changes by comparing the old schema with the new one. As reloading the entire schema is less efficient, it is delayed until it is required, which is when the subsequent data operation arrives. This way, only one schema refresh is done for multiple `ALTER TABLE` operations if they arrive sequentially, instead of doing a full schema refresh for each `ALTER TABLE` operation individually.