### PR TITLE
Optimize postgres snapshotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3984,6 +3984,7 @@ dependencies = [
  "rustls 0.21.9",
  "rustls-native-certs",
  "serial_test 1.0.0",
+ "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
  "uuid",

--- a/dozer-ingestion/postgres/Cargo.toml
+++ b/dozer-ingestion/postgres/Cargo.toml
@@ -26,3 +26,4 @@ rand = "0.8.5"
 
 [dev-dependencies]
 serial_test = "1.0.0"
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/dozer-ingestion/postgres/src/schema/tests.rs
+++ b/dozer-ingestion/postgres/src/schema/tests.rs
@@ -3,21 +3,19 @@ use dozer_ingestion_connector::utils::ListOrFilterColumns;
 use rand::Rng;
 use serial_test::serial;
 use std::collections::HashSet;
-use std::hash::Hash;
 
 use crate::schema::helper::SchemaHelper;
 use crate::test_utils::load_test_connection_config;
 use crate::tests::client::TestPostgresClient;
 use crate::{PostgresConnectorError, PostgresSchemaError};
 
-fn assert_vec_eq<T>(a: &[T], b: &[T]) -> bool
-where
-    T: Eq + Hash,
-{
-    let a: HashSet<_> = a.iter().collect();
-    let b: HashSet<_> = b.iter().collect();
+macro_rules! assert_vec_eq {
+    ($a:expr, $b:expr) => {{
+        let a: HashSet<_> = $a.iter().cloned().collect();
+        let b: HashSet<_> = $b.iter().cloned().collect();
 
-    a == b
+        assert_eq!(a, b)
+    }};
 }
 
 #[tokio::test]
@@ -40,15 +38,19 @@ async fn test_connector_get_tables() {
 
     let table = result.first().unwrap();
     assert_eq!(table_name, table.name);
-    assert!(assert_vec_eq(
+    assert_vec_eq!(
         &[
             "name".to_string(),
             "description".to_string(),
-            "weight".to_string(),
+            "weight_single".to_string(),
+            "weight_double".to_string(),
             "id".to_string(),
+            "index2".to_string(),
+            "index4".to_string(),
+            "index8".to_string(),
         ],
         &table.columns
-    ));
+    );
 
     client.drop_schema(&schema).await;
 }
@@ -78,10 +80,7 @@ async fn test_connector_get_schema_with_selected_columns() {
 
     let table = result.first().unwrap();
     assert_eq!(table_name, table.name);
-    assert!(assert_vec_eq(
-        &["name".to_string(), "id".to_string()],
-        &table.columns
-    ));
+    assert_vec_eq!(&["name".to_string(), "id".to_string()], &table.columns);
 
     client.drop_schema(&schema).await;
 }
@@ -111,15 +110,19 @@ async fn test_connector_get_schema_without_selected_columns() {
 
     let table = result.first().unwrap();
     assert_eq!(table_name, table.name.clone());
-    assert!(assert_vec_eq(
+    assert_vec_eq!(
         &[
             "id".to_string(),
             "name".to_string(),
             "description".to_string(),
-            "weight".to_string(),
+            "weight_single".to_string(),
+            "weight_double".to_string(),
+            "index2".to_string(),
+            "index4".to_string(),
+            "index8".to_string(),
         ],
         &table.columns
-    ));
+    );
 
     client.drop_schema(&schema).await;
 }

--- a/dozer-ingestion/postgres/src/tests/client.rs
+++ b/dozer-ingestion/postgres/src/tests/client.rs
@@ -46,7 +46,11 @@ impl TestPostgresClient {
                 id SERIAL PRIMARY KEY,
                 name VARCHAR(255) NOT NULL,
                 description VARCHAR(512),
-                weight DOUBLE PRECISION
+                weight_single REAL,
+                weight_double DOUBLE PRECISION,
+                index2 INT2,
+                index4 INT4,
+                index8 INT8
             );"
         ))
         .await;
@@ -84,15 +88,19 @@ impl TestPostgresClient {
                 buf.write_str(",").unwrap();
             }
             buf.write_fmt(format_args!(
-                "(\'Product {}\',\'Product {} description\',{})",
+                "(\'Product {}\',\'Product {} description\',{}, {}, {}, {}, {})",
                 i + offset,
                 i + offset,
-                Decimal::new((i * 41) as i64, 2)
+                Decimal::new((i * 41) as i64, 2),
+                Decimal::new((i * 41) as i64, 2),
+                i + offset,
+                i + offset,
+                i + offset,
             ))
             .unwrap();
         }
 
-        let query = format!("insert into {table_name}(name, description, weight) values {buf}",);
+        let query = format!("insert into {table_name}(name, description, weight_single, weight_double, index2, index4, index8) values {buf}",);
 
         self.execute_query(&query).await;
     }


### PR DESCRIPTION
The match on type was not properly optimized, so manually make a lookup
table for data conversion routines.
Also pre-allocate the full fields vector.
These changes together improve throughput by about 9%.

As we probably want to move to a different method for snapshotting altogether,
feel free to close this PR, but it might be nice inspiration for possible 
optimizations.
