### PR TITLE
fix: Improve performance of date parsing

### DIFF
--- a/dozer-ingestion/postgres/src/helper.rs
+++ b/dozer-ingestion/postgres/src/helper.rs
@@ -24,7 +24,10 @@ use crate::{
     xlog_mapper::TableColumn, DateConversionError, PostgresConnectorError, PostgresSchemaError,
 };
 
+/// This function converts any offset string (+03, +03:00 and etc) to FixedOffset
+///
 fn parse_timezone_offset(offset_string: String) -> Result<Option<FixedOffset>, ParseIntError> {
+    // Fill right side with zeros when offset is not full length
     let offset_string = format!("{:0<9}", offset_string);
 
     let sign = &offset_string[0..1];
@@ -42,6 +45,7 @@ fn parse_timezone_offset(offset_string: String) -> Result<Option<FixedOffset>, P
 }
 
 fn convert_date(date: String) -> Result<NaiveDateTime, DateConversionError> {
+    // Fill right side with zeros when date time is not full
     let date_string = format!("{:0<26}", date);
 
     let year: i32 = date_string[0..4].parse()?;
@@ -64,6 +68,7 @@ fn convert_date(date: String) -> Result<NaiveDateTime, DateConversionError> {
 }
 
 fn convert_date_with_timezone(date: String) -> Result<DateTime<FixedOffset>, DateConversionError> {
+    // Find position of last + or -, which is the start of timezone offset
     let pos_plus = date.rfind('+');
     let pos_min = date.rfind('-');
 

--- a/dozer-ingestion/postgres/src/lib.rs
+++ b/dozer-ingestion/postgres/src/lib.rs
@@ -1,3 +1,4 @@
+use std::num::ParseIntError;
 use std::string::FromUtf8Error;
 
 use dozer_ingestion_connector::dozer_types::{
@@ -206,4 +207,22 @@ pub enum PostgresSchemaError {
 
     #[error("Failed to read date. Error: {0}")]
     DateReadError(#[from] chrono::ParseError),
+
+    #[error(transparent)]
+    DateConversionError(#[from] DateConversionError),
+}
+
+#[derive(Error, Debug)]
+pub enum DateConversionError {
+    #[error("Failed to read error part. Error: {0}")]
+    FailedParseDate(#[from] ParseIntError),
+
+    #[error("Failed to convert date")]
+    InvalidDate,
+
+    #[error("Failed to convert time")]
+    InvalidTime,
+
+    #[error("Ambiguous date result")]
+    AmbiguousTimeResult,
 }


### PR DESCRIPTION
These changes in date parsing allowed an increase in throughput of CDC stream processing from 55k/s to 100k/s for the same data.