### PR TITLE
feat: Add `CheckpointedLogReader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,7 @@ dependencies = [
 name = "dozer-log"
 version = "0.3.0"
 dependencies = [
+ "async-stream",
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-http",

--- a/dozer-cli/src/pipeline/dummy_sink.rs
+++ b/dozer-cli/src/pipeline/dummy_sink.rs
@@ -47,7 +47,7 @@ impl Sink for DummySink {
         Ok(())
     }
 
-    fn persist(&mut self, _queue: &Queue) -> Result<(), BoxedError> {
+    fn persist(&mut self, _epoch: &Epoch, _queue: &Queue) -> Result<(), BoxedError> {
         Ok(())
     }
 

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -111,10 +111,13 @@ impl Sink for LogSink {
         Ok(())
     }
 
-    fn persist(&mut self, queue: &Queue) -> Result<(), BoxedError> {
-        self.runtime
-            .block_on(self.log.lock())
-            .persist(queue, self.log.clone(), &self.runtime)?;
+    fn persist(&mut self, epoch: &Epoch, queue: &Queue) -> Result<(), BoxedError> {
+        self.runtime.block_on(self.log.lock()).persist(
+            epoch.common_info.id,
+            queue,
+            self.log.clone(),
+            &self.runtime,
+        )?;
         Ok(())
     }
 

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use crate::checkpoint::serialize::{DeserializationError, SerializationError};
 use crate::node::PortHandle;
+use dozer_log::reader::CheckpointedLogReaderError;
 use dozer_recordstore::RecordStoreError;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
@@ -44,8 +45,8 @@ pub enum ExecutionError {
     ObjectStorage(#[from] dozer_log::storage::Error),
     #[error("Checkpoint writer thread panicked")]
     CheckpointWriterThreadPanicked,
-    #[error("Unrecognized checkpoint: {0}")]
-    UnrecognizedCheckpoint(String),
+    #[error("Checkpointed log reader error: {0}")]
+    CheckpointedLogReader(#[from] CheckpointedLogReaderError),
     #[error("Cannot deserialize checkpoint: {0}")]
     CorruptedCheckpoint(#[source] bincode::error::DecodeError),
     #[error("Table {table_name} of source {source_name} cannot restart. You have to clean data from previous runs by running `dozer clean`")]

--- a/dozer-core/src/executor/sink_node.rs
+++ b/dozer-core/src/executor/sink_node.rs
@@ -143,7 +143,7 @@ impl ReceiverLoop for SinkNode {
         }
 
         if let Some(queue) = epoch.common_info.sink_persist_queue.as_ref() {
-            if let Err(e) = self.sink.persist(queue) {
+            if let Err(e) = self.sink.persist(epoch, queue) {
                 self.error_manager.report(e);
             }
         }

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -117,7 +117,7 @@ pub trait Sink: Send + Sync + Debug {
         record_store: &ProcessorRecordStore,
         op: ProcessorOperation,
     ) -> Result<(), BoxedError>;
-    fn persist(&mut self, queue: &Queue) -> Result<(), BoxedError>;
+    fn persist(&mut self, epoch: &Epoch, queue: &Queue) -> Result<(), BoxedError>;
 
     fn on_source_snapshotting_done(&mut self, connection_name: String) -> Result<(), BoxedError>;
 }

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -491,7 +491,7 @@ impl Sink for ErrSink {
         Ok(())
     }
 
-    fn persist(&mut self, _queue: &Queue) -> Result<(), BoxedError> {
+    fn persist(&mut self, _epoch: &Epoch, _queue: &Queue) -> Result<(), BoxedError> {
         Ok(())
     }
 

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -86,7 +86,7 @@ impl Sink for CountingSink {
         Ok(())
     }
 
-    fn persist(&mut self, _queue: &Queue) -> Result<(), BoxedError> {
+    fn persist(&mut self, _epoch: &Epoch, _queue: &Queue) -> Result<(), BoxedError> {
         Ok(())
     }
 

--- a/dozer-lambda/src/js/tests.rs
+++ b/dozer-lambda/src/js/tests.rs
@@ -131,6 +131,8 @@ mod mock {
                     storage: Some(Storage::Local(LocalStorage {
                         root: "mock".to_string(),
                     })),
+                    checkpoint_prefix: "mock-checkpoint".to_string(),
+                    log_prefix: "mock-log".to_string(),
                 }))
             } else {
                 err_not_found(&endpoint)

--- a/dozer-log/Cargo.toml
+++ b/dozer-log/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 
 [dependencies]
+async-stream = "0.3.5"
 aws-config = "0.56.1"
 aws-sdk-s3 = "0.34.0"
 aws-smithy-http = "0.56.1"

--- a/dozer-log/src/reader/checkpoint.rs
+++ b/dozer-log/src/reader/checkpoint.rs
@@ -1,0 +1,170 @@
+use async_stream::try_stream;
+use camino::{Utf8Path, Utf8PathBuf};
+use dozer_types::{
+    grpc_types::internal::{
+        internal_pipeline_service_client::InternalPipelineServiceClient, StorageRequest,
+    },
+    thiserror,
+    tonic::{
+        self,
+        transport::{self, Channel},
+    },
+};
+use futures_util::{Stream, StreamExt};
+
+use crate::{
+    reader::create_storage,
+    replication::{self, load_persisted_log_entries, PersistedLogEntry},
+    storage::{self, Storage},
+};
+
+#[derive(Debug)]
+pub struct CheckpointedLogReader {
+    client: InternalPipelineServiceClient<Channel>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("connect to internal service: {0}")]
+    Connect(#[from] transport::Error),
+    #[error("describe storage of endpoint {0}: {1}")]
+    DescribeStorage(String, #[source] tonic::Status),
+    #[error("storage: {0}")]
+    Storage(#[from] storage::Error),
+    #[error("unrecognized checkpoint: {0}")]
+    UnrecognizedCheckpoint(String),
+    #[error("replication error: {0}")]
+    Replication(#[from] replication::Error),
+}
+
+impl CheckpointedLogReader {
+    pub async fn new(app_server_url: String) -> Result<Self, Error> {
+        let client = InternalPipelineServiceClient::connect(app_server_url).await?;
+        Ok(Self { client })
+    }
+
+    pub async fn list_entries(
+        &mut self,
+        endpoint: String,
+    ) -> Result<(Box<dyn Storage>, Vec<PersistedLogEntry>), Error> {
+        // Request storage information.
+        let storage_response = self
+            .client
+            .describe_storage(StorageRequest {
+                endpoint: endpoint.clone(),
+            })
+            .await
+            .map_err(|e| Error::DescribeStorage(endpoint.clone(), e))?
+            .into_inner();
+        let storage = create_storage(storage_response.storage.expect("Must not be None")).await?;
+
+        // Find last epoch id.
+        let mut last_epoch_id = None;
+        {
+            let stream = list_record_store_slices(&*storage, &storage_response.checkpoint_prefix);
+            let mut stream = std::pin::pin!(stream);
+            while let Some(meta) = stream.next().await {
+                let meta = meta?;
+                last_epoch_id = Some(meta.epoch_id);
+            }
+        }
+
+        // Load persisted log entries.
+        let entries =
+            load_persisted_log_entries(&*storage, storage_response.log_prefix, last_epoch_id)
+                .await?;
+
+        Ok((storage, entries))
+    }
+}
+
+pub struct RecordStoreSliceMeta {
+    pub key: String,
+    pub epoch_id: u64,
+    pub processor_prefix: Utf8PathBuf,
+}
+
+pub fn list_record_store_slices<'a>(
+    storage: &'a dyn Storage,
+    checkpoint_prefix: &'a str,
+) -> impl Stream<Item = Result<RecordStoreSliceMeta, Error>> + 'a {
+    let record_store_prefix = record_store_prefix(checkpoint_prefix);
+    let mut continuation_token = None;
+    try_stream! {
+        loop {
+            let objects = storage
+                .list_objects(record_store_prefix.to_string(), continuation_token)
+                .await?;
+
+            for object in objects.objects {
+                let object_name = AsRef::<Utf8Path>::as_ref(&object.key)
+                    .strip_prefix(&record_store_prefix)
+                    .map_err(|_| Error::UnrecognizedCheckpoint(object.key.clone()))?;
+                let epoch_id = object_name
+                    .as_str()
+                    .parse()
+                    .map_err(|_| Error::UnrecognizedCheckpoint(object.key.clone()))?;
+                let processor_prefix = processor_prefix(checkpoint_prefix, epoch_id);
+                yield RecordStoreSliceMeta {
+                    key: object.key,
+                    epoch_id,
+                    processor_prefix,
+                };
+            }
+
+            continuation_token = objects.continuation_token;
+            if continuation_token.is_none() {
+                break;
+            }
+        }
+    }
+}
+
+pub fn processor_prefix(checkpoint_prefix: &str, epoch_id: u64) -> Utf8PathBuf {
+    AsRef::<Utf8Path>::as_ref(checkpoint_prefix).join(format!("{:020}", epoch_id))
+}
+
+fn record_store_prefix(checkpoint_prefix: &str) -> Utf8PathBuf {
+    AsRef::<Utf8Path>::as_ref(checkpoint_prefix).join("record_store")
+}
+
+pub fn record_store_key(checkpoint_prefix: &str, epoch_id: u64) -> Utf8PathBuf {
+    // Format with `u64` max number of digits.
+    record_store_prefix(checkpoint_prefix).join(format!("{:020}", epoch_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::replication::load_persisted_log_entry;
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "this is an example of using `CheckpointedLogReader`"]
+    async fn test_checkpointed_log_reader() {
+        let mut reader = CheckpointedLogReader::new("http://localhost:50051".into())
+            .await
+            .unwrap();
+        let endpoint = "test_endpoint";
+
+        let mut current_end = 0;
+        loop {
+            let (storage, entries) = reader.list_entries(endpoint.to_string()).await.unwrap();
+            let new_entries = entries
+                .into_iter()
+                .filter(|entry| entry.range.start > current_end)
+                .collect::<Vec<_>>();
+            for new_entry in &new_entries {
+                let _operations = load_persisted_log_entry(&*storage, new_entry)
+                    .await
+                    .unwrap();
+            }
+
+            if let Some(entry) = new_entries.last() {
+                current_end = entry.range.end;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        }
+    }
+}

--- a/dozer-log/src/replication/tests.rs
+++ b/dozer-log/src/replication/tests.rs
@@ -13,7 +13,7 @@ use crate::{
 
 async fn create_test_log() -> (TempDir, Arc<Mutex<Log>>, Queue) {
     let (temp_dir, storage) = create_temp_dir_local_storage().await;
-    let log = Log::new(&*storage, "log".to_string(), 0).await.unwrap();
+    let log = Log::new(&*storage, "log".to_string(), None).await.unwrap();
     let queue = Queue::new(storage, 10).0;
     (temp_dir, Arc::new(Mutex::new(log)), queue)
 }
@@ -115,7 +115,7 @@ fn watch_partial() {
     std::thread::spawn(move || {
         runtime_clone
             .block_on(log.lock())
-            .persist(&queue, log.clone(), &runtime_clone)
+            .persist(0, &queue, log.clone(), &runtime_clone)
             .unwrap();
     })
     .join()
@@ -159,7 +159,7 @@ fn watch_out_of_range() {
     std::thread::spawn(move || {
         runtime_clone
             .block_on(log_clone.lock())
-            .persist(&queue, log_clone.clone(), &runtime_clone)
+            .persist(0, &queue, log_clone.clone(), &runtime_clone)
             .unwrap();
     })
     .join()
@@ -200,7 +200,7 @@ fn in_memory_log_should_shrink_after_persist() {
     let handle = std::thread::spawn(move || {
         runtime_clone
             .block_on(log_clone.lock())
-            .persist(&queue, log_clone.clone(), &runtime_clone)
+            .persist(0, &queue, log_clone.clone(), &runtime_clone)
             .unwrap()
     })
     .join()

--- a/dozer-sql/src/tests/builder_test.rs
+++ b/dozer-sql/src/tests/builder_test.rs
@@ -182,7 +182,7 @@ impl Sink for TestSink {
         Ok(())
     }
 
-    fn persist(&mut self, _queue: &Queue) -> Result<(), BoxedError> {
+    fn persist(&mut self, _epoch: &Epoch, _queue: &Queue) -> Result<(), BoxedError> {
         Ok(())
     }
 

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -255,7 +255,7 @@ impl Sink for TestSink {
         Ok(())
     }
 
-    fn persist(&mut self, _queue: &Queue) -> Result<(), BoxedError> {
+    fn persist(&mut self, _epoch: &Epoch, _queue: &Queue) -> Result<(), BoxedError> {
         Ok(())
     }
 

--- a/dozer-types/protos/internal.proto
+++ b/dozer-types/protos/internal.proto
@@ -37,6 +37,8 @@ message StorageResponse {
     LocalStorage local = 1;
     S3Storage s3 = 2;
   };
+  string checkpoint_prefix = 3;
+  string log_prefix = 4;
 }
 
 message DescribeApplicationResponse {


### PR DESCRIPTION
This PR adds `CheckpointedLogReader` which only reads the checkpointed log entries, hence ensuring exact once semantics.

It's not backward compatible because it changes the log entry naming convention to include epoch id in the name.