### PR TITLE
Fix spurious rebuilds for aerospike sink

### DIFF
--- a/dozer-sink-aerospike/aerospike-client-sys/build.rs
+++ b/dozer-sink-aerospike/aerospike-client-sys/build.rs
@@ -57,9 +57,9 @@ fn main() {
     println!("cargo:rustc-link-lib=pthread");
 
     println!("cargo:rerun-if-changed=aerospike_client.h");
+    println!("cargo:rerun-if-changed=aerospike-client-c");
     let bindings = bindgen::Builder::default()
         .header("aerospike_client.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .allowlist_type("(as|aerospike)_.*")
         .allowlist_type("aerospike")
         .allowlist_function("(as|aerospike)_.*")


### PR DESCRIPTION
The default bindgen cargo hooks hook on code generated by the build script, which means `aerospike-client-sys` will always rebuild. This commit changes that to use the original sources instead for checking for changes.