### PR TITLE
perf: Add Operation::BatchInsert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,6 +4007,7 @@ dependencies = [
 name = "dozer-lambda"
 version = "0.1.0"
 dependencies = [
+ "async-recursion",
  "dozer-deno",
  "dozer-log",
  "dozer-types",

--- a/dozer-cli/src/cli/init.rs
+++ b/dozer-cli/src/cli/init.rs
@@ -160,6 +160,7 @@ pub fn generate_connection(connection_name: &str) -> Connection {
                 sslmode: None,
                 connection_url: None,
                 schema: None,
+                batch_size: None,
             };
             let connection: Connection = Connection {
                 name: "postgres".to_owned(),

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -119,6 +119,18 @@ impl Sink for LogSink {
         Ok(())
     }
 
+    fn on_source_snapshotting_started(
+        &mut self,
+        connection_name: String,
+    ) -> Result<(), BoxedError> {
+        let end = self
+            .runtime
+            .block_on(self.log.lock())
+            .write(LogOperation::SnapshottingStarted { connection_name });
+        self.pb.set_position(end as u64);
+        Ok(())
+    }
+
     fn on_source_snapshotting_done(&mut self, connection_name: String) -> Result<(), BoxedError> {
         let end = self
             .runtime

--- a/dozer-core/src/executor/processor_node.rs
+++ b/dozer-core/src/executor/processor_node.rs
@@ -131,6 +131,11 @@ impl ReceiverLoop for ProcessorNode {
         self.channel_manager.send_terminate()
     }
 
+    fn on_snapshotting_started(&mut self, connection_name: String) -> Result<(), ExecutionError> {
+        self.channel_manager
+            .send_snapshotting_started(connection_name)
+    }
+
     fn on_snapshotting_done(&mut self, connection_name: String) -> Result<(), ExecutionError> {
         self.channel_manager.send_snapshotting_done(connection_name)
     }

--- a/dozer-core/src/executor/sink_node.rs
+++ b/dozer-core/src/executor/sink_node.rs
@@ -115,6 +115,9 @@ impl ReceiverLoop for SinkNode {
             Operation::Update { .. } => {
                 labels.push(OPERATION_TYPE_LABEL, "update");
             }
+            Operation::BatchInsert { .. } => {
+                labels.push(OPERATION_TYPE_LABEL, "batch_insert");
+            }
         }
 
         if let Err(e) = self.sink.process(
@@ -152,6 +155,13 @@ impl ReceiverLoop for SinkNode {
     }
 
     fn on_terminate(&mut self) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn on_snapshotting_started(&mut self, connection_name: String) -> Result<(), ExecutionError> {
+        if let Err(e) = self.sink.on_source_snapshotting_started(connection_name) {
+            self.error_manager.report(e);
+        }
         Ok(())
     }
 

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -115,5 +115,7 @@ pub trait Sink: Send + Sync + Debug {
     ) -> Result<(), BoxedError>;
     fn persist(&mut self, epoch: &Epoch, queue: &Queue) -> Result<(), BoxedError>;
 
+    fn on_source_snapshotting_started(&mut self, connection_name: String)
+        -> Result<(), BoxedError>;
     fn on_source_snapshotting_done(&mut self, connection_name: String) -> Result<(), BoxedError>;
 }

--- a/dozer-core/src/record_store.rs
+++ b/dozer-core/src/record_store.rs
@@ -116,6 +116,15 @@ impl RecordWriter for PrimaryKeyLookupRecordWriter {
                 self.index.insert(new_key, new.clone());
                 Ok(Operation::Update { old, new })
             }
+            Operation::BatchInsert { new } => {
+                let mut new_records = Vec::with_capacity(new.len());
+                for record in new {
+                    let new_key = record.get_key(&self.schema.primary_index);
+                    self.index.insert(new_key, record.clone());
+                    new_records.push(record);
+                }
+                Ok(Operation::BatchInsert { new: new_records })
+            }
         }
     }
 

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -491,6 +491,13 @@ impl Sink for ErrSink {
         Ok(())
     }
 
+    fn on_source_snapshotting_started(
+        &mut self,
+        _connection_name: String,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
     fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -89,6 +89,13 @@ impl Sink for CountingSink {
         Ok(())
     }
 
+    fn on_source_snapshotting_started(
+        &mut self,
+        _connection_name: String,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
     fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }

--- a/dozer-ingestion/postgres/src/connector.rs
+++ b/dozer-ingestion/postgres/src/connector.rs
@@ -27,6 +27,7 @@ pub struct PostgresConfig {
     pub name: String,
     pub config: Config,
     pub schema: Option<String>,
+    pub batch_size: usize,
 }
 
 #[derive(Debug)]
@@ -36,6 +37,7 @@ pub struct PostgresConnector {
     conn_config: Config,
     schema_helper: SchemaHelper,
     pub schema: Option<String>,
+    batch_size: usize,
 }
 
 #[derive(Debug)]
@@ -62,6 +64,7 @@ impl PostgresConnector {
             replication_conn_config,
             schema_helper: helper,
             schema: config.schema,
+            batch_size: config.batch_size,
         }
     }
 
@@ -233,6 +236,7 @@ impl Connector for PostgresConnector {
             ingestor,
             self.conn_config.clone(),
             self.schema.clone(),
+            self.batch_size,
         );
         iterator.start(lsn).await.map_err(Into::into)
     }

--- a/dozer-ingestion/postgres/src/helper.rs
+++ b/dozer-ingestion/postgres/src/helper.rs
@@ -339,13 +339,11 @@ pub fn get_values(
     Ok(values)
 }
 
-pub fn map_row_to_operation_event(
+pub fn map_row_to_record(
     row: &Row,
     conversion: &[ConversionFn],
-) -> Result<Operation, PostgresSchemaError> {
-    get_values(row, conversion).map(|values| Operation::Insert {
-        new: Record::new(values),
-    })
+) -> Result<Record, PostgresSchemaError> {
+    get_values(row, conversion).map(Record::new)
 }
 
 pub fn map_schema(columns: &[Column]) -> Result<Schema, PostgresConnectorError> {

--- a/dozer-ingestion/postgres/src/tests/continue_replication_tests.rs
+++ b/dozer-ingestion/postgres/src/tests/continue_replication_tests.rs
@@ -27,6 +27,7 @@ mod tests {
             name: "test".to_string(),
             config: conn_config.clone(),
             schema: None,
+            batch_size: 1000,
         };
 
         let connector = PostgresConnector::new(postgres_config);
@@ -80,6 +81,7 @@ mod tests {
             name: connector_name,
             config: conn_config.clone(),
             schema: None,
+            batch_size: 1000,
         };
 
         let connector = PostgresConnector::new(postgres_config);

--- a/dozer-ingestion/src/lib.rs
+++ b/dozer-ingestion/src/lib.rs
@@ -34,6 +34,8 @@ use tokio::runtime::Runtime;
 pub mod errors;
 pub use dozer_ingestion_connector::*;
 
+const DEFAULT_POSTGRES_SNAPSHOT_BATCH_SIZE: u32 = 100_000;
+
 pub fn get_connector(
     runtime: Arc<Runtime>,
     connection: Connection,
@@ -46,6 +48,7 @@ pub fn get_connector(
                 name: connection.name,
                 config,
                 schema: c.schema,
+                batch_size: c.batch_size.unwrap_or(DEFAULT_POSTGRES_SNAPSHOT_BATCH_SIZE) as usize,
             };
 
             if let Some(dbname) = postgres_config.config.get_dbname() {

--- a/dozer-ingestion/tests/test_suite/connectors/postgres.rs
+++ b/dozer-ingestion/tests/test_suite/connectors/postgres.rs
@@ -132,6 +132,7 @@ async fn create_postgres_server() -> (Client, PostgresConnectorTest, PostgresCon
         name: "postgres_connector_test".to_string(),
         config: config.clone(),
         schema: None,
+        batch_size: 1000,
     });
 
     let client = connect(config.clone()).await.unwrap();

--- a/dozer-lambda/Cargo.toml
+++ b/dozer-lambda/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 dozer-types = { path = "../dozer-types" }
 dozer-log = { path = "../dozer-log" }
 dozer-deno = { path = "../dozer-deno" }
+async-recursion = "1.0.5"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/dozer-log-js/src/mapper.rs
+++ b/dozer-log-js/src/mapper.rs
@@ -29,6 +29,12 @@ pub fn map_executor_operation<'a, C: Context<'a>>(
             let typ = cx.string("commit");
             result.set(cx, "type", typ)?;
         }
+        LogOperation::SnapshottingStarted { connection_name } => {
+            let typ = cx.string("snapshotting_started");
+            result.set(cx, "type", typ)?;
+            let connection_name = cx.string(&connection_name);
+            result.set(cx, "connection_name", connection_name)?;
+        }
         LogOperation::SnapshottingDone { connection_name } => {
             let typ = cx.string("snapshotting_done");
             result.set(cx, "type", typ)?;
@@ -67,6 +73,16 @@ fn map_operation<'a, C: Context<'a>>(
             result.set(cx, "old", old)?;
             let new = map_record(new, schema, cx)?;
             result.set(cx, "new", new)?;
+        }
+        Operation::BatchInsert { new } => {
+            let typ = cx.string("batch_insert");
+            result.set(cx, "type", typ)?;
+            let new_js = cx.empty_array();
+            for (i, record) in new.into_iter().enumerate() {
+                let record = map_record(record, schema, cx)?;
+                new_js.set(cx, i as u32, record)?;
+            }
+            result.set(cx, "new", new_js)?;
         }
     }
 

--- a/dozer-log-python/src/mapper.rs
+++ b/dozer-log-python/src/mapper.rs
@@ -22,6 +22,10 @@ pub fn map_executor_operation(
         LogOperation::Commit { .. } => {
             result.set_item("type", "commit")?;
         }
+        LogOperation::SnapshottingStarted { connection_name } => {
+            result.set_item("type", "snapshotting_started")?;
+            result.set_item("connection_name", connection_name)?;
+        }
         LogOperation::SnapshottingDone { connection_name } => {
             result.set_item("type", "snapshotting_done")?;
             result.set_item("connection_name", connection_name)?;
@@ -47,6 +51,14 @@ fn map_op<'py>(op: Operation, schema: &Schema, py: Python<'py>) -> PyResult<&'py
             result.set_item("type", "update")?;
             result.set_item("old", map_record(old, schema, py)?)?;
             result.set_item("new", map_record(new, schema, py)?)?;
+        }
+        Operation::BatchInsert { new } => {
+            result.set_item("type", "batch_insert")?;
+            let new_py = PyList::empty(py);
+            for record in new {
+                new_py.append(map_record(record, schema, py)?)?;
+            }
+            result.set_item("new", new_py)?;
         }
     }
 

--- a/dozer-log/src/replication/mod.rs
+++ b/dozer-log/src/replication/mod.rs
@@ -325,6 +325,9 @@ pub enum LogOperation {
         source_states: SourceStates,
         decision_instant: SystemTime,
     },
+    SnapshottingStarted {
+        connection_name: String,
+    },
     SnapshottingDone {
         connection_name: String,
     },

--- a/dozer-sinks/snowflake/src/lib.rs
+++ b/dozer-sinks/snowflake/src/lib.rs
@@ -457,9 +457,18 @@ impl SnowflakeSink {
                             previous_op_kind = OpKind::Update;
                             query_builder.update(&table, old, new);
                         }
+                        Operation::BatchInsert { new } => {
+                            if !previous_op_kind.is_insert() {
+                                flush!()
+                            }
+                            previous_op_kind = OpKind::Insert;
+                            insert.extend(new);
+                        }
                     }
                 }
-                LogOperation::Commit { .. } | LogOperation::SnapshottingDone { .. } => {
+                LogOperation::Commit { .. }
+                | LogOperation::SnapshottingStarted { .. }
+                | LogOperation::SnapshottingDone { .. } => {
                     unreachable!("should've been filtered out earlier")
                 }
             }

--- a/dozer-sql/src/aggregation/processor.rs
+++ b/dozer-sql/src/aggregation/processor.rs
@@ -572,6 +572,13 @@ impl AggregationProcessor {
                     Ok(r)
                 }
             }
+            Operation::BatchInsert { new } => {
+                let mut result = vec![];
+                for record in new {
+                    result.extend(self.aggregate(Operation::Insert { new: record })?);
+                }
+                Ok(result)
+            }
         }
     }
 

--- a/dozer-sql/src/product/join/processor.rs
+++ b/dozer-sql/src/product/join/processor.rs
@@ -118,6 +118,19 @@ impl Processor for ProductProcessor {
                 old_records.extend(new_records);
                 old_records
             }
+            Operation::BatchInsert { new } => {
+                for record in &new {
+                    self.process(
+                        from_port,
+                        _record_store,
+                        Operation::Insert {
+                            new: record.clone(),
+                        },
+                        fw,
+                    )?;
+                }
+                return Ok(());
+            }
         };
 
         let elapsed = now.elapsed();

--- a/dozer-sql/src/product/set/set_processor.rs
+++ b/dozer-sql/src/product/set/set_processor.rs
@@ -160,6 +160,16 @@ impl Processor for SetProcessor {
                     }
                 }
             }
+            Operation::BatchInsert { new } => {
+                for record in new {
+                    self.process(
+                        _from_port,
+                        _record_store,
+                        Operation::Insert { new: record },
+                        fw,
+                    )?;
+                }
+            }
         }
         Ok(())
     }

--- a/dozer-sql/src/projection/processor.rs
+++ b/dozer-sql/src/projection/processor.rs
@@ -92,6 +92,17 @@ impl Processor for ProjectionProcessor {
             Operation::Delete { ref old } => self.delete(old)?,
             Operation::Insert { ref new } => self.insert(new)?,
             Operation::Update { ref old, ref new } => self.update(old, new)?,
+            Operation::BatchInsert { new } => {
+                for record in new {
+                    self.process(
+                        _from_port,
+                        _record_store,
+                        Operation::Insert { new: record },
+                        fw,
+                    )?;
+                }
+                return Ok(());
+            }
         };
         fw.send(output_op, DEFAULT_PORT_HANDLE);
         Ok(())

--- a/dozer-sql/src/selection/processor.rs
+++ b/dozer-sql/src/selection/processor.rs
@@ -81,6 +81,16 @@ impl Processor for SelectionProcessor {
                     }
                 }
             }
+            Operation::BatchInsert { new } => {
+                for record in new {
+                    self.process(
+                        _from_port,
+                        _record_store,
+                        Operation::Insert { new: record },
+                        fw,
+                    )?;
+                }
+            }
         }
         Ok(())
     }

--- a/dozer-sql/src/table_operator/processor.rs
+++ b/dozer-sql/src/table_operator/processor.rs
@@ -81,6 +81,16 @@ impl Processor for TableOperatorProcessor {
                     fw.send(Operation::Insert { new: record }, DEFAULT_PORT_HANDLE);
                 }
             }
+            Operation::BatchInsert { new } => {
+                for record in new {
+                    self.process(
+                        _from_port,
+                        record_store,
+                        Operation::Insert { new: record },
+                        fw,
+                    )?;
+                }
+            }
         }
         Ok(())
     }

--- a/dozer-sql/src/tests/builder_test.rs
+++ b/dozer-sql/src/tests/builder_test.rs
@@ -181,6 +181,13 @@ impl Sink for TestSink {
         Ok(())
     }
 
+    fn on_source_snapshotting_started(
+        &mut self,
+        _connection_name: String,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
     fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
         Ok(())
     }

--- a/dozer-sql/src/window/processor.rs
+++ b/dozer-sql/src/window/processor.rs
@@ -68,6 +68,16 @@ impl Processor for WindowProcessor {
                     fw,
                 )?;
             }
+            Operation::BatchInsert { new } => {
+                for record in new {
+                    self.process(
+                        _from_port,
+                        record_store,
+                        Operation::Insert { new: record },
+                        fw,
+                    )?;
+                }
+            }
         }
         Ok(())
     }

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -228,6 +228,12 @@ impl TestSink {
                     records_map.insert(get_key(&new), vec![new]);
                 }
             }
+            Operation::BatchInsert { new } => {
+                drop(records_map);
+                for record in new {
+                    self.update_result(_record_store, Operation::Insert { new: record })?;
+                }
+            }
         }
         Ok(())
     }
@@ -248,6 +254,13 @@ impl Sink for TestSink {
     }
 
     fn persist(&mut self, _epoch: &Epoch, _queue: &Queue) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn on_source_snapshotting_started(
+        &mut self,
+        _connection_name: String,
+    ) -> Result<(), BoxedError> {
         Ok(())
     }
 

--- a/dozer-types/src/models/connection.rs
+++ b/dozer-types/src/models/connection.rs
@@ -54,9 +54,13 @@ pub struct PostgresConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_url: Option<String>,
 
-    /// The connection url to use
+    /// The schema of the tables
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
+
+    /// The snapshot batch size
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch_size: Option<u32>,
 }
 
 impl SchemaExample for PostgresConfig {

--- a/dozer-types/src/tests/postgres_yaml_deserialize.rs
+++ b/dozer-types/src/tests/postgres_yaml_deserialize.rs
@@ -19,6 +19,7 @@ fn standard() {
         sslmode: None,
         connection_url: None,
         schema: None,
+        batch_size: None,
     };
     let expected = ConnectionConfig::Postgres(postgres_auth);
     assert_eq!(expected, deserializer_result);
@@ -53,6 +54,7 @@ fn standard_with_ssl_mode() {
         sslmode: Some("require".to_string()),
         connection_url: None,
         schema: None,
+        batch_size: None,
     };
     let expected = ConnectionConfig::Postgres(postgres_auth);
     assert_eq!(expected, deserializer_result);
@@ -82,6 +84,7 @@ fn standard_url() {
         sslmode: None,
         connection_url: Some("postgres://postgres:postgres@ep-silent-bread-370191.ap-southeast-1.aws.neon.tech:5432/neondb?sslmode=prefer".to_string()),
         schema: None,
+        batch_size: None,
     };
     let expected = ConnectionConfig::Postgres(postgres_auth);
     assert_eq!(expected, deserializer_result);
@@ -112,6 +115,7 @@ fn standard_url_missing_user() {
         sslmode: None,
         connection_url: Some("postgresql://localhost:5432/stocks?sslmode=prefer".to_string()),
         schema: None,
+        batch_size: None,
     };
     let expected = ConnectionConfig::Postgres(postgres_auth);
     assert_eq!(expected, deserializer_result);
@@ -143,6 +147,7 @@ fn standard_url_missing_password() {
         sslmode: None,
         connection_url: Some("postgresql://localhost:5432/stocks?sslmode=prefer".to_string()),
         schema: None,
+        batch_size: None,
     };
     let expected = ConnectionConfig::Postgres(postgres_auth);
     assert_eq!(expected, deserializer_result);
@@ -174,6 +179,7 @@ fn standard_url_2() {
         sslmode: None,
         connection_url: Some("postgresql://localhost:5432/stocks?sslmode=prefer".to_string()),
         schema: None,
+        batch_size: None,
     };
     let expected = ConnectionConfig::Postgres(postgres_auth);
     assert_eq!(expected, deserializer_result);

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -291,6 +291,7 @@ pub enum Operation {
     Delete { old: Record },
     Insert { new: Record },
     Update { old: Record, new: Record },
+    BatchInsert { new: Vec<Record> },
 }
 
 // Helpful in interacting with external systems during ingestion and querying

--- a/json_schemas/connections.json
+++ b/json_schemas/connections.json
@@ -17,6 +17,15 @@
       ],
       "type": "object",
       "properties": {
+        "batch_size": {
+          "description": "The snapshot batch size",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
         "connection_url": {
           "description": "The connection url to use",
           "type": [
@@ -55,7 +64,7 @@
           "minimum": 0.0
         },
         "schema": {
-          "description": "The connection url to use",
+          "description": "The schema of the tables",
           "type": [
             "string",
             "null"

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -1534,6 +1534,15 @@
       ],
       "type": "object",
       "properties": {
+        "batch_size": {
+          "description": "The snapshot batch size",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
         "connection_url": {
           "description": "The connection url to use",
           "type": [
@@ -1572,7 +1581,7 @@
           "minimum": 0.0
         },
         "schema": {
-          "description": "The connection url to use",
+          "description": "The schema of the tables",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
Here we use the `BatchInsert` operation to minimize channel sending overhead.

Processors currently just process as if it's sequential `Insert`s.

Change: 7.41s -> 2.32s
Target: 1.89s