### PR TITLE
feat: Support different kinds of endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-bincode = { version = "2.0.0-rc.3", features = ["derive"]}
-datafusion = { version = "33.0.0"}
-datafusion-expr = { version = "33.0.0"}
+bincode = { version = "2.0.0-rc.3", features = ["derive"] }
+datafusion = { version = "33.0.0" }
+datafusion-expr = { version = "33.0.0" }
 
 [patch.crates-io]
 postgres = { git = "https://github.com/getdozer/rust-postgres" }

--- a/dozer-api/src/cache_builder/mod.rs
+++ b/dozer-api/src/cache_builder/mod.rs
@@ -14,7 +14,7 @@ use dozer_cache::{
 use dozer_tracing::{Labels, LabelsAndProgress};
 use dozer_types::grpc_types::internal::internal_pipeline_service_client::InternalPipelineServiceClient;
 use dozer_types::indicatif::ProgressBar;
-use dozer_types::models::api_endpoint::{
+use dozer_types::models::endpoint::{
     default_log_reader_batch_size, default_log_reader_buffer_size,
     default_log_reader_timeout_in_millis, ApiEndpoint, ConflictResolution,
 };

--- a/dozer-api/src/generator/oapi/generator.rs
+++ b/dozer-api/src/generator/oapi/generator.rs
@@ -5,7 +5,7 @@ use dozer_types::indexmap::{self, IndexMap};
 use dozer_types::serde_json;
 use dozer_types::serde_json::Map;
 use dozer_types::types::{IndexDefinition, TimeUnit};
-use dozer_types::{models::api_endpoint::ApiEndpoint, types::FieldType};
+use dozer_types::{models::endpoint::ApiEndpoint, types::FieldType};
 use openapiv3::*;
 use serde_json::{json, Value};
 

--- a/dozer-api/src/grpc/internal/internal_pipeline_server.rs
+++ b/dozer-api/src/grpc/internal/internal_pipeline_server.rs
@@ -12,7 +12,7 @@ use dozer_types::log::info;
 use dozer_types::models::api_config::{
     default_app_grpc_host, default_app_grpc_port, AppGrpcOptions,
 };
-use dozer_types::models::api_endpoint::ApiEndpoint;
+use dozer_types::models::endpoint::ApiEndpoint;
 use dozer_types::tonic::transport::server::TcpIncoming;
 use dozer_types::tonic::transport::Server;
 use dozer_types::tonic::{self, Request, Response, Status, Streaming};

--- a/dozer-api/src/lib.rs
+++ b/dozer-api/src/lib.rs
@@ -2,7 +2,7 @@ use arc_swap::ArcSwap;
 use cache_builder::CacheBuilder;
 use dozer_cache::{cache::RwCacheManager, errors::CacheError, CacheReader};
 use dozer_tracing::{Labels, LabelsAndProgress};
-use dozer_types::{grpc_types::types::Operation, models::api_endpoint::ApiEndpoint};
+use dozer_types::{grpc_types::types::Operation, models::endpoint::ApiEndpoint};
 use futures_util::Future;
 use generator::protoc::generate_all;
 use std::{ops::Deref, sync::Arc};

--- a/dozer-api/src/rest/api_generator.rs
+++ b/dozer-api/src/rest/api_generator.rs
@@ -9,7 +9,7 @@ use dozer_cache::cache::CacheRecord;
 use dozer_cache::{CacheReader, Phase};
 use dozer_types::errors::types::CannotConvertF64ToJson;
 use dozer_types::indexmap::IndexMap;
-use dozer_types::models::api_endpoint::ApiEndpoint;
+use dozer_types::models::endpoint::ApiEndpoint;
 use dozer_types::types::{Field, Schema};
 use openapiv3::OpenAPI;
 

--- a/dozer-api/src/rest/tests/routes.rs
+++ b/dozer-api/src/rest/tests/routes.rs
@@ -6,7 +6,7 @@ use actix_http::{body::MessageBody, Request};
 use actix_web::dev::{Service, ServiceResponse};
 use actix_web::http::header::ContentType;
 use dozer_cache::Phase;
-use dozer_types::models::api_endpoint::ApiEndpoint;
+use dozer_types::models::endpoint::ApiEndpoint;
 use dozer_types::serde_json::{json, Value};
 use http::StatusCode;
 
@@ -197,15 +197,19 @@ async fn path_collision_test() {
     let first_endpoint = ApiEndpoint {
         name: "films".to_string(),
         path: "/foo".to_string(),
-        table_name: "film".to_string(),
-        ..Default::default()
+        index: Default::default(),
+        conflict_resolution: Default::default(),
+        version: Default::default(),
+        log_reader_options: Default::default(),
     };
 
     let second_endpoint = ApiEndpoint {
         name: "films_second".to_string(),
         path: "/foo/second".to_string(),
-        table_name: "film".to_string(),
-        ..Default::default()
+        index: Default::default(),
+        conflict_resolution: Default::default(),
+        version: Default::default(),
+        log_reader_options: Default::default(),
     };
 
     let api_server = ApiServer::create_app_entry(

--- a/dozer-api/src/test_utils.rs
+++ b/dozer-api/src/test_utils.rs
@@ -2,7 +2,7 @@ use dozer_tracing::Labels;
 use dozer_types::serde_json::{json, Value};
 use dozer_types::types::{Field, Record, SchemaWithIndex, SourceDefinition};
 use dozer_types::{
-    models::api_endpoint::{ApiEndpoint, ApiIndex},
+    models::endpoint::{ApiEndpoint, ApiIndex},
     types::{FieldDefinition, FieldType, IndexDefinition, Schema},
 };
 
@@ -63,7 +63,6 @@ pub fn get_endpoint() -> ApiEndpoint {
             primary_key: vec!["film_id".to_string()],
             secondary: Default::default(),
         },
-        table_name: "film".to_string(),
         conflict_resolution: Default::default(),
         log_reader_options: Default::default(),
         version: None,

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/conflict_resolution_tests.rs
@@ -2,7 +2,7 @@ use crate::cache::index;
 use crate::cache::lmdb::cache::{CacheWriteOptions, MainEnvironment};
 use crate::cache::test_utils::schema_multi_indices;
 use crate::errors::CacheError;
-use dozer_types::models::api_endpoint::{
+use dozer_types::models::endpoint::{
     ConflictResolution, OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes,
 };
 use dozer_types::types::{Field, Record, Schema};

--- a/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
+++ b/dozer-cache/src/cache/lmdb/cache/main_environment/mod.rs
@@ -18,9 +18,7 @@ use dozer_types::{
 };
 use dozer_types::{
     log::warn,
-    models::api_endpoint::{
-        OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes,
-    },
+    models::endpoint::{OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes},
 };
 use tempdir::TempDir;
 

--- a/dozer-cache/src/cache/mod.rs
+++ b/dozer-cache/src/cache/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use self::expression::QueryExpression;
 use crate::errors::CacheError;
 use dozer_tracing::Labels;
-use dozer_types::models::api_endpoint::{
+use dozer_types::models::endpoint::{
     OnDeleteResolutionTypes, OnInsertResolutionTypes, OnUpdateResolutionTypes,
 };
 use dozer_types::node::SourceStates;

--- a/dozer-cache/src/cache/plan/planner.rs
+++ b/dozer-cache/src/cache/plan/planner.rs
@@ -1,6 +1,6 @@
 use crate::cache::expression::{FilterExpression, Operator, SortDirection, SortOptions};
 use crate::errors::PlanError;
-use dozer_types::models::api_endpoint::{FullText, SecondaryIndex, SortedInverted};
+use dozer_types::models::endpoint::{FullText, SecondaryIndex, SortedInverted};
 use dozer_types::types::{Field, FieldDefinition, Schema};
 use dozer_types::types::{FieldType, IndexDefinition};
 use dozer_types::{json_value_to_field, serde_yaml};

--- a/dozer-cli/src/pipeline/mod.rs
+++ b/dozer-cli/src/pipeline/mod.rs
@@ -4,7 +4,7 @@ mod dummy_sink;
 mod log_sink;
 pub mod source_builder;
 
-pub use builder::PipelineBuilder;
+pub use builder::{EndpointLog, EndpointLogKind, PipelineBuilder};
 pub use log_sink::{LogSink, LogSinkFactory};
 
 #[cfg(test)]

--- a/dozer-cli/src/pipeline/tests/builder.rs
+++ b/dozer-cli/src/pipeline/tests/builder.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::pipeline::builder::{EndpointLog, EndpointLogKind};
 use crate::pipeline::source_builder::SourceBuilder;
 use crate::pipeline::PipelineBuilder;
 use dozer_api::shutdown;
@@ -67,7 +68,10 @@ fn load_multi_sources() {
         config
             .endpoints
             .into_iter()
-            .map(|endpoint| (endpoint, None))
+            .map(|endpoint| EndpointLog {
+                table_name: endpoint.table_name,
+                kind: EndpointLogKind::Dummy,
+            })
             .collect(),
         Default::default(),
         Flags::default(),

--- a/dozer-cli/src/simple/build/contract/mod.rs
+++ b/dozer-cli/src/simple/build/contract/mod.rs
@@ -85,7 +85,7 @@ impl Contract {
                 continue;
             };
 
-            let node_index = find_sink(dag_schemas, &api.name)
+            let node_index = find_sink(dag_schemas, &endpoint.table_name)
                 .ok_or(BuildError::MissingEndpoint(api.name.clone()))?;
 
             let (schema, secondary_indexes) =
@@ -169,13 +169,13 @@ impl Contract {
 
 mod service;
 
-/// Sink's `NodeHandle::id` must be `endpoint_name`.
-fn find_sink(dag: &DagSchemas, endpoint_name: &str) -> Option<NodeIndex> {
+/// Sink's `NodeHandle::id` must be `table_name`.
+fn find_sink(dag: &DagSchemas, endpoint_table_name: &str) -> Option<NodeIndex> {
     dag.graph()
         .node_references()
         .find(|(_node_index, node)| {
             if let dozer_core::NodeKind::Sink(_) = &node.kind {
-                node.handle.id == endpoint_name
+                node.handle.id == endpoint_table_name
             } else {
                 false
             }

--- a/dozer-cli/src/simple/build/contract/modify_schema.rs
+++ b/dozer-cli/src/simple/build/contract/modify_schema.rs
@@ -1,5 +1,5 @@
 use dozer_types::{
-    models::api_endpoint::{
+    models::endpoint::{
         ApiEndpoint, FullText, SecondaryIndex, SecondaryIndexConfig, SortedInverted,
     },
     types::{FieldDefinition, FieldType, IndexDefinition, Schema, SchemaWithIndex},

--- a/dozer-cli/src/simple/helper.rs
+++ b/dozer-cli/src/simple/helper.rs
@@ -3,9 +3,10 @@ use crate::console_helper::PURPLE;
 use crate::errors::OrchestrationError;
 use dozer_types::log::info;
 use dozer_types::models::api_config::ApiConfig;
-use dozer_types::models::api_endpoint::ApiEndpoint;
 use dozer_types::models::config::default_home_dir;
 use dozer_types::models::config::Config;
+use dozer_types::models::endpoint::Endpoint;
+use dozer_types::models::endpoint::EndpointKind;
 use dozer_types::prettytable::{row, Table};
 
 pub fn validate_config(config: &Config) -> Result<(), OrchestrationError> {
@@ -24,7 +25,7 @@ pub fn validate_config(config: &Config) -> Result<(), OrchestrationError> {
     Ok(())
 }
 
-pub fn validate_endpoints(endpoints: &[ApiEndpoint]) -> Result<(), OrchestrationError> {
+pub fn validate_endpoints(endpoints: &[Endpoint]) -> Result<(), OrchestrationError> {
     if endpoints.is_empty() {
         return Err(OrchestrationError::EmptyEndpoints);
     }
@@ -64,12 +65,14 @@ fn print_api_config(api_config: &ApiConfig) {
     );
 }
 
-pub fn print_api_endpoints(endpoints: &Vec<ApiEndpoint>) {
+pub fn print_api_endpoints(endpoints: &[Endpoint]) {
     let mut table_parent = Table::new();
 
     table_parent.add_row(row!["Path", "Name"]);
     for endpoint in endpoints {
-        table_parent.add_row(row![endpoint.path, endpoint.name]);
+        if let EndpointKind::Api(api) = &endpoint.kind {
+            table_parent.add_row(row![api.path, api.name]);
+        }
     }
     info!(
         "[API] {}\n{}",

--- a/dozer-ingestion/postgres/src/tests/dozer-config.yaml
+++ b/dozer-ingestion/postgres/src/tests/dozer-config.yaml
@@ -39,17 +39,9 @@ sources:
       - next_shares
     connection: stocks
 endpoints:
-  - name: stocks
-    path: /stocks
-    # Direct from source
-    table_name: stocks
-    index:
-      primary_key:
-        - id
-  - name: stocks_meta
-    path: /stocks-meta
-    # Direct from source
-    table_name: stocks_meta
-    index:
-      primary_key:
-        - symbol
+  # Direct from source
+  - table_name: stocks
+    kind: !Dummy
+  # Direct from source
+  - table_name: stocks_meta
+    kind: !Dummy

--- a/dozer-ingestion/snowflake/src/tests/dozer-config.yaml
+++ b/dozer-ingestion/snowflake/src/tests/dozer-config.yaml
@@ -24,9 +24,5 @@ sql: |
   FROM orders;
 
 endpoints:
-  - name: customers
-    path: /customers
-    table_name: customers_data
-    index:
-      primary_key:
-        - C_CUSTKEY
+  - table_name: customers_data
+    kind: !Dummy

--- a/dozer-ingestion/tests/test_suite/connectors/dozer.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/dozer.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use dozer_cli::shutdown::{self, ShutdownSender};
 use dozer_cli::simple::SimpleOrchestrator;
+use dozer_ingestion_connector::dozer_types::models::endpoint::{Endpoint, EndpointKind};
 use dozer_ingestion_connector::dozer_types::{
     grpc_types::{
         conversions::field_to_grpc,
@@ -13,7 +14,7 @@ use dozer_ingestion_connector::dozer_types::{
     },
     log::info,
     models::{
-        api_endpoint::ApiEndpoint,
+        endpoint::ApiEndpoint,
         ingestion_types::{
             GrpcConfig, GrpcConfigSchemas, NestedDozerConfig, NestedDozerLogOptions,
         },
@@ -211,14 +212,16 @@ async fn create_nested_dozer_server(
             schema: None,
             refresh_config: Default::default(),
         }],
-        endpoints: vec![ApiEndpoint {
-            name: table_name.to_owned(),
-            path: "/test".to_owned(),
+        endpoints: vec![Endpoint {
             table_name: table_name.clone(),
-            index: Default::default(),
-            conflict_resolution: Default::default(),
-            version: None,
-            log_reader_options: Default::default(),
+            kind: EndpointKind::Api(ApiEndpoint {
+                name: table_name.to_owned(),
+                path: "/test".to_owned(),
+                index: Default::default(),
+                conflict_resolution: Default::default(),
+                version: None,
+                log_reader_options: Default::default(),
+            }),
         }],
         ..Default::default()
     };

--- a/dozer-log/src/reader/mod.rs
+++ b/dozer-log/src/reader/mod.rs
@@ -9,7 +9,7 @@ use dozer_types::grpc_types::internal::{
     storage_response, BuildRequest, LogRequest, LogResponse, StorageRequest,
 };
 use dozer_types::log::debug;
-use dozer_types::models::api_endpoint::{
+use dozer_types::models::endpoint::{
     default_log_reader_batch_size, default_log_reader_buffer_size,
     default_log_reader_timeout_in_millis,
 };

--- a/dozer-tests/src/e2e_tests/checker/client.rs
+++ b/dozer-tests/src/e2e_tests/checker/client.rs
@@ -16,6 +16,7 @@ use dozer_types::{
     models::{
         api_config::{default_grpc_port, default_host, default_rest_port},
         config::Config,
+        endpoint::EndpointKind,
         flags::default_dynamic,
     },
     types::{FieldDefinition, FieldType, DATE_FORMAT},
@@ -82,7 +83,17 @@ impl Client {
                     .config
                     .endpoints
                     .iter()
-                    .find(|e| &e.name == endpoint)
+                    .filter_map(|e| match &e.kind {
+                        EndpointKind::Api(api) => {
+                            if &api.name == endpoint {
+                                Some(api)
+                            } else {
+                                None
+                            }
+                        }
+                        EndpointKind::Dummy => None,
+                    })
+                    .next()
                     .unwrap_or_else(|| panic!("Cannot find endpoint {endpoint} in config"))
                     .path
                     .clone();

--- a/dozer-tests/src/tests/e2e/fixtures/basic.yaml
+++ b/dozer-tests/src/tests/e2e/fixtures/basic.yaml
@@ -35,6 +35,7 @@ sources:
     connection: ingest
 
 endpoints:
-  - name: users
-    path: /users
-    table_name: users
+  - table_name: users
+    kind: !Api
+      name: users
+      path: /users

--- a/dozer-tests/src/tests/e2e/fixtures/basic_sql.yaml
+++ b/dozer-tests/src/tests/e2e/fixtures/basic_sql.yaml
@@ -44,6 +44,8 @@ sources:
     connection: ny_taxi
 
 endpoints:
-  - name: trips
-    path: /trips
-    table_name: trips_cache
+  - table_name: trips_cache
+    kind: !Api
+      name: trips
+      path: /trips
+    

--- a/dozer-tests/src/tests/e2e/fixtures/basic_sql_wildcard.yaml
+++ b/dozer-tests/src/tests/e2e/fixtures/basic_sql_wildcard.yaml
@@ -59,6 +59,7 @@ sql: |
     ON table3.table3_id = table4.table4_id;
 
 endpoints:
-  - name: wildcard_res
-    table_name: wildcard_res
-    path: /wildcard_res
+  - table_name: wildcard_res
+    kind: !Api
+      name: wildcard_res
+      path: /wildcard_res

--- a/dozer-tests/src/tests/e2e/fixtures/left_join.yaml
+++ b/dozer-tests/src/tests/e2e/fixtures/left_join.yaml
@@ -44,6 +44,7 @@ api:
 sql: SELECT id INTO table1_endpoint FROM table1 LEFT JOIN table2 ON table1.id = table2.table1_id
 
 endpoints:
-  - name: table1_endpoint
-    table_name: table1_endpoint
-    path: /table1_endpoint
+  - table_name: table1_endpoint
+    kind: !Api
+      name: table1_endpoint
+      path: /table1_endpoint

--- a/dozer-types/src/models/config.rs
+++ b/dozer-types/src/models/config.rs
@@ -1,9 +1,17 @@
 use std::path::Path;
 
 use super::{
-    api_config::ApiConfig, api_endpoint::ApiEndpoint, app_config::AppConfig, cloud::Cloud,
-    connection::Connection, equal_default, flags::Flags, lambda_config::LambdaConfig,
-    sink_config::SinkConfig, source::Source, telemetry::TelemetryConfig,
+    api_config::ApiConfig,
+    app_config::AppConfig,
+    cloud::Cloud,
+    connection::Connection,
+    endpoint::{Endpoint, EndpointKind},
+    equal_default,
+    flags::Flags,
+    lambda_config::LambdaConfig,
+    sink_config::SinkConfig,
+    source::Source,
+    telemetry::TelemetryConfig,
 };
 use crate::constants::DEFAULT_HOME_DIR;
 use crate::models::udf_config::UdfConfig;
@@ -38,7 +46,7 @@ pub struct Config {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     /// api endpoints to expose
-    pub endpoints: Vec<ApiEndpoint>,
+    pub endpoints: Vec<Endpoint>,
 
     #[serde(default, skip_serializing_if = "equal_default")]
     /// Api server config related: port, host, etc
@@ -115,7 +123,9 @@ impl Config {
         ]);
         let mut endpoints_table = table!();
         for endpoint in &self.endpoints {
-            endpoints_table.add_row(row![endpoint.name, endpoint.table_name, endpoint.path]);
+            if let EndpointKind::Api(api) = &endpoint.kind {
+                endpoints_table.add_row(row![api.name, endpoint.table_name, api.path]);
+            }
         }
         if !self.endpoints.is_empty() {
             table.add_row(row!["endpoints", endpoints_table]);

--- a/dozer-types/src/models/endpoint.rs
+++ b/dozer-types/src/models/endpoint.rs
@@ -92,13 +92,27 @@ pub struct LogReaderOptions {
     pub buffer_size: Option<u32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Default, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct Endpoint {
+    /// name of the table in source database; Type: String
+    pub table_name: String,
+
+    /// endpoint kind
+    pub kind: EndpointKind,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub enum EndpointKind {
+    Api(ApiEndpoint),
+    Dummy,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ApiEndpoint {
     pub name: String,
-
-    /// name of the table in source database; Type: String
-    pub table_name: String,
 
     /// path of endpoint - e.g: /stocks
     pub path: String,

--- a/dozer-types/src/models/mod.rs
+++ b/dozer-types/src/models/mod.rs
@@ -1,10 +1,10 @@
 pub mod api_config;
-pub mod api_endpoint;
 pub mod api_security;
 pub mod app_config;
 pub mod cloud;
 pub mod config;
 pub mod connection;
+pub mod endpoint;
 pub mod flags;
 pub mod ingestion_types;
 mod json_schema_helper;

--- a/dozer-types/src/tests/secondary_index_yaml_deserialize.rs
+++ b/dozer-types/src/tests/secondary_index_yaml_deserialize.rs
@@ -1,4 +1,4 @@
-use crate::models::api_endpoint::{FullText, SecondaryIndex, SecondaryIndexConfig, SortedInverted};
+use crate::models::endpoint::{FullText, SecondaryIndex, SecondaryIndexConfig, SortedInverted};
 
 #[test]
 fn standard() {

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -63,7 +63,7 @@
       "description": "api endpoints to expose",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/ApiEndpoint"
+        "$ref": "#/definitions/Endpoint"
       }
     },
     "flags": {
@@ -173,8 +173,7 @@
       "type": "object",
       "required": [
         "name",
-        "path",
-        "table_name"
+        "path"
       ],
       "properties": {
         "conflict_resolution": {
@@ -191,10 +190,6 @@
         },
         "path": {
           "description": "path of endpoint - e.g: /stocks",
-          "type": "string"
-        },
-        "table_name": {
-          "description": "name of the table in source database; Type: String",
           "type": "string"
         },
         "version": {
@@ -801,6 +796,50 @@
         }
       },
       "additionalProperties": false
+    },
+    "Endpoint": {
+      "type": "object",
+      "required": [
+        "kind",
+        "table_name"
+      ],
+      "properties": {
+        "kind": {
+          "description": "endpoint kind",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EndpointKind"
+            }
+          ]
+        },
+        "table_name": {
+          "description": "name of the table in source database; Type: String",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EndpointKind": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Dummy"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Api"
+          ],
+          "properties": {
+            "Api": {
+              "$ref": "#/definitions/ApiEndpoint"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "EthConfig": {
       "examples": [


### PR DESCRIPTION
In this PR we modify the `endpoints` config to following format:

```yaml
endpoints:
- table_name: users
  kind: !Api
    name: users
    path: /users
```

or

```yaml
endpoints:
- table_name: users
  kind: !Dummy
```

In the future, new endpoint type can be added to form a stateless pipeline.