### PR TITLE
refactor: Change `OpIdentifier` to `RestartableState`

### DIFF
--- a/dozer-cli/src/cli/helper.rs
+++ b/dozer-cli/src/cli/helper.rs
@@ -103,7 +103,7 @@ async fn load_config(
     ignore_pipe: bool,
 ) -> Result<(Config, Vec<String>), CliError> {
     let read_stdin = atty::isnt(Stream::Stdin) && !ignore_pipe;
-    let first_config_path = config_url_or_paths.get(0);
+    let first_config_path = config_url_or_paths.first();
     match first_config_path {
         None => Err(ConfigurationFilePathNotProvided),
         Some(path) => {

--- a/dozer-cli/src/pipeline/connector_source.rs
+++ b/dozer-cli/src/pipeline/connector_source.rs
@@ -262,12 +262,12 @@ impl Source for ConnectorSource {
                         .iter()
                         .zip(&self.ports)
                         .map(|(table, port)| {
-                            let checkpoint = last_checkpoint.get(port).copied().flatten();
+                            let state = last_checkpoint.get(port).cloned().flatten();
                             TableToIngest {
                                 schema: table.schema.clone(),
                                 name: table.name.clone(),
                                 column_names: table.column_names.clone(),
-                                checkpoint,
+                                state,
                             }
                         })
                         .collect::<Vec<_>>();

--- a/dozer-core/src/builder_dag.rs
+++ b/dozer-core/src/builder_dag.rs
@@ -81,7 +81,7 @@ impl BuilderDag {
                             last_checkpoint_by_name
                                 .as_mut()
                                 .and_then(|last_checkpoint| {
-                                    last_checkpoint.remove(&port_name).flatten()
+                                    last_checkpoint.remove(&port_name).flatten().cloned()
                                 }),
                         );
                     }

--- a/dozer-core/src/forwarder.rs
+++ b/dozer-core/src/forwarder.rs
@@ -222,12 +222,12 @@ impl SourceChannelManager {
         request_termination: bool,
     ) -> Result<bool, ExecutionError> {
         match message {
-            IngestionMessage::OperationEvent { op, id, .. } => {
+            IngestionMessage::OperationEvent { op, state, .. } => {
                 let port_name = self.port_names[&port].clone();
                 self.current_op_ids.insert(
                     port_name,
-                    if let Some(id) = id {
-                        TableState::Restartable(id)
+                    if let Some(state) = state {
+                        TableState::Restartable(state)
                     } else {
                         TableState::NonRestartable
                     },

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -5,7 +5,7 @@ use dozer_recordstore::{ProcessorRecordStore, ProcessorRecordStoreDeserializer};
 
 use dozer_log::storage::{Object, Queue};
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::node::OpIdentifier;
+use dozer_types::node::RestartableState;
 use dozer_types::serde::{Deserialize, Serialize};
 use dozer_types::tonic::async_trait;
 use dozer_types::types::Schema;
@@ -54,7 +54,7 @@ pub trait SourceFactory: Send + Sync + Debug {
     ) -> Result<Box<dyn Source>, BoxedError>;
 }
 
-pub type SourceState = HashMap<PortHandle, Option<OpIdentifier>>;
+pub type SourceState = HashMap<PortHandle, Option<RestartableState>>;
 
 pub trait Source: Send + Sync + Debug {
     fn start(

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -16,7 +16,7 @@ use dozer_log::tokio;
 use dozer_recordstore::{ProcessorRecordStore, ProcessorRecordStoreDeserializer};
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::models::ingestion_types::IngestionMessage;
-use dozer_types::node::{NodeHandle, OpIdentifier};
+use dozer_types::node::NodeHandle;
 use dozer_types::tonic::async_trait;
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
@@ -378,7 +378,7 @@ impl Source for ErrGeneratorSource {
                             Field::String(format!("value_{n}")),
                         ]),
                     },
-                    id: Some(OpIdentifier::new(n, 0)),
+                    state: Some(n.to_be_bytes().to_vec().into()),
                 },
                 GENERATOR_SOURCE_OUTPUT_PORT,
             )?;

--- a/dozer-ingestion/connector/src/ingestor.rs
+++ b/dozer-ingestion/connector/src/ingestor.rs
@@ -96,7 +96,7 @@ mod tests {
             .handle_message(IngestionMessage::OperationEvent {
                 table_index: 0,
                 op: operation.clone(),
-                id: None,
+                state: None,
             })
             .await
             .unwrap();
@@ -104,7 +104,7 @@ mod tests {
             .handle_message(IngestionMessage::OperationEvent {
                 table_index: 0,
                 op: operation2.clone(),
-                id: None,
+                state: None,
             })
             .await
             .unwrap();
@@ -121,7 +121,7 @@ mod tests {
                 IngestionMessage::OperationEvent {
                     table_index: 0,
                     op,
-                    id: None
+                    state: None
                 },
                 msg
             );

--- a/dozer-ingestion/connector/src/lib.rs
+++ b/dozer-ingestion/connector/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::node::OpIdentifier;
+use dozer_types::node::RestartableState;
 use dozer_types::serde;
 use dozer_types::serde::{Deserialize, Serialize};
 pub use dozer_types::tonic::async_trait;
@@ -146,8 +146,8 @@ pub struct TableToIngest {
     pub name: String,
     /// The column names to be mapped.
     pub column_names: Vec<String>,
-    /// The checkpoint to start after.
-    pub checkpoint: Option<OpIdentifier>,
+    /// The state to restart after.
+    pub state: Option<RestartableState>,
 }
 
 impl TableToIngest {
@@ -156,7 +156,7 @@ impl TableToIngest {
             schema: table_info.schema,
             name: table_info.name,
             column_names: table_info.column_names,
-            checkpoint: None,
+            state: None,
         }
     }
 }

--- a/dozer-ingestion/deltalake/src/reader.rs
+++ b/dozer-ingestion/deltalake/src/reader.rs
@@ -40,7 +40,7 @@ impl DeltaLakeReader {
         table: &TableToIngest,
         ingestor: &Ingestor,
     ) -> Result<(), BoxedError> {
-        assert!(table.checkpoint.is_none());
+        assert!(table.state.is_none());
 
         let table_path = table_path(&self.config, &table.name)?;
         let ctx = SessionContext::new();
@@ -75,7 +75,7 @@ impl DeltaLakeReader {
                                 lifetime: None,
                             },
                         },
-                        id: None,
+                        state: None,
                     })
                     .await
                     .unwrap();

--- a/dozer-ingestion/dozer/src/lib.rs
+++ b/dozer-ingestion/dozer/src/lib.rs
@@ -8,6 +8,9 @@ use dozer_log::errors::{ReaderBuilderError, ReaderError};
 
 #[derive(Error, Debug)]
 enum NestedDozerConnectorError {
+    #[error("Failed to parse checkpoint state")]
+    CorruptedState,
+
     #[error("Failed to connect to upstream dozer at {0}: {1:?}")]
     ConnectionError(String, #[source] dozer_types::tonic::transport::Error),
 

--- a/dozer-ingestion/ethereum/src/log/connector.rs
+++ b/dozer-ingestion/ethereum/src/log/connector.rs
@@ -71,7 +71,7 @@ impl EthLogConnector {
                     .map(|t| vec![H256::from_str(t).unwrap()])
                     .collect();
                 builder.topics(
-                    topics.get(0).cloned(),
+                    topics.first().cloned(),
                     topics.get(1).cloned(),
                     topics.get(2).cloned(),
                     topics.get(3).cloned(),

--- a/dozer-ingestion/ethereum/src/log/helper.rs
+++ b/dozer-ingestion/ethereum/src/log/helper.rs
@@ -74,7 +74,8 @@ pub fn decode_event(
     if let Some(contract_tuple) = c {
         // Topics 0, 1, 2 should be name, buyer, seller in most cases
         let name = log
-            .topics.first()
+            .topics
+            .first()
             .expect("name is expected")
             .to_owned()
             .to_string();

--- a/dozer-ingestion/ethereum/src/log/helper.rs
+++ b/dozer-ingestion/ethereum/src/log/helper.rs
@@ -74,8 +74,7 @@ pub fn decode_event(
     if let Some(contract_tuple) = c {
         // Topics 0, 1, 2 should be name, buyer, seller in most cases
         let name = log
-            .topics
-            .get(0)
+            .topics.first()
             .expect("name is expected")
             .to_owned()
             .to_string();

--- a/dozer-ingestion/ethereum/src/log/sender.rs
+++ b/dozer-ingestion/ethereum/src/log/sender.rs
@@ -222,7 +222,7 @@ async fn process_log(details: Arc<EthDetails<'_>>, msg: Log) {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index,
                     op,
-                    id: None,
+                    state: None,
                 })
                 .await
                 .is_err()
@@ -245,7 +245,7 @@ async fn process_log(details: Arc<EthDetails<'_>>, msg: Log) {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index,
                     op,
-                    id: None,
+                    state: None,
                 })
                 .await;
         } else {

--- a/dozer-ingestion/ethereum/src/trace/connector.rs
+++ b/dozer-ingestion/ethereum/src/trace/connector.rs
@@ -155,7 +155,7 @@ pub async fn run(
                                 .handle_message(IngestionMessage::OperationEvent {
                                     table_index: 0, // We have only one table
                                     op,
-                                    id: None,
+                                    state: None,
                                 })
                                 .await
                                 .is_err()

--- a/dozer-ingestion/grpc/src/adapter/arrow.rs
+++ b/dozer-ingestion/grpc/src/adapter/arrow.rs
@@ -115,7 +115,7 @@ pub async fn handle_message(
             .handle_message(IngestionMessage::OperationEvent {
                 table_index,
                 op,
-                id: None,
+                state: None,
             })
             .await
             .is_err()

--- a/dozer-ingestion/grpc/src/adapter/default.rs
+++ b/dozer-ingestion/grpc/src/adapter/default.rs
@@ -88,7 +88,7 @@ pub async fn handle_message(
         .handle_message(IngestionMessage::OperationEvent {
             table_index,
             op,
-            id: None,
+            state: None,
         })
         .await;
     Ok(())

--- a/dozer-ingestion/javascript/src/js_extension/mod.rs
+++ b/dozer-ingestion/javascript/src/js_extension/mod.rs
@@ -120,7 +120,7 @@ async fn send(ingestor: Ingestor, val: JsMessage) -> Result<(), Error> {
             IngestionMessage::OperationEvent {
                 table_index: 0,
                 op,
-                id: None,
+                state: None,
             }
         }
     };

--- a/dozer-ingestion/kafka/src/debezium/mapper.rs
+++ b/dozer-ingestion/kafka/src/debezium/mapper.rs
@@ -383,7 +383,7 @@ mod tests {
         fields_map.insert("weight".to_string(), weight_struct);
 
         let fields = convert_value_to_schema(value, &schema, &fields_map).unwrap();
-        assert_eq!(*fields.get(0).unwrap(), Field::from(1));
+        assert_eq!(*fields.first().unwrap(), Field::from(1));
         assert_eq!(*fields.get(1).unwrap(), Field::from("Product".to_string()));
         assert_eq!(
             *fields.get(2).unwrap(),
@@ -440,7 +440,7 @@ mod tests {
         fields_map.insert("name".to_string(), name_struct);
 
         let fields = convert_value_to_schema(value, &schema, &fields_map).unwrap();
-        assert_eq!(*fields.get(0).unwrap(), Field::from(1));
+        assert_eq!(*fields.first().unwrap(), Field::from(1));
         assert_eq!(*fields.get(1).unwrap(), Field::Null);
     }
 }

--- a/dozer-ingestion/kafka/src/debezium/schema_registry.rs
+++ b/dozer-ingestion/kafka/src/debezium/schema_registry.rs
@@ -97,7 +97,7 @@ impl SchemaRegistry {
         let sr_settings = SrSettings::new(schema_registry_url);
         match table_names {
             None => Ok(vec![]),
-            Some(tables) => match tables.get(0) {
+            Some(tables) => match tables.first() {
                 None => Ok(vec![]),
                 Some(table) => {
                     let key_result =

--- a/dozer-ingestion/kafka/src/debezium/stream_consumer.rs
+++ b/dozer-ingestion/kafka/src/debezium/stream_consumer.rs
@@ -94,7 +94,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
         let topics: Vec<&str> = tables
             .iter()
             .map(|t| {
-                assert!(t.checkpoint.is_none());
+                assert!(t.state.is_none());
                 t.name.as_str()
             })
             .collect();
@@ -154,7 +154,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                         lifetime: None,
                                     },
                                 },
-                                id: None,
+                                state: None,
                             })
                             .await
                             .is_err()
@@ -176,7 +176,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                         lifetime: None,
                                     },
                                 },
-                                id: None,
+                                state: None,
                             })
                             .await
                             .is_err()
@@ -198,7 +198,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                         lifetime: None,
                                     },
                                 },
-                                id: None,
+                                state: None,
                             })
                             .await
                             .is_err()

--- a/dozer-ingestion/kafka/src/stream_consumer_basic.rs
+++ b/dozer-ingestion/kafka/src/stream_consumer_basic.rs
@@ -88,7 +88,7 @@ impl StreamConsumer for StreamConsumerBasic {
 
         let mut schemas = HashMap::new();
         for (table_index, table) in tables.into_iter().enumerate() {
-            assert!(table.checkpoint.is_none());
+            assert!(table.state.is_none());
 
             let schema = if let Some(url) = schema_registry_url {
                 SchemaRegistryBasic::get_single_schema(&table.name, url).await?
@@ -158,7 +158,7 @@ impl StreamConsumer for StreamConsumerBasic {
                                             lifetime: None,
                                         },
                                     },
-                                    id: None,
+                                    state: None,
                                 })
                                 .await
                                 .is_err()

--- a/dozer-ingestion/mongodb/src/lib.rs
+++ b/dozer-ingestion/mongodb/src/lib.rs
@@ -626,7 +626,7 @@ impl Connector for MongodbConnector {
                     .handle_message(IngestionMessage::OperationEvent {
                         table_index,
                         op,
-                        id: None,
+                        state: None,
                     })
                     .await
                     .is_err()
@@ -673,7 +673,7 @@ impl Connector for MongodbConnector {
                     .handle_message(IngestionMessage::OperationEvent {
                         table_index,
                         op,
-                        id: None,
+                        state: None,
                     })
                     .await
                     .is_err()

--- a/dozer-ingestion/mysql/src/binlog.rs
+++ b/dozer-ingestion/mysql/src/binlog.rs
@@ -459,7 +459,7 @@ impl BinlogIngestor<'_, '_, '_> {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index: table.def.table_index,
                     op: op?,
-                    id: None,
+                    state: None,
                 })
                 .await
                 .is_err()

--- a/dozer-ingestion/mysql/src/binlog.rs
+++ b/dozer-ingestion/mysql/src/binlog.rs
@@ -1016,6 +1016,39 @@ impl<'a> BinlogRowsEvent<'a> {
     }
 }
 
+trait ByteSliceExt {
+    fn trim_start(&self) -> &[u8];
+    fn starts_with_case_insensitive(&self, prefix: &[u8]) -> bool;
+}
+
+impl ByteSliceExt for [u8] {
+    fn trim_start(&self) -> &[u8] {
+        for i in 0..self.len() {
+            if !self[i].is_ascii_whitespace() {
+                return &self[i..];
+            }
+        }
+        &[]
+    }
+
+    fn starts_with_case_insensitive(&self, prefix: &[u8]) -> bool {
+        if self.len() < prefix.len() {
+            false
+        } else {
+            self[..prefix.len()].eq_ignore_ascii_case(prefix)
+        }
+    }
+}
+
+fn object_name_to_string(object_name: &sqlparser::ast::ObjectName) -> String {
+    object_name
+        .0
+        .iter()
+        .map(|ident| ident.value.as_str())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -1185,37 +1218,4 @@ mod tests {
             None::<BinlogValue<'_>>.into_field(&FieldType::Int).unwrap(),
         );
     }
-}
-
-trait ByteSliceExt {
-    fn trim_start(&self) -> &[u8];
-    fn starts_with_case_insensitive(&self, prefix: &[u8]) -> bool;
-}
-
-impl ByteSliceExt for [u8] {
-    fn trim_start(&self) -> &[u8] {
-        for i in 0..self.len() {
-            if !self[i].is_ascii_whitespace() {
-                return &self[i..];
-            }
-        }
-        &[]
-    }
-
-    fn starts_with_case_insensitive(&self, prefix: &[u8]) -> bool {
-        if self.len() < prefix.len() {
-            false
-        } else {
-            self[..prefix.len()].eq_ignore_ascii_case(prefix)
-        }
-    }
-}
-
-fn object_name_to_string(object_name: &sqlparser::ast::ObjectName) -> String {
-    object_name
-        .0
-        .iter()
-        .map(|ident| ident.value.as_str())
-        .collect::<Vec<_>>()
-        .join(".")
 }

--- a/dozer-ingestion/mysql/src/connector.rs
+++ b/dozer-ingestion/mysql/src/connector.rs
@@ -196,7 +196,7 @@ impl Connector for MySQLConnector {
         let table_infos = tables
             .into_iter()
             .map(|table| {
-                assert!(table.checkpoint.is_none());
+                assert!(table.state.is_none());
                 TableInfo {
                     schema: table.schema,
                     name: table.name,
@@ -318,7 +318,7 @@ impl MySQLConnector {
                     .handle_message(IngestionMessage::OperationEvent {
                         table_index,
                         op,
-                        id: None,
+                        state: None,
                     })
                     .await
                     .is_err()
@@ -531,7 +531,7 @@ mod tests {
                         Field::Float(1.0.into()),
                     ]),
                 },
-                id: None,
+                state: None,
             },
             IngestionMessage::OperationEvent {
                 table_index: 0,
@@ -542,7 +542,7 @@ mod tests {
                         Field::Float(2.0.into()),
                     ]),
                 },
-                id: None,
+                state: None,
             },
             IngestionMessage::OperationEvent {
                 table_index: 0,
@@ -553,7 +553,7 @@ mod tests {
                         Field::Float(3.0.into()),
                     ]),
                 },
-                id: None,
+                state: None,
             },
             IngestionMessage::SnapshottingDone,
         ];
@@ -619,7 +619,7 @@ mod tests {
                 op: Insert {
                     new: Record::new(vec![Field::Int(4), Field::Float(4.0.into())]),
                 },
-                id: None,
+                state: None,
             },
             IngestionMessage::SnapshottingDone,
             IngestionMessage::SnapshottingStarted,
@@ -628,7 +628,7 @@ mod tests {
                 op: Insert {
                     new: Record::new(vec![Field::Int(1), Field::Json(true.into())]),
                 },
-                id: None,
+                state: None,
             },
             IngestionMessage::SnapshottingDone,
         ];
@@ -648,7 +648,7 @@ mod tests {
                     old: Record::new(vec![Field::Int(4), Field::Float(4.0.into())]),
                     new: Record::new(vec![Field::Int(4), Field::Float(5.0.into())]),
                 },
-                id: None,
+                state: None,
             },
             IngestionMessage::SnapshottingDone,
         ];
@@ -667,7 +667,7 @@ mod tests {
                 op: Delete {
                     old: Record::new(vec![Field::Int(4), Field::Float(5.0.into())]),
                 },
-                id: None,
+                state: None,
             },
             IngestionMessage::SnapshottingDone,
         ];

--- a/dozer-ingestion/object-store/src/connector.rs
+++ b/dozer-ingestion/object-store/src/connector.rs
@@ -132,7 +132,7 @@ impl<T: DozerObjectStore> Connector for ObjectStoreConnector<T> {
         let mut handles = vec![];
 
         for (table_index, table_info) in tables.iter().enumerate() {
-            assert!(table_info.checkpoint.is_none());
+            assert!(table_info.state.is_none());
             let table_info = TableInfo {
                 schema: table_info.schema.clone(),
                 name: table_info.name.clone(),

--- a/dozer-ingestion/object-store/src/table_reader.rs
+++ b/dozer-ingestion/object-store/src/table_reader.rs
@@ -114,7 +114,7 @@ pub async fn read(
                 .send(Ok(Some(IngestionMessage::OperationEvent {
                     table_index,
                     op: evt,
-                    id: None,
+                    state: None,
                 })))
                 .await
                 .is_err()

--- a/dozer-ingestion/object-store/src/tests/local_storage_tests.rs
+++ b/dozer-ingestion/object-store/src/tests/local_storage_tests.rs
@@ -23,10 +23,10 @@ async fn test_get_schema_of_parquet() {
 
     let connector = ObjectStoreConnector::new(local_storage);
     let (_, schemas) = connector.list_all_schemas().await.unwrap();
-    let schema = schemas.get(0).unwrap();
+    let schema = schemas.first().unwrap();
 
     let fields = schema.schema.fields.clone();
-    assert_eq!(fields.get(0).unwrap().typ, FieldType::Int);
+    assert_eq!(fields.first().unwrap().typ, FieldType::Int);
     assert_eq!(fields.get(1).unwrap().typ, FieldType::Boolean);
     assert_eq!(fields.get(2).unwrap().typ, FieldType::Int);
     assert_eq!(fields.get(3).unwrap().typ, FieldType::Int);
@@ -45,10 +45,10 @@ async fn test_get_schema_of_csv() {
 
     let connector = ObjectStoreConnector::new(local_storage);
     let (_, schemas) = connector.list_all_schemas().await.unwrap();
-    let schema = schemas.get(0).unwrap();
+    let schema = schemas.first().unwrap();
 
     let fields = schema.schema.fields.clone();
-    assert_eq!(fields.get(0).unwrap().typ, FieldType::Int);
+    assert_eq!(fields.first().unwrap().typ, FieldType::Int);
     assert_eq!(fields.get(1).unwrap().typ, FieldType::String);
     assert_eq!(fields.get(2).unwrap().typ, FieldType::String);
     assert_eq!(fields.get(3).unwrap().typ, FieldType::Int);
@@ -213,7 +213,7 @@ fn test_csv_read() {
             test_type_conversion!(values, 7, Field::String(_));
             test_type_conversion!(values, 8, Field::String(_));
 
-            if let Field::Int(id) = values.get(0).unwrap() {
+            if let Field::Int(id) = values.first().unwrap() {
                 if *id == 2 || *id == 12 {
                     test_type_conversion!(values, 9, Field::Float(_));
                 } else {
@@ -269,7 +269,7 @@ fn test_csv_read_marker() {
             test_type_conversion!(values, 7, Field::String(_));
             test_type_conversion!(values, 8, Field::String(_));
 
-            if let Field::Int(id) = values.get(0).unwrap() {
+            if let Field::Int(id) = values.first().unwrap() {
                 if *id == 2 || *id == 12 {
                     test_type_conversion!(values, 9, Field::Float(_));
                 } else {
@@ -325,7 +325,7 @@ fn test_csv_read_only_one_marker() {
             test_type_conversion!(values, 7, Field::String(_));
             test_type_conversion!(values, 8, Field::String(_));
 
-            if let Field::Int(id) = values.get(0).unwrap() {
+            if let Field::Int(id) = values.first().unwrap() {
                 if *id == 2 || *id == 12 {
                     test_type_conversion!(values, 9, Field::Float(_));
                 } else {

--- a/dozer-ingestion/postgres/src/connector.rs
+++ b/dozer-ingestion/postgres/src/connector.rs
@@ -186,7 +186,7 @@ impl Connector for PostgresConnector {
         let tables = tables
             .into_iter()
             .map(|table| {
-                assert!(table.checkpoint.is_none());
+                assert!(table.state.is_none());
                 ListOrFilterColumns {
                     schema: table.schema,
                     name: table.name,

--- a/dozer-ingestion/postgres/src/replication_slot_helper.rs
+++ b/dozer-ingestion/postgres/src/replication_slot_helper.rs
@@ -57,7 +57,7 @@ impl ReplicationSlotHelper {
             .map_err(PostgresConnectorError::FetchReplicationSlotError)?;
 
         Ok(matches!(
-            slot_query_row.get(0),
+            slot_query_row.first(),
             Some(SimpleQueryMessage::Row(_))
         ))
     }
@@ -75,7 +75,7 @@ impl ReplicationSlotHelper {
             .await
             .map_err(PostgresConnectorError::FetchReplicationSlotError)?;
 
-        let column_index = if let Some(SimpleQueryMessage::Row(row)) = slots.get(0) {
+        let column_index = if let Some(SimpleQueryMessage::Row(row)) = slots.first() {
             row.columns().iter().position(|c| c.name() == "slot_name")
         } else {
             None

--- a/dozer-ingestion/postgres/src/schema/sorter.rs
+++ b/dozer-ingestion/postgres/src/schema/sorter.rs
@@ -127,11 +127,11 @@ mod tests {
         ];
 
         let result = sort_fields(&postgres_table, &expected_order).unwrap();
-        assert_eq!(result.get(0).unwrap().0.name, "first field");
+        assert_eq!(result.first().unwrap().0.name, "first field");
         assert_eq!(result.get(1).unwrap().0.name, "second field");
         assert_eq!(result.get(2).unwrap().0.name, "third field");
 
-        assert!(result.get(0).unwrap().1);
+        assert!(result.first().unwrap().1);
         assert!(!result.get(1).unwrap().1);
         assert!(!result.get(2).unwrap().1);
     }
@@ -153,28 +153,28 @@ mod tests {
 
         let result = sort_schemas(expected_table_order, &mapped_tables).unwrap();
         assert_eq!(
-            result.get(0).unwrap().1.fields().get(0).unwrap().name,
+            result.first().unwrap().1.fields().first().unwrap().name,
             postgres_table.get_field(0).unwrap().name
         );
         assert_eq!(
-            result.get(0).unwrap().1.fields().get(1).unwrap().name,
+            result.first().unwrap().1.fields().get(1).unwrap().name,
             postgres_table.get_field(1).unwrap().name
         );
         assert_eq!(
-            result.get(0).unwrap().1.fields().get(2).unwrap().name,
+            result.first().unwrap().1.fields().get(2).unwrap().name,
             postgres_table.get_field(2).unwrap().name
         );
 
         assert_eq!(
-            result.get(0).unwrap().1.is_index_field(0),
+            result.first().unwrap().1.is_index_field(0),
             postgres_table.is_index_field(0)
         );
         assert_eq!(
-            result.get(0).unwrap().1.is_index_field(1),
+            result.first().unwrap().1.is_index_field(1),
             postgres_table.is_index_field(1)
         );
         assert_eq!(
-            result.get(0).unwrap().1.is_index_field(2),
+            result.first().unwrap().1.is_index_field(2),
             postgres_table.is_index_field(2)
         );
     }
@@ -197,10 +197,10 @@ mod tests {
 
         let result = sort_schemas(expected_table_order, &mapped_tables).unwrap();
         assert_eq!(
-            &result.get(0).unwrap().1.fields().get(0).unwrap().name,
-            columns_order.get(0).unwrap()
+            &result.first().unwrap().1.fields().first().unwrap().name,
+            columns_order.first().unwrap()
         );
-        assert_eq!(result.get(0).unwrap().1.fields().len(), 1);
+        assert_eq!(result.first().unwrap().1.fields().len(), 1);
     }
 
     #[test]
@@ -225,18 +225,18 @@ mod tests {
 
         let result = sort_schemas(expected_table_order, &mapped_tables).unwrap();
         assert_eq!(
-            &result.get(0).unwrap().1.fields().get(0).unwrap().name,
-            columns_order.get(0).unwrap()
+            &result.first().unwrap().1.fields().first().unwrap().name,
+            columns_order.first().unwrap()
         );
         assert_eq!(
-            &result.get(0).unwrap().1.fields().get(1).unwrap().name,
+            &result.first().unwrap().1.fields().get(1).unwrap().name,
             columns_order.get(1).unwrap()
         );
         assert_eq!(
-            &result.get(0).unwrap().1.fields().get(2).unwrap().name,
+            &result.first().unwrap().1.fields().get(2).unwrap().name,
             columns_order.get(2).unwrap()
         );
-        assert_eq!(result.get(0).unwrap().1.fields().len(), 3);
+        assert_eq!(result.first().unwrap().1.fields().len(), 3);
     }
 
     #[test]
@@ -277,20 +277,20 @@ mod tests {
         ];
 
         let result = sort_schemas(expected_table_order, &mapped_tables).unwrap();
-        let first_table_after_sort = result.get(0).unwrap();
+        let first_table_after_sort = result.first().unwrap();
         let second_table_after_sort = result.get(1).unwrap();
 
         assert_eq!(
             first_table_after_sort.0 .1,
-            expected_table_order.get(0).unwrap().name
+            expected_table_order.first().unwrap().name
         );
         assert_eq!(
             second_table_after_sort.0 .1,
             expected_table_order.get(1).unwrap().name
         );
         assert_eq!(
-            &first_table_after_sort.1.fields().get(0).unwrap().name,
-            columns_order_1.get(0).unwrap()
+            &first_table_after_sort.1.fields().first().unwrap().name,
+            columns_order_1.first().unwrap()
         );
         assert_eq!(
             &first_table_after_sort.1.fields().get(1).unwrap().name,
@@ -301,8 +301,8 @@ mod tests {
             columns_order_1.get(2).unwrap()
         );
         assert_eq!(
-            &second_table_after_sort.1.fields().get(0).unwrap().name,
-            columns_order_2.get(0).unwrap()
+            &second_table_after_sort.1.fields().first().unwrap().name,
+            columns_order_2.first().unwrap()
         );
         assert_eq!(
             &second_table_after_sort.1.fields().get(1).unwrap().name,

--- a/dozer-ingestion/postgres/src/schema/tests.rs
+++ b/dozer-ingestion/postgres/src/schema/tests.rs
@@ -38,7 +38,7 @@ async fn test_connector_get_tables() {
     let schema_helper = SchemaHelper::new(client.postgres_config.clone(), None);
     let result = schema_helper.get_tables(None).await.unwrap();
 
-    let table = result.get(0).unwrap();
+    let table = result.first().unwrap();
     assert_eq!(table_name, table.name);
     assert!(assert_vec_eq(
         &[
@@ -76,7 +76,7 @@ async fn test_connector_get_schema_with_selected_columns() {
     };
     let result = schema_helper.get_tables(Some(&[table_info])).await.unwrap();
 
-    let table = result.get(0).unwrap();
+    let table = result.first().unwrap();
     assert_eq!(table_name, table.name);
     assert!(assert_vec_eq(
         &["name".to_string(), "id".to_string()],
@@ -109,7 +109,7 @@ async fn test_connector_get_schema_without_selected_columns() {
     };
     let result = schema_helper.get_tables(Some(&[table_info])).await.unwrap();
 
-    let table = result.get(0).unwrap();
+    let table = result.first().unwrap();
     assert_eq!(table_name, table.name.clone());
     assert!(assert_vec_eq(
         &[

--- a/dozer-ingestion/postgres/src/snapshotter.rs
+++ b/dozer-ingestion/postgres/src/snapshotter.rs
@@ -136,7 +136,7 @@ impl<'a> PostgresSnapshotter<'a> {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index,
                     op: evt,
-                    id: None,
+                    state: None,
                 })
                 .await
                 .is_err()

--- a/dozer-ingestion/snowflake/src/lib.rs
+++ b/dozer-ingestion/snowflake/src/lib.rs
@@ -17,6 +17,9 @@ mod tests;
 
 #[derive(Error, Debug)]
 pub enum SnowflakeError {
+    #[error("Failed to parse checkpoint state")]
+    CorruptedState,
+
     #[error("Snowflake query error")]
     QueryError(#[source] Box<DiagnosticRecord>),
 

--- a/dozer-sql/expression/src/execution.rs
+++ b/dozer-sql/expression/src/execution.rs
@@ -451,7 +451,7 @@ impl Expression {
                 results,
                 else_result: _,
             } => {
-                let typ = results.get(0).unwrap().get_type(schema)?;
+                let typ = results.first().unwrap().get_type(schema)?;
                 Ok(ExpressionType::new(
                     typ.return_type,
                     true,

--- a/dozer-sql/jsonpath/src/path/json.rs
+++ b/dozer-sql/jsonpath/src/path/json.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 /// The method expects to get a number on the right side and array or string or object on the left
 /// where the number of characters, elements or fields will be compared respectively.
 pub fn size(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
-    let Some(n) = right.get(0).and_then(|v| v.to_usize()) else {
+    let Some(n) = right.first().and_then(|v| v.to_usize()) else {
         return false;
     };
     left.iter().all(|el| match el.destructure_ref() {
@@ -26,7 +26,7 @@ pub fn sub_set_of(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
     }
 
     if let Some(elems) = left.first().and_then(|e| (*e).as_array()) {
-        if let Some(right_elems) = right.get(0).and_then(|v| v.as_array()) {
+        if let Some(right_elems) = right.first().and_then(|v| v.as_array()) {
             if right_elems.is_empty() {
                 return false;
             }
@@ -58,7 +58,7 @@ pub fn any_of(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
         return false;
     }
 
-    let Some(elems) = right.get(0).and_then(|v| v.as_array()) else {
+    let Some(elems) = right.first().and_then(|v| v.as_array()) else {
         return false;
     };
     if elems.is_empty() {
@@ -91,7 +91,7 @@ pub fn regex(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
         return false;
     }
 
-    let Some(str) = right.get(0).and_then(|v| v.as_string()) else {
+    let Some(str) = right.first().and_then(|v| v.as_string()) else {
         return false;
     };
     if let Ok(regex) = Regex::new(str) {
@@ -112,7 +112,7 @@ pub fn inside(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
         return false;
     }
 
-    let Some(first) = right.get(0) else {
+    let Some(first) = right.first() else {
         return false;
     };
     if let Some(elems) = first.as_array() {
@@ -136,8 +136,8 @@ pub fn inside(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
 /// ensure the number on the left side is less the number on the right side
 pub fn less(left: Vec<&JsonValue>, right: Vec<&JsonValue>) -> bool {
     if left.len() == 1 && right.len() == 1 {
-        let left_no = left.get(0).and_then(|v| v.as_number());
-        let right_no = right.get(0).and_then(|v| v.as_number());
+        let left_no = left.first().and_then(|v| v.as_number());
+        let right_no = right.first().and_then(|v| v.as_number());
         match (left_no, right_no) {
             (Some(l), Some(r)) => l < r,
             _ => false,

--- a/dozer-sql/jsonpath/src/path/top.rs
+++ b/dozer-sql/jsonpath/src/path/top.rs
@@ -102,7 +102,7 @@ impl<'a> Path<'a> for FnPath {
                 }
             };
 
-            match input.get(0) {
+            match input.first() {
                 Some(v) => match v {
                     NewValue(d) => take_len(d),
                     Slice(s) => take_len(s),

--- a/dozer-sql/src/aggregation/aggregator.rs
+++ b/dozer-sql/src/aggregation/aggregator.rs
@@ -277,8 +277,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Sum,
             args,
         } => Ok((
-            vec![args
-                .get(0)
+            vec![args.first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Sum.to_string())
                 })?
@@ -289,8 +288,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Min,
             args,
         } => Ok((
-            vec![args
-                .get(0)
+            vec![args.first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Min.to_string())
                 })?
@@ -301,8 +299,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::MinAppendOnly,
             args,
         } => Ok((
-            vec![args
-                .get(0)
+            vec![args.first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(
                         AggregateFunctionType::MinAppendOnly.to_string(),
@@ -315,8 +312,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Max,
             args,
         } => Ok((
-            vec![args
-                .get(0)
+            vec![args.first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Max.to_string())
                 })?
@@ -327,8 +323,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::MaxAppendOnly,
             args,
         } => Ok((
-            vec![args
-                .get(0)
+            vec![args.first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(
                         AggregateFunctionType::MaxAppendOnly.to_string(),
@@ -342,7 +337,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             args,
         } => Ok((
             vec![
-                args.get(0)
+                args.first()
                     .ok_or_else(|| {
                         PipelineError::NotEnoughArguments(
                             AggregateFunctionType::MaxValue.to_string(),
@@ -364,7 +359,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             args,
         } => Ok((
             vec![
-                args.get(0)
+                args.first()
                     .ok_or_else(|| {
                         PipelineError::NotEnoughArguments(
                             AggregateFunctionType::MinValue.to_string(),
@@ -385,8 +380,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Avg,
             args,
         } => Ok((
-            vec![args
-                .get(0)
+            vec![args.first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Avg.to_string())
                 })?
@@ -397,8 +391,7 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Count,
             args,
         } => Ok((
-            vec![args
-                .get(0)
+            vec![args.first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Count.to_string())
                 })?
@@ -416,7 +409,7 @@ pub fn update_val_map(
     field_map: &mut BTreeMap<Field, u64>,
     return_map: &mut BTreeMap<Field, Vec<Field>>,
 ) -> Result<(), PipelineError> {
-    let field = match fields.get(0) {
+    let field = match fields.first() {
         Some(v) => v,
         None => {
             return Err(InvalidFunctionArgument(

--- a/dozer-sql/src/aggregation/aggregator.rs
+++ b/dozer-sql/src/aggregation/aggregator.rs
@@ -277,7 +277,8 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Sum,
             args,
         } => Ok((
-            vec![args.first()
+            vec![args
+                .first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Sum.to_string())
                 })?
@@ -288,7 +289,8 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Min,
             args,
         } => Ok((
-            vec![args.first()
+            vec![args
+                .first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Min.to_string())
                 })?
@@ -299,7 +301,8 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::MinAppendOnly,
             args,
         } => Ok((
-            vec![args.first()
+            vec![args
+                .first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(
                         AggregateFunctionType::MinAppendOnly.to_string(),
@@ -312,7 +315,8 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Max,
             args,
         } => Ok((
-            vec![args.first()
+            vec![args
+                .first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Max.to_string())
                 })?
@@ -323,7 +327,8 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::MaxAppendOnly,
             args,
         } => Ok((
-            vec![args.first()
+            vec![args
+                .first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(
                         AggregateFunctionType::MaxAppendOnly.to_string(),
@@ -380,7 +385,8 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Avg,
             args,
         } => Ok((
-            vec![args.first()
+            vec![args
+                .first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Avg.to_string())
                 })?
@@ -391,7 +397,8 @@ pub fn get_aggregator_type_from_aggregation_expression(
             fun: AggregateFunctionType::Count,
             args,
         } => Ok((
-            vec![args.first()
+            vec![args
+                .first()
                 .ok_or_else(|| {
                     PipelineError::NotEnoughArguments(AggregateFunctionType::Count.to_string())
                 })?

--- a/dozer-sql/src/aggregation/max_value.rs
+++ b/dozer-sql/src/aggregation/max_value.rs
@@ -68,7 +68,7 @@ fn get_max_value(
         let val = calculate_err!(field_map.keys().max(), MaxValue).clone();
 
         match return_map.get(&val) {
-            Some(v) => match v.get(0) {
+            Some(v) => match v.first() {
                 Some(v) => {
                     let value = v.clone();
                     Ok(value)

--- a/dozer-sql/src/aggregation/min_value.rs
+++ b/dozer-sql/src/aggregation/min_value.rs
@@ -68,7 +68,7 @@ fn get_min_value(
         let val = calculate_err!(field_map.keys().min(), MinValue).clone();
 
         match return_map.get(&val) {
-            Some(v) => match v.get(0) {
+            Some(v) => match v.first() {
                 Some(v) => {
                     let value = v.clone();
                     Ok(value)

--- a/dozer-sql/src/pipeline_builder/from_builder.rs
+++ b/dozer-sql/src/pipeline_builder/from_builder.rs
@@ -159,7 +159,7 @@ pub fn insert_table_operator_processor_to_pipeline(
             query_context.runtime.clone(),
         );
 
-        if let Some(table) = operator.args.get(0) {
+        if let Some(table) = operator.args.first() {
             let source_name = match table {
                 TableOperatorArg::Argument(argument) => get_source_name(&operator.name, argument)?,
                 TableOperatorArg::Descriptor(descriptor) => {
@@ -218,7 +218,7 @@ pub fn insert_table_operator_processor_to_pipeline(
         }
         let processor = WindowProcessorFactory::new(processor_name.clone(), operator.clone());
 
-        if let Some(table) = operator.args.get(0) {
+        if let Some(table) = operator.args.first() {
             let source_name = match table {
                 TableOperatorArg::Argument(argument) => get_source_name(&operator.name, argument)?,
                 TableOperatorArg::Descriptor(descriptor) => {

--- a/dozer-sql/src/table_operator/tests/operator_test.rs
+++ b/dozer-sql/src/table_operator/tests/operator_test.rs
@@ -66,7 +66,7 @@ fn test_lifetime() {
         .execute(&record_store, &record, &schema)
         .unwrap();
     assert_eq!(result.len(), 1);
-    let lifetime_record = result.get(0).unwrap();
+    let lifetime_record = result.first().unwrap();
 
     let mut expected_record = record.clone();
 

--- a/dozer-sql/src/tests/builder_test.rs
+++ b/dozer-sql/src/tests/builder_test.rs
@@ -16,7 +16,6 @@ use dozer_types::chrono::DateTime;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::log::debug;
 use dozer_types::models::ingestion_types::IngestionMessage;
-use dozer_types::node::OpIdentifier;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::types::{
     Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
@@ -112,7 +111,7 @@ impl Source for TestSource {
         fw: &mut dyn SourceChannelForwarder,
         _last_checkpoint: SourceState,
     ) -> Result<(), BoxedError> {
-        for n in 0..10 {
+        for n in 0..10u64 {
             fw.send(
                 IngestionMessage::OperationEvent {
                     table_index: 0,
@@ -126,7 +125,7 @@ impl Source for TestSource {
                             ),
                         ]),
                     },
-                    id: Some(OpIdentifier::new(n, 0)),
+                    state: Some(n.to_be_bytes().to_vec().into()),
                 },
                 DEFAULT_PORT_HANDLE,
             )

--- a/dozer-sql/src/tests/utils.rs
+++ b/dozer-sql/src/tests/utils.rs
@@ -13,7 +13,7 @@ pub fn get_select(sql: &str) -> Result<Box<Select>, PipelineError> {
 
     let ast = Parser::parse_sql(&dialect, sql).unwrap();
 
-    let statement = ast.get(0).expect("First statement is missing").to_owned();
+    let statement = ast.first().expect("First statement is missing").to_owned();
     if let Statement::Query(query) = statement {
         Ok(get_query_select(&query))
     } else {

--- a/dozer-sql/src/window/tests/operator_test.rs
+++ b/dozer-sql/src/window/tests/operator_test.rs
@@ -30,7 +30,7 @@ fn test_hop() {
         )
         .unwrap();
     assert_eq!(result.len(), 5);
-    let window_record = result.get(0).unwrap();
+    let window_record = result.first().unwrap();
 
     let expected_record = ProcessorRecord::appended(
         &record,
@@ -82,7 +82,7 @@ fn test_tumble() {
         )
         .unwrap();
     assert_eq!(result.len(), 1);
-    let window_record = result.get(0).unwrap();
+    let window_record = result.first().unwrap();
 
     let expected_record = ProcessorRecord::appended(
         &record,

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -133,7 +133,7 @@ impl Source for TestSource {
                 IngestionMessage::OperationEvent {
                     table_index: 0,
                     op,
-                    id: None,
+                    state: None,
                 },
                 *port,
             )

--- a/dozer-types/src/models/ingestion_types.rs
+++ b/dozer-types/src/models/ingestion_types.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     helper::{deserialize_duration_secs_f64, f64_schema, serialize_duration_secs_f64},
     models::connection::SchemaExample,
-    node::OpIdentifier,
+    node::RestartableState,
     types::Operation,
 };
 
@@ -24,8 +24,8 @@ pub enum IngestionMessage {
         table_index: usize,
         /// The CDC event.
         op: Operation,
-        /// If this connector supports restarting from a specific CDC event, it should provide an identifier.
-        id: Option<OpIdentifier>,
+        /// If this connector supports restarting from a specific CDC event, it should provide a `RestartableState`.
+        state: Option<RestartableState>,
     },
     /// A connector uses this message kind to notify Dozer that a initial snapshot of the source tables is started
     SnapshottingStarted,

--- a/dozer-types/src/node.rs
+++ b/dozer-types/src/node.rs
@@ -63,60 +63,19 @@ impl Display for NodeHandle {
 }
 
 #[derive(
-    Clone,
-    Debug,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    bincode::Encode,
-    bincode::Decode,
+    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, bincode::Encode, bincode::Decode,
 )]
-/// A identifier made of two `u64`s.
-pub struct OpIdentifier {
-    /// High 64 bits of the identifier.
-    pub txid: u64,
-    /// Low 64 bits of the identifier.
-    pub seq_in_tx: u64,
-}
+/// A table's restartable state, any binary data.
+pub struct RestartableState(pub Vec<u8>);
 
-impl OpIdentifier {
-    pub fn new(txid: u64, seq_in_tx: u64) -> Self {
-        Self { txid, seq_in_tx }
-    }
-
-    pub fn to_bytes(&self) -> [u8; 16] {
-        let mut result = [0_u8; 16];
-        result[0..8].copy_from_slice(&self.txid.to_be_bytes());
-        result[8..16].copy_from_slice(&self.seq_in_tx.to_be_bytes());
-        result
-    }
-
-    pub fn from_bytes(bytes: [u8; 16]) -> Self {
-        let txid = u64::from_be_bytes(bytes[0..8].try_into().unwrap());
-        let seq_in_tx = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
-        Self::new(txid, seq_in_tx)
+impl From<Vec<u8>> for RestartableState {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
     }
 }
 
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    bincode::Encode,
-    bincode::Decode,
+    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, bincode::Encode, bincode::Decode,
 )]
 /// A table's ingestion state.
 pub enum TableState {
@@ -124,8 +83,8 @@ pub enum TableState {
     NotStarted,
     /// This table has some data ingested, and it can't be restarted.
     NonRestartable,
-    /// This table has some data ingested, and it can be restarted using the given identifier.
-    Restartable(OpIdentifier),
+    /// This table has some data ingested, and it can be restarted if it's given the state.
+    Restartable(RestartableState),
 }
 
 /// Map from a `Source` node's handle to its tables' states.


### PR DESCRIPTION
As discussed in https://github.com/getdozer/dozer/discussions/2212, we allow the connector to use arbitrary data to record its "state". The state can be sent along CDC events and the connector should respect the state to `start` after.