### PR TITLE
refactor: Send source state and op id to sink

### DIFF
--- a/dozer-cli/src/pipeline/connector_source.rs
+++ b/dozer-cli/src/pipeline/connector_source.rs
@@ -339,7 +339,7 @@ async fn forward_message_to_pipeline(
                     break;
                 }
             }
-            IngestionMessage::SnapshottingDone | IngestionMessage::SnapshottingStarted => {
+            IngestionMessage::SnapshottingDone { .. } | IngestionMessage::SnapshottingStarted => {
                 for port in &ports {
                     if sender.send((*port, message.clone())).await.is_err() {
                         break;

--- a/dozer-core/src/channels.rs
+++ b/dozer-core/src/channels.rs
@@ -1,10 +1,10 @@
 use crate::node::PortHandle;
-use dozer_types::types::Operation;
+use dozer_types::types::OperationWithId;
 
 pub trait ProcessorChannelForwarder {
     /// Sends a operation to downstream nodes. Panics if the operation cannot be sent.
     ///
     /// We must panic instead of returning an error because this method will be called by `Processor::process`,
     /// which only returns recoverable errors.
-    fn send(&mut self, op: Operation, port: PortHandle);
+    fn send(&mut self, op: OperationWithId, port: PortHandle);
 }

--- a/dozer-core/src/errors.rs
+++ b/dozer-core/src/errors.rs
@@ -37,6 +37,10 @@ pub enum ExecutionError {
     RestoreRecordWriter(#[source] DeserializationError),
     #[error("Source error: {0}")]
     Source(#[source] BoxedError),
+    #[error("Sink error: {0}")]
+    Sink(#[source] BoxedError),
+    #[error("State of {0} is not consistent across sinks")]
+    SourceStateConflict(NodeHandle),
     #[error("File system error {0:?}: {1}")]
     FileSystemError(PathBuf, #[source] std::io::Error),
     #[error("Recordstore error: {0}")]

--- a/dozer-core/src/executor/processor_node.rs
+++ b/dozer-core/src/executor/processor_node.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, mem::swap};
 
 use crossbeam::channel::Receiver;
 use daggy::NodeIndex;
-use dozer_types::node::NodeHandle;
-use dozer_types::types::Operation;
+use dozer_types::node::{NodeHandle, OpIdentifier};
+use dozer_types::types::OperationWithId;
 
 use crate::epoch::Epoch;
 use crate::error_manager::ErrorManager;
@@ -100,7 +100,7 @@ impl ReceiverLoop for ProcessorNode {
         Cow::Owned(self.port_handles[index].to_string())
     }
 
-    fn on_op(&mut self, index: usize, op: Operation) -> Result<(), ExecutionError> {
+    fn on_op(&mut self, index: usize, op: OperationWithId) -> Result<(), ExecutionError> {
         if let Err(e) = self.processor.process(
             self.port_handles[index],
             &self.record_store,
@@ -136,7 +136,12 @@ impl ReceiverLoop for ProcessorNode {
             .send_snapshotting_started(connection_name)
     }
 
-    fn on_snapshotting_done(&mut self, connection_name: String) -> Result<(), ExecutionError> {
-        self.channel_manager.send_snapshotting_done(connection_name)
+    fn on_snapshotting_done(
+        &mut self,
+        connection_name: String,
+        id: Option<OpIdentifier>,
+    ) -> Result<(), ExecutionError> {
+        self.channel_manager
+            .send_snapshotting_done(connection_name, id)
     }
 }

--- a/dozer-core/src/executor_operation.rs
+++ b/dozer-core/src/executor_operation.rs
@@ -1,5 +1,8 @@
 use dozer_recordstore::{ProcessorRecord, StoreRecord};
-use dozer_types::types::Operation;
+use dozer_types::{
+    node::OpIdentifier,
+    types::{Operation, OperationWithId},
+};
 
 use crate::{epoch::Epoch, errors::ExecutionError};
 
@@ -67,9 +70,18 @@ impl ProcessorOperation {
 
 #[derive(Clone, Debug)]
 pub enum ExecutorOperation {
-    Op { op: Operation },
-    Commit { epoch: Epoch },
+    Op {
+        op: OperationWithId,
+    },
+    Commit {
+        epoch: Epoch,
+    },
     Terminate,
-    SnapshottingStarted { connection_name: String },
-    SnapshottingDone { connection_name: String },
+    SnapshottingStarted {
+        connection_name: String,
+    },
+    SnapshottingDone {
+        connection_name: String,
+        id: Option<OpIdentifier>,
+    },
 }

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -16,7 +16,7 @@ use dozer_types::models::ingestion_types::IngestionMessage;
 use dozer_types::node::{NodeHandle, OpIdentifier};
 use dozer_types::tonic::async_trait;
 use dozer_types::types::{
-    Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
+    Field, FieldDefinition, FieldType, Operation, OperationWithId, Record, Schema, SourceDefinition,
 };
 
 use std::collections::HashMap;
@@ -92,7 +92,7 @@ impl Processor for ErrorProcessor {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         self.count += 1;
@@ -361,7 +361,7 @@ impl Source for ErrGeneratorSource {
                                 Field::String(format!("value_{n}")),
                             ]),
                         },
-                        state: Some(OpIdentifier::new(0, n)),
+                        id: Some(OpIdentifier::new(0, n)),
                     },
                 ))
                 .await?;
@@ -456,7 +456,7 @@ impl Sink for ErrSink {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        _op: Operation,
+        _op: OperationWithId,
     ) -> Result<(), BoxedError> {
         self.current += 1;
         if self.current == self.err_at {
@@ -480,8 +480,24 @@ impl Sink for ErrSink {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
+    fn on_source_snapshotting_done(
+        &mut self,
+        _connection_name: String,
+        _id: Option<OpIdentifier>,
+    ) -> Result<(), BoxedError> {
         Ok(())
+    }
+
+    fn set_source_state(&mut self, _source_state: &[u8]) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn get_source_state(&mut self) -> Result<Option<Vec<u8>>, BoxedError> {
+        Ok(None)
+    }
+
+    fn get_latest_op_id(&mut self) -> Result<Option<OpIdentifier>, BoxedError> {
+        Ok(None)
     }
 }
 

--- a/dozer-core/src/tests/dag_base_run.rs
+++ b/dozer-core/src/tests/dag_base_run.rs
@@ -15,7 +15,7 @@ use dozer_recordstore::{ProcessorRecordStore, ProcessorRecordStoreDeserializer};
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
 use dozer_types::tonic::async_trait;
-use dozer_types::types::{Operation, Schema};
+use dozer_types::types::{OperationWithId, Schema};
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -77,7 +77,7 @@ impl Processor for NoopProcessor {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         fw.send(op, DEFAULT_PORT_HANDLE);
@@ -237,7 +237,7 @@ impl Processor for NoopJoinProcessor {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         fw.send(op, DEFAULT_PORT_HANDLE);

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -4,7 +4,8 @@ use crate::DEFAULT_PORT_HANDLE;
 use dozer_log::storage::Queue;
 use dozer_recordstore::ProcessorRecordStore;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::{Operation, Schema};
+use dozer_types::node::OpIdentifier;
+use dozer_types::types::{OperationWithId, Schema};
 
 use dozer_types::log::debug;
 use std::collections::HashMap;
@@ -74,7 +75,7 @@ impl Sink for CountingSink {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        _op: Operation,
+        _op: OperationWithId,
     ) -> Result<(), BoxedError> {
         self.current += 1;
         if self.current == self.expected {
@@ -98,8 +99,24 @@ impl Sink for CountingSink {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
+    fn on_source_snapshotting_done(
+        &mut self,
+        _connection_name: String,
+        _id: Option<OpIdentifier>,
+    ) -> Result<(), BoxedError> {
         Ok(())
+    }
+
+    fn set_source_state(&mut self, _source_state: &[u8]) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn get_source_state(&mut self) -> Result<Option<Vec<u8>>, BoxedError> {
+        Ok(None)
+    }
+
+    fn get_latest_op_id(&mut self) -> Result<Option<OpIdentifier>, BoxedError> {
+        Ok(None)
     }
 }
 

--- a/dozer-core/src/tests/sources.rs
+++ b/dozer-core/src/tests/sources.rs
@@ -117,7 +117,7 @@ impl Source for GeneratorSource {
                                 Field::String(format!("value_{n}")),
                             ]),
                         },
-                        state: Some(OpIdentifier::new(0, n)),
+                        id: Some(OpIdentifier::new(0, n)),
                     },
                 ))
                 .await?;
@@ -248,7 +248,7 @@ impl Source for DualPortGeneratorSource {
                                 Field::String(format!("value_{n}")),
                             ]),
                         },
-                        state: Some(OpIdentifier::new(0, n)),
+                        id: Some(OpIdentifier::new(0, n)),
                     },
                 ))
                 .await?;
@@ -263,7 +263,7 @@ impl Source for DualPortGeneratorSource {
                                 Field::String(format!("value_{n}")),
                             ]),
                         },
-                        state: Some(OpIdentifier::new(0, n)),
+                        id: Some(OpIdentifier::new(0, n)),
                     },
                 ))
                 .await?;

--- a/dozer-ingestion/connector/src/ingestor.rs
+++ b/dozer-ingestion/connector/src/ingestor.rs
@@ -96,7 +96,7 @@ mod tests {
             .handle_message(IngestionMessage::OperationEvent {
                 table_index: 0,
                 op: operation.clone(),
-                state: None,
+                id: None,
             })
             .await
             .unwrap();
@@ -104,12 +104,12 @@ mod tests {
             .handle_message(IngestionMessage::OperationEvent {
                 table_index: 0,
                 op: operation2.clone(),
-                state: None,
+                id: None,
             })
             .await
             .unwrap();
         ingestor
-            .handle_message(IngestionMessage::SnapshottingDone)
+            .handle_message(IngestionMessage::SnapshottingDone { id: None })
             .await
             .unwrap();
 
@@ -121,7 +121,7 @@ mod tests {
                 IngestionMessage::OperationEvent {
                     table_index: 0,
                     op,
-                    state: None
+                    id: None
                 },
                 msg
             );

--- a/dozer-ingestion/deltalake/src/reader.rs
+++ b/dozer-ingestion/deltalake/src/reader.rs
@@ -69,7 +69,7 @@ impl DeltaLakeReader {
                                 lifetime: None,
                             },
                         },
-                        state: None,
+                        id: None,
                     })
                     .await
                     .unwrap();

--- a/dozer-ingestion/dozer/src/connector.rs
+++ b/dozer-ingestion/dozer/src/connector.rs
@@ -260,7 +260,7 @@ async fn read_table(
             .send(IngestionMessage::OperationEvent {
                 table_index,
                 op,
-                state: Some(OpIdentifier::new(0, op_and_pos.pos)),
+                id: Some(OpIdentifier::new(0, op_and_pos.pos)),
             })
             .await;
     }

--- a/dozer-ingestion/ethereum/src/log/sender.rs
+++ b/dozer-ingestion/ethereum/src/log/sender.rs
@@ -222,7 +222,7 @@ async fn process_log(details: Arc<EthDetails<'_>>, msg: Log) {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index,
                     op,
-                    state: None,
+                    id: None,
                 })
                 .await
                 .is_err()
@@ -245,7 +245,7 @@ async fn process_log(details: Arc<EthDetails<'_>>, msg: Log) {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index,
                     op,
-                    state: None,
+                    id: None,
                 })
                 .await;
         } else {

--- a/dozer-ingestion/ethereum/src/trace/connector.rs
+++ b/dozer-ingestion/ethereum/src/trace/connector.rs
@@ -160,7 +160,7 @@ pub async fn run(
                                 .handle_message(IngestionMessage::OperationEvent {
                                     table_index: 0, // We have only one table
                                     op,
-                                    state: None,
+                                    id: None,
                                 })
                                 .await
                                 .is_err()

--- a/dozer-ingestion/grpc/src/adapter/arrow.rs
+++ b/dozer-ingestion/grpc/src/adapter/arrow.rs
@@ -115,7 +115,7 @@ pub async fn handle_message(
             .handle_message(IngestionMessage::OperationEvent {
                 table_index,
                 op,
-                state: None,
+                id: None,
             })
             .await
             .is_err()

--- a/dozer-ingestion/grpc/src/adapter/default.rs
+++ b/dozer-ingestion/grpc/src/adapter/default.rs
@@ -88,7 +88,7 @@ pub async fn handle_message(
         .handle_message(IngestionMessage::OperationEvent {
             table_index,
             op,
-            state: None,
+            id: None,
         })
         .await;
     Ok(())

--- a/dozer-ingestion/javascript/src/js_extension/mod.rs
+++ b/dozer-ingestion/javascript/src/js_extension/mod.rs
@@ -114,13 +114,13 @@ impl JsExtension {
 async fn send(ingestor: Ingestor, val: JsMessage) -> Result<(), Error> {
     let msg = match val.typ {
         MsgType::SnapshottingStarted => IngestionMessage::SnapshottingStarted,
-        MsgType::SnapshottingDone => IngestionMessage::SnapshottingDone,
+        MsgType::SnapshottingDone => IngestionMessage::SnapshottingDone { id: None },
         MsgType::Insert | MsgType::Delete | MsgType::Update => {
             let op = map_operation(val)?;
             IngestionMessage::OperationEvent {
                 table_index: 0,
                 op,
-                state: None,
+                id: None,
             }
         }
     };

--- a/dozer-ingestion/kafka/src/debezium/stream_consumer.rs
+++ b/dozer-ingestion/kafka/src/debezium/stream_consumer.rs
@@ -152,7 +152,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                         lifetime: None,
                                     },
                                 },
-                                state: None,
+                                id: None,
                             })
                             .await
                             .is_err()
@@ -174,7 +174,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                         lifetime: None,
                                     },
                                 },
-                                state: None,
+                                id: None,
                             })
                             .await
                             .is_err()
@@ -196,7 +196,7 @@ impl StreamConsumer for DebeziumStreamConsumer {
                                         lifetime: None,
                                     },
                                 },
-                                state: None,
+                                id: None,
                             })
                             .await
                             .is_err()

--- a/dozer-ingestion/kafka/src/stream_consumer_basic.rs
+++ b/dozer-ingestion/kafka/src/stream_consumer_basic.rs
@@ -159,7 +159,7 @@ impl StreamConsumer for StreamConsumerBasic {
                                             lifetime: None,
                                         },
                                     },
-                                    state: None,
+                                    id: None,
                                 })
                                 .await
                                 .is_err()

--- a/dozer-ingestion/mongodb/src/lib.rs
+++ b/dozer-ingestion/mongodb/src/lib.rs
@@ -631,7 +631,7 @@ impl Connector for MongodbConnector {
                     .handle_message(IngestionMessage::OperationEvent {
                         table_index,
                         op,
-                        state: None,
+                        id: None,
                     })
                     .await
                     .is_err()
@@ -641,7 +641,7 @@ impl Connector for MongodbConnector {
                 }
             }
             if snapshot_ingestor
-                .handle_message(IngestionMessage::SnapshottingDone)
+                .handle_message(IngestionMessage::SnapshottingDone { id: None })
                 .await
                 .is_err()
             {
@@ -678,7 +678,7 @@ impl Connector for MongodbConnector {
                     .handle_message(IngestionMessage::OperationEvent {
                         table_index,
                         op,
-                        state: None,
+                        id: None,
                     })
                     .await
                     .is_err()

--- a/dozer-ingestion/mysql/src/binlog.rs
+++ b/dozer-ingestion/mysql/src/binlog.rs
@@ -542,7 +542,7 @@ impl BinlogIngestor<'_, '_, '_> {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index: table.def.table_index,
                     op: op?,
-                    state: Some(encode_state(pos)),
+                    id: Some(encode_state(pos)),
                 })
                 .await
                 .is_err()

--- a/dozer-ingestion/mysql/src/connector.rs
+++ b/dozer-ingestion/mysql/src/connector.rs
@@ -378,7 +378,7 @@ impl MySQLConnector {
                             .handle_message(IngestionMessage::OperationEvent {
                                 table_index,
                                 op,
-                                state: None,
+                                id: None,
                             })
                             .await
                             .is_err()
@@ -403,7 +403,7 @@ impl MySQLConnector {
 
         if snapshot_started
             && ingestor
-                .handle_message(IngestionMessage::SnapshottingDone)
+                .handle_message(IngestionMessage::SnapshottingDone { id: None })
                 .await
                 .is_err()
         {
@@ -623,7 +623,7 @@ mod tests {
                         Field::Float(1.0.into()),
                     ]),
                 },
-                state: None,
+                id: None,
             },
             IngestionMessage::OperationEvent {
                 table_index: 0,
@@ -634,7 +634,7 @@ mod tests {
                         Field::Float(2.0.into()),
                     ]),
                 },
-                state: None,
+                id: None,
             },
             IngestionMessage::OperationEvent {
                 table_index: 0,
@@ -645,9 +645,9 @@ mod tests {
                         Field::Float(3.0.into()),
                     ]),
                 },
-                state: None,
+                id: None,
             },
-            IngestionMessage::SnapshottingDone,
+            IngestionMessage::SnapshottingDone { id: None },
         ];
 
         check_ingestion_messages(&mut iterator, expected_ingestion_messages).await;
@@ -711,16 +711,16 @@ mod tests {
                 op: Insert {
                     new: Record::new(vec![Field::Int(4), Field::Float(4.0.into())]),
                 },
-                state: None,
+                id: None,
             },
             IngestionMessage::OperationEvent {
                 table_index: 1,
                 op: Insert {
                     new: Record::new(vec![Field::Int(1), Field::Json(true.into())]),
                 },
-                state: None,
+                id: None,
             },
-            IngestionMessage::SnapshottingDone,
+            IngestionMessage::SnapshottingDone { id: None },
         ];
 
         check_ingestion_messages(&mut iterator, expected_ingestion_messages).await;
@@ -736,7 +736,7 @@ mod tests {
                 old: Record::new(vec![Field::Int(4), Field::Float(4.0.into())]),
                 new: Record::new(vec![Field::Int(4), Field::Float(5.0.into())]),
             },
-            state: None,
+            id: None,
         }];
 
         check_ingestion_messages(&mut iterator, expected_ingestion_messages).await;
@@ -751,7 +751,7 @@ mod tests {
             op: Delete {
                 old: Record::new(vec![Field::Int(4), Field::Float(5.0.into())]),
             },
-            state: None,
+            id: None,
         }];
 
         check_ingestion_messages(&mut iterator, expected_ingestion_messages).await;

--- a/dozer-ingestion/object-store/src/connector.rs
+++ b/dozer-ingestion/object-store/src/connector.rs
@@ -177,7 +177,7 @@ impl<T: DozerObjectStore> Connector for ObjectStoreConnector<T> {
         let updated_state = try_join_all(handles).await.unwrap();
 
         sender
-            .send(Ok(Some(IngestionMessage::SnapshottingDone)))
+            .send(Ok(Some(IngestionMessage::SnapshottingDone { id: None })))
             .await
             .unwrap();
 

--- a/dozer-ingestion/object-store/src/table_reader.rs
+++ b/dozer-ingestion/object-store/src/table_reader.rs
@@ -114,7 +114,7 @@ pub async fn read(
                 .send(Ok(Some(IngestionMessage::OperationEvent {
                     table_index,
                     op: evt,
-                    state: None,
+                    id: None,
                 })))
                 .await
                 .is_err()

--- a/dozer-ingestion/object-store/src/tests/local_storage_tests.rs
+++ b/dozer-ingestion/object-store/src/tests/local_storage_tests.rs
@@ -102,7 +102,7 @@ fn test_read_parquet_file() {
     }
 
     let row = iterator.next();
-    if let Some(IngestionMessage::SnapshottingDone) = row {
+    if let Some(IngestionMessage::SnapshottingDone { .. }) = row {
     } else {
         panic!("Unexpected message");
     }
@@ -151,7 +151,7 @@ fn test_read_parquet_file_marker() {
     }
 
     let row = iterator.next();
-    if let Some(IngestionMessage::SnapshottingDone) = row {
+    if let Some(IngestionMessage::SnapshottingDone { .. }) = row {
     } else {
         panic!("Unexpected message");
     }
@@ -172,7 +172,7 @@ fn test_read_parquet_file_no_marker() {
     }
 
     let row = iterator.next();
-    if let Some(IngestionMessage::SnapshottingDone) = row {
+    if let Some(IngestionMessage::SnapshottingDone { .. }) = row {
     } else {
         panic!("Unexpected message");
     }
@@ -228,7 +228,7 @@ fn test_csv_read() {
     }
 
     let row = iterator.next();
-    if let Some(IngestionMessage::SnapshottingDone) = row {
+    if let Some(IngestionMessage::SnapshottingDone { .. }) = row {
     } else {
         panic!("Unexpected message");
     }
@@ -284,7 +284,7 @@ fn test_csv_read_marker() {
     }
 
     let row = iterator.next();
-    if let Some(IngestionMessage::SnapshottingDone) = row {
+    if let Some(IngestionMessage::SnapshottingDone { .. }) = row {
     } else {
         panic!("Unexpected message");
     }
@@ -342,7 +342,7 @@ fn test_csv_read_only_one_marker() {
     // No data to be snapshotted
 
     let row = iterator.next();
-    if let Some(IngestionMessage::SnapshottingDone) = row {
+    if let Some(IngestionMessage::SnapshottingDone { .. }) = row {
     } else {
         panic!("Unexpected message");
     }
@@ -365,7 +365,7 @@ fn test_csv_read_no_marker() {
     // No data to be snapshotted
 
     let row = iterator.next();
-    if let Some(IngestionMessage::SnapshottingDone) = row {
+    if let Some(IngestionMessage::SnapshottingDone { .. }) = row {
     } else {
         panic!("Unexpected message");
     }

--- a/dozer-ingestion/postgres/src/replicator.rs
+++ b/dozer-ingestion/postgres/src/replicator.rs
@@ -132,7 +132,7 @@ impl<'a> CDCHandler<'a> {
                                 .handle_message(IngestionMessage::OperationEvent {
                                     table_index,
                                     op,
-                                    state: Some(OpIdentifier::new(self.begin_lsn, self.seq_no)),
+                                    id: Some(OpIdentifier::new(self.begin_lsn, self.seq_no)),
                                 })
                                 .await
                                 .is_err()

--- a/dozer-ingestion/postgres/src/snapshotter.rs
+++ b/dozer-ingestion/postgres/src/snapshotter.rs
@@ -161,7 +161,7 @@ impl<'a> PostgresSnapshotter<'a> {
                 .handle_message(IngestionMessage::OperationEvent {
                     table_index,
                     op: evt,
-                    state: None,
+                    id: None,
                 })
                 .await
                 .is_err()
@@ -173,7 +173,7 @@ impl<'a> PostgresSnapshotter<'a> {
 
         if self
             .ingestor
-            .handle_message(IngestionMessage::SnapshottingDone)
+            .handle_message(IngestionMessage::SnapshottingDone { id: None })
             .await
             .is_err()
         {

--- a/dozer-ingestion/snowflake/src/stream_consumer.rs
+++ b/dozer-ingestion/snowflake/src/stream_consumer.rs
@@ -126,7 +126,7 @@ impl StreamConsumer {
                     .blocking_handle_message(IngestionMessage::OperationEvent {
                         table_index,
                         op,
-                        state: Some(OpIdentifier::new(iteration, idx as u64)),
+                        id: Some(OpIdentifier::new(iteration, idx as u64)),
                     })
                     .is_err()
                 {

--- a/dozer-ingestion/webhook/src/server.rs
+++ b/dozer-ingestion/webhook/src/server.rs
@@ -130,13 +130,13 @@ impl WebhookServer {
                     op: Operation::Insert {
                         new: records[0].clone(),
                     },
-                    state: None,
+                    id: None,
                 }
             } else {
                 IngestionMessage::OperationEvent {
                     table_index: table_idx,
                     op: Operation::BatchInsert { new: records },
-                    state: None,
+                    id: None,
                 }
             };
             ingestor
@@ -165,7 +165,7 @@ impl WebhookServer {
                 let op: IngestionMessage = IngestionMessage::OperationEvent {
                     table_index: table_idx,
                     op: Operation::Delete { old: record },
-                    state: None,
+                    id: None,
                 };
                 ingestor.handle_message(op).await.map_err(|e| {
                     actix_web::error::ErrorInternalServerError(format!("Error: {}", e))

--- a/dozer-ingestion/webhook/src/tests.rs
+++ b/dozer-ingestion/webhook/src/tests.rs
@@ -151,7 +151,7 @@ fn ingest_webhook_batch_insert() {
     if let IngestionMessage::OperationEvent {
         table_index: _,
         op,
-        state: _,
+        id: _,
     } = msg
     {
         assert_eq!(
@@ -208,7 +208,7 @@ fn ingest_webhook_delete() {
     if let IngestionMessage::OperationEvent {
         table_index: _,
         op,
-        state: _,
+        id: _,
     } = msg
     {
         if let dozer_ingestion_connector::dozer_types::types::Operation::Delete { old } = op {

--- a/dozer-sink-clickhouse/src/lib.rs
+++ b/dozer-sink-clickhouse/src/lib.rs
@@ -17,10 +17,12 @@ use dozer_recordstore::ProcessorRecordStore;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::log::debug;
 use dozer_types::models::endpoint::ClickhouseSinkConfig;
-
+use dozer_types::node::OpIdentifier;
 use dozer_types::serde::Serialize;
 use dozer_types::tonic::async_trait;
-use dozer_types::types::{DozerDuration, DozerPoint, Field, FieldType, Operation, Record, Schema};
+use dozer_types::types::{
+    DozerDuration, DozerPoint, Field, FieldType, Operation, OperationWithId, Record, Schema,
+};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -310,9 +312,9 @@ impl Sink for ClickhouseSink {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
     ) -> Result<(), BoxedError> {
-        match op {
+        match op.op {
             Operation::Insert { new } => {
                 let values = self.map_fields(new)?;
                 self.runtime.block_on(async {
@@ -444,7 +446,23 @@ impl Sink for ClickhouseSink {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
+    fn on_source_snapshotting_done(
+        &mut self,
+        _connection_name: String,
+        _id: Option<OpIdentifier>,
+    ) -> Result<(), BoxedError> {
         Ok(())
+    }
+
+    fn set_source_state(&mut self, _source_state: &[u8]) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn get_source_state(&mut self) -> Result<Option<Vec<u8>>, BoxedError> {
+        Ok(None)
+    }
+
+    fn get_latest_op_id(&mut self) -> Result<Option<OpIdentifier>, BoxedError> {
+        Ok(None)
     }
 }

--- a/dozer-sql/src/aggregation/processor.rs
+++ b/dozer-sql/src/aggregation/processor.rs
@@ -12,7 +12,7 @@ use dozer_recordstore::ProcessorRecordStore;
 use dozer_sql_expression::execution::Expression;
 use dozer_types::bincode;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::{Field, FieldType, Operation, Record, Schema};
+use dozer_types::types::{Field, FieldType, Operation, OperationWithId, Record, Schema};
 use std::collections::HashMap;
 
 use crate::aggregation::aggregator::{
@@ -604,12 +604,12 @@ impl Processor for AggregationProcessor {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        let ops = self.aggregate(op)?;
+        let ops = self.aggregate(op.op)?;
         for output_op in ops {
-            fw.send(output_op, DEFAULT_PORT_HANDLE);
+            fw.send(OperationWithId::without_id(output_op), DEFAULT_PORT_HANDLE);
         }
         Ok(())
     }

--- a/dozer-sql/src/product/set/set_processor.rs
+++ b/dozer-sql/src/product/set/set_processor.rs
@@ -12,7 +12,7 @@ use dozer_core::node::{PortHandle, Processor};
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_recordstore::{ProcessorRecordStore, ProcessorRecordStoreDeserializer};
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::{Operation, Record};
+use dozer_types::types::{Operation, OperationWithId, Record};
 use std::fmt::{Debug, Formatter};
 
 pub struct SetProcessor {
@@ -102,20 +102,26 @@ impl Processor for SetProcessor {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        match op {
+        match op.op {
             Operation::Delete { old } => {
                 let records = self.delete(old).map_err(PipelineError::ProductError)?;
 
                 for (action, record) in records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(Operation::Insert { new: record }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Insert { new: record }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                         SetAction::Delete => {
-                            fw.send(Operation::Delete { old: record }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Delete { old: record }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                     }
                 }
@@ -126,10 +132,16 @@ impl Processor for SetProcessor {
                 for (action, record) in records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(Operation::Insert { new: record }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Insert { new: record }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                         SetAction::Delete => {
-                            fw.send(Operation::Delete { old: record }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Delete { old: record }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                     }
                 }
@@ -141,10 +153,16 @@ impl Processor for SetProcessor {
                 for (action, old) in old_records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(Operation::Insert { new: old }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Insert { new: old }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                         SetAction::Delete => {
-                            fw.send(Operation::Delete { old }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Delete { old }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                     }
                 }
@@ -152,10 +170,16 @@ impl Processor for SetProcessor {
                 for (action, new) in new_records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(Operation::Insert { new }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Insert { new }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                         SetAction::Delete => {
-                            fw.send(Operation::Delete { old: new }, DEFAULT_PORT_HANDLE);
+                            fw.send(
+                                OperationWithId::without_id(Operation::Delete { old: new }),
+                                DEFAULT_PORT_HANDLE,
+                            );
                         }
                     }
                 }
@@ -165,7 +189,7 @@ impl Processor for SetProcessor {
                     self.process(
                         _from_port,
                         _record_store,
-                        Operation::Insert { new: record },
+                        OperationWithId::without_id(Operation::Insert { new: record }),
                         fw,
                     )?;
                 }

--- a/dozer-sql/src/product/table/processor.rs
+++ b/dozer-sql/src/product/table/processor.rs
@@ -5,7 +5,7 @@ use dozer_core::node::{PortHandle, Processor};
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_recordstore::ProcessorRecordStore;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::Operation;
+use dozer_types::types::OperationWithId;
 
 #[derive(Debug)]
 pub struct TableProcessor {
@@ -27,7 +27,7 @@ impl Processor for TableProcessor {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         fw.send(op, DEFAULT_PORT_HANDLE);

--- a/dozer-sql/src/tests/builder_test.rs
+++ b/dozer-sql/src/tests/builder_test.rs
@@ -17,7 +17,7 @@ use dozer_types::node::OpIdentifier;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::tonic::async_trait;
 use dozer_types::types::{
-    Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
+    Field, FieldDefinition, FieldType, Operation, OperationWithId, Record, Schema, SourceDefinition,
 };
 use tokio::sync::mpsc::Sender;
 
@@ -133,7 +133,7 @@ impl Source for TestSource {
                                 ),
                             ]),
                         },
-                        state: None,
+                        id: None,
                     },
                 ))
                 .await
@@ -180,7 +180,7 @@ impl Sink for TestSink {
         &mut self,
         _from_port: PortHandle,
         _record_store: &ProcessorRecordStore,
-        op: Operation,
+        op: OperationWithId,
     ) -> Result<(), BoxedError> {
         println!("Sink: {:?}", op);
         Ok(())
@@ -201,8 +201,24 @@ impl Sink for TestSink {
         Ok(())
     }
 
-    fn on_source_snapshotting_done(&mut self, _connection_name: String) -> Result<(), BoxedError> {
+    fn on_source_snapshotting_done(
+        &mut self,
+        _connection_name: String,
+        _id: Option<OpIdentifier>,
+    ) -> Result<(), BoxedError> {
         Ok(())
+    }
+
+    fn set_source_state(&mut self, _source_state: &[u8]) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn get_source_state(&mut self) -> Result<Option<Vec<u8>>, BoxedError> {
+        Ok(None)
+    }
+
+    fn get_latest_op_id(&mut self) -> Result<Option<OpIdentifier>, BoxedError> {
+        Ok(None)
     }
 }
 

--- a/dozer-types/src/models/ingestion_types.rs
+++ b/dozer-types/src/models/ingestion_types.rs
@@ -25,13 +25,13 @@ pub enum IngestionMessage {
         /// The CDC event.
         op: Operation,
         /// If this connector supports restarting from a specific CDC event, it should provide a `OpIdentifier`.
-        state: Option<OpIdentifier>,
+        id: Option<OpIdentifier>,
     },
     /// A connector uses this message kind to notify Dozer that a initial snapshot of the source tables is started
     SnapshottingStarted,
     /// A connector uses this message kind to notify Dozer that a initial snapshot of the source tables is done,
     /// and the data is up-to-date until next CDC event.
-    SnapshottingDone,
+    SnapshottingDone { id: Option<OpIdentifier> },
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Hash, JsonSchema, Default)]

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -8,6 +8,7 @@ use std::hash::Hash;
 use std::str::FromStr;
 
 use crate::errors::types::TypeError;
+use crate::node::OpIdentifier;
 use prettytable::{Cell, Row, Table};
 use serde::{self, Deserialize, Serialize};
 
@@ -292,6 +293,18 @@ pub enum Operation {
     Insert { new: Record },
     Update { old: Record, new: Record },
     BatchInsert { new: Vec<Record> },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, bincode::Encode, bincode::Decode)]
+pub struct OperationWithId {
+    pub id: Option<OpIdentifier>,
+    pub op: Operation,
+}
+
+impl OperationWithId {
+    pub fn without_id(op: Operation) -> Self {
+        Self { id: None, op }
+    }
 }
 
 // Helpful in interacting with external systems during ingestion and querying


### PR DESCRIPTION
There are two changes in this PR:

- Change `ExecutorOperation::Op`'s type from `Operation` to `OperationWithId`, thus making the sink aware of the id that may be associated with an operation.
- In `dozer-core/src/builder_dag.rs`, the sinks are built first and the sources' connection level state and op level state are read from the sink, instead of from the checkpoint. After building the source with the connection level state, the state is read from the source again and written to sink.

Based on this PR, if a sink implements the writes and reads properly, it's said to be supporting resuming.

Part of #2342