### PR TITLE
feat: Oracle replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4030,7 +4030,9 @@ name = "dozer-ingestion-oracle"
 version = "0.1.0"
 dependencies = [
  "dozer-ingestion-connector",
+ "env_logger 0.11.1",
  "oracle",
+ "regex",
 ]
 
 [[package]]
@@ -9102,13 +9104,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -9123,9 +9125,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/dozer-ingestion/oracle/Cargo.toml
+++ b/dozer-ingestion/oracle/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 dozer-ingestion-connector = { path = "../connector" }
 oracle = { version = "0.5.7", features = ["chrono", "stmt_without_lifetime"] }
+regex = "1.10.3"
+
+[dev-dependencies]
+env_logger = "0.11.1"

--- a/dozer-ingestion/oracle/src/connector/mapping.rs
+++ b/dozer-ingestion/oracle/src/connector/mapping.rs
@@ -45,24 +45,27 @@ fn map_data_type(
         table_name: table_name.to_string(),
         column_name: column_name.to_string(),
     })?;
-    let typ = match data_type {
-        "VARCHAR2" => Ok(FieldType::String),
-        "NVARCHAR2" => unimplemented!("convert NVARCHAR2 to String"),
-        "NUMBER" => Ok(FieldType::Decimal),
-        "FLOAT" => Ok(FieldType::Float),
-        "DATE" => Ok(FieldType::Date),
-        "BINARY_FLOAT" => Ok(FieldType::Float),
-        "BINARY_DOUBLE" => Ok(FieldType::Float),
-        "TIMESTAMP" => Ok(FieldType::Timestamp),
-        "RAW" => Ok(FieldType::Binary),
-        "ROWID" => Ok(FieldType::String),
-        "CHAR" => Ok(FieldType::String),
-        "NCHAR" => unimplemented!("convert NCHAR to String"),
-        "CLOB" => Ok(FieldType::String),
-        "NCLOB" => unimplemented!("convert NCLOB to String"),
-        "BLOB" => Ok(FieldType::Binary),
-        other => Err(DataTypeError::UnsupportedDataType(other.to_string())),
-    }?;
+    let typ = if data_type.starts_with("TIMESTAMP") {
+        FieldType::Timestamp
+    } else {
+        match data_type {
+            "VARCHAR2" => Ok(FieldType::String),
+            "NVARCHAR2" => unimplemented!("convert NVARCHAR2 to String"),
+            "NUMBER" => Ok(FieldType::Decimal),
+            "FLOAT" => Ok(FieldType::Float),
+            "DATE" => Ok(FieldType::Date),
+            "BINARY_FLOAT" => Ok(FieldType::Float),
+            "BINARY_DOUBLE" => Ok(FieldType::Float),
+            "RAW" => Ok(FieldType::Binary),
+            "ROWID" => Ok(FieldType::String),
+            "CHAR" => Ok(FieldType::String),
+            "NCHAR" => unimplemented!("convert NCHAR to String"),
+            "CLOB" => Ok(FieldType::String),
+            "NCLOB" => unimplemented!("convert NCLOB to String"),
+            "BLOB" => Ok(FieldType::Binary),
+            other => Err(DataTypeError::UnsupportedDataType(other.to_string())),
+        }?
+    };
     let nullable = nullable != Some("N");
     Ok(MappedColumn { typ, nullable })
 }

--- a/dozer-ingestion/oracle/src/connector/replicate/listing.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/listing.rs
@@ -1,0 +1,149 @@
+use dozer_ingestion_connector::dozer_types::log::warn;
+use oracle::Connection;
+
+use crate::connector::{Error, Scn};
+
+#[derive(Debug, Clone)]
+pub struct ArchivedLog {
+    pub name: String,
+    pub sequence: u32,
+    pub first_change: Scn,
+    pub next_change: Scn,
+}
+
+impl ArchivedLog {
+    pub fn list(connection: &Connection, start_scn: Scn) -> Result<Vec<ArchivedLog>, Error> {
+        let sql = "SELECT NAME, SEQUENCE#, FIRST_CHANGE#, NEXT_CHANGE# FROM V$ARCHIVED_LOG WHERE NEXT_CHANGE# > :start_scn ORDER BY SEQUENCE# ASC";
+        let rows = connection
+            .query_as::<(String, u32, Scn, Scn)>(sql, &[&start_scn])
+            .unwrap();
+
+        let mut result = vec![];
+        for row in rows {
+            let (name, sequence, first_change, next_change) = row?;
+            let log = ArchivedLog {
+                name,
+                sequence,
+                first_change,
+                next_change,
+            };
+            if is_continuous(result.last(), &log) {
+                result.push(log);
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Log {
+    pub group: u32,
+    pub sequence: u32,
+    pub first_change: Scn,
+    pub next_change: Scn,
+}
+
+impl Log {
+    pub fn list(connection: &Connection, start_scn: Scn) -> Result<Vec<Log>, Error> {
+        let sql = "SELECT GROUP#, SEQUENCE#, FIRST_CHANGE#, NEXT_CHANGE# FROM V$LOG WHERE NEXT_CHANGE# > :start_scn ORDER BY SEQUENCE# ASC";
+        let rows = connection
+            .query_as::<(u32, u32, Scn, Scn)>(sql, &[&start_scn])
+            .unwrap();
+
+        let mut result = vec![];
+        for row in rows {
+            let (group, sequence, first_change, next_change) = row?;
+            let log = Log {
+                group,
+                sequence,
+                first_change,
+                next_change,
+            };
+            if is_continuous(result.last(), &log) {
+                result.push(log);
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LogFile {
+    pub group: u32,
+    pub member: String,
+}
+
+impl LogFile {
+    pub fn list(connection: &Connection) -> Result<Vec<LogFile>, Error> {
+        let sql = "SELECT GROUP#, MEMBER FROM V$LOGFILE WHERE STATUS IS NULL";
+        let rows = connection.query_as::<(u32, String)>(sql, &[]).unwrap();
+
+        let mut result = vec![];
+        for row in rows {
+            let (group, member) = row?;
+            let log_file = LogFile { group, member };
+            result.push(log_file);
+        }
+
+        Ok(result)
+    }
+}
+
+pub trait HasLogIdentifier {
+    fn sequence(&self) -> u32;
+    fn first_change(&self) -> Scn;
+    fn next_change(&self) -> Scn;
+}
+
+impl HasLogIdentifier for ArchivedLog {
+    fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
+    fn first_change(&self) -> Scn {
+        self.first_change
+    }
+
+    fn next_change(&self) -> Scn {
+        self.next_change
+    }
+}
+
+impl HasLogIdentifier for Log {
+    fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
+    fn first_change(&self) -> Scn {
+        self.first_change
+    }
+
+    fn next_change(&self) -> Scn {
+        self.next_change
+    }
+}
+
+pub fn is_continuous(
+    last_log: Option<&impl HasLogIdentifier>,
+    current_log: &impl HasLogIdentifier,
+) -> bool {
+    let Some(last_log) = last_log else {
+        return true;
+    };
+
+    let sequence_is_continuous = last_log.sequence() + 1 == current_log.sequence();
+    let scn_is_continuous = last_log.next_change() == current_log.first_change();
+
+    if sequence_is_continuous != scn_is_continuous {
+        warn!(
+            "Log {} has next change {}, but log {} has first change {}",
+            last_log.sequence(),
+            last_log.next_change(),
+            current_log.sequence(),
+            current_log.first_change()
+        );
+    }
+    sequence_is_continuous && scn_is_continuous
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/listing.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/listing.rs
@@ -1,0 +1,50 @@
+use dozer_ingestion_connector::dozer_types::chrono::{DateTime, Utc};
+use oracle::Connection;
+
+use crate::connector::{Error, Scn};
+
+#[derive(Debug, Clone)]
+pub struct LogManagerContent {
+    pub commit_scn: Scn,
+    pub commit_timestamp: DateTime<Utc>,
+    pub operation_code: u8,
+    pub seg_owner: Option<String>,
+    pub table_name: Option<String>,
+    pub sql_redo: String,
+}
+
+impl LogManagerContent {
+    pub fn list(
+        connection: &Connection,
+        con_id: Option<u32>,
+    ) -> Result<impl Iterator<Item = Result<LogManagerContent, Error>> + '_, Error> {
+        type Row = (
+            Scn,
+            DateTime<Utc>,
+            u8,
+            Option<String>,
+            Option<String>,
+            String,
+        );
+        let rows = if let Some(con_id) = con_id {
+            let sql = "SELECT COMMIT_SCN, COMMIT_TIMESTAMP, OPERATION_CODE, SEG_OWNER, TABLE_NAME, SQL_REDO FROM V$LOGMNR_CONTENTS WHERE SRC_CON_ID = :con_id";
+            connection.query_as::<Row>(sql, &[&con_id])
+        } else {
+            let sql = "SELECT COMMIT_SCN, COMMIT_TIMESTAMP, OPERATION_CODE, SEG_OWNER, TABLE_NAME, SQL_REDO FROM V$LOGMNR_CONTENTS";
+            connection.query_as::<Row>(sql, &[])
+        }?;
+
+        Ok(rows.into_iter().map(|row| {
+            let (commit_scn, commit_timestamp, operation_code, seg_owner, table_name, sql_redo) =
+                row?;
+            Ok(LogManagerContent {
+                commit_scn,
+                commit_timestamp,
+                operation_code,
+                seg_owner,
+                table_name,
+                sql_redo,
+            })
+        }))
+    }
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/mapping.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/mapping.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+
+use dozer_ingestion_connector::dozer_types::{
+    chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, ParseError, Utc},
+    ordered_float::OrderedFloat,
+    rust_decimal::prelude::ToPrimitive,
+    types::{Field, FieldType, Record, Schema},
+};
+
+use crate::connector::Error;
+
+use super::parse::ParsedValue;
+
+pub fn map_row(mut row: HashMap<String, ParsedValue>, schema: &Schema) -> Result<Record, Error> {
+    let mut values = vec![];
+    for field in &schema.fields {
+        let value = row
+            .remove(&field.name)
+            .ok_or_else(|| Error::FieldNotFound(field.name.clone()))?;
+        values.push(map_value(value, field.typ, field.nullable, &field.name)?);
+    }
+
+    Ok(Record::new(values))
+}
+
+fn map_value(
+    value: ParsedValue,
+    typ: FieldType,
+    nullable: bool,
+    name: &str,
+) -> Result<Field, Error> {
+    match (value, typ, nullable) {
+        (ParsedValue::Null, _, false) => Err(Error::NullValue(name.to_string())),
+        (ParsedValue::Null, _, true) => Ok(Field::Null),
+        (ParsedValue::String(string), FieldType::Float, _) => {
+            Ok(Field::Float(OrderedFloat(string.parse()?)))
+        }
+        (ParsedValue::Number(number), FieldType::Float, _) => Ok(Field::Float(OrderedFloat(
+            number
+                .to_f64()
+                .ok_or_else(|| Error::FloatOverflow(number))?,
+        ))),
+        (ParsedValue::String(string), FieldType::Decimal, _) => Ok(Field::Decimal(string.parse()?)),
+        (ParsedValue::Number(number), FieldType::Decimal, _) => Ok(Field::Decimal(number)),
+        (ParsedValue::String(string), FieldType::String, _) => Ok(Field::String(string)),
+        (ParsedValue::Number(_), FieldType::String, _) => Err(Error::TypeMismatch {
+            field: name.to_string(),
+            expected: FieldType::String,
+            actual: FieldType::Decimal,
+        }),
+        (_, FieldType::Binary, _) => unimplemented!("parse binary from redo sql"),
+        (ParsedValue::String(string), FieldType::Date, _) => Ok(Field::Date(
+            parse_date(&string).map_err(|e| Error::ParseDateTime(e, string))?,
+        )),
+        (ParsedValue::Number(_), FieldType::Date, _) => Err(Error::TypeMismatch {
+            field: name.to_string(),
+            expected: FieldType::Date,
+            actual: FieldType::Decimal,
+        }),
+        (ParsedValue::String(string), FieldType::Timestamp, _) => Ok(Field::Timestamp(
+            parse_date_time(&string).map_err(|e| Error::ParseDateTime(e, string))?,
+        )),
+        (ParsedValue::Number(_), FieldType::Timestamp, _) => Err(Error::TypeMismatch {
+            field: name.to_string(),
+            expected: FieldType::Timestamp,
+            actual: FieldType::Decimal,
+        }),
+        _ => unreachable!(),
+    }
+}
+
+fn parse_date(string: &str) -> Result<NaiveDate, ParseError> {
+    NaiveDate::parse_from_str(string, "%d-%b-%y")
+}
+
+fn parse_date_time(string: &str) -> Result<DateTime<FixedOffset>, ParseError> {
+    let date_time = NaiveDateTime::parse_from_str(string, "%d-%b-%y %I.%M.%S%.6f %p")?;
+    Ok(Ok(DateTime::<Utc>::from_naive_utc_and_offset(date_time, Utc))?.fixed_offset())
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/mod.rs
@@ -1,0 +1,154 @@
+use std::{collections::HashMap, sync::mpsc::SyncSender};
+
+use dozer_ingestion_connector::dozer_types::{self, types::Schema};
+use oracle::Connection;
+
+use crate::connector::{Error, Scn};
+
+use self::parse::{ParsedLogManagerContentKind, ParsedOperation};
+
+use super::listing::ArchivedLog;
+
+#[derive(Debug, Clone)]
+pub enum MappedLogManagerContent {
+    Commit(Scn),
+    Op {
+        table_index: usize,
+        op: dozer_types::types::Operation,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct LogMiner {
+    parser: parse::Parser,
+}
+
+impl LogMiner {
+    pub fn new() -> Self {
+        Self {
+            parser: parse::Parser::new(),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn mine(
+        &self,
+        connection: &Connection,
+        log: &ArchivedLog,
+        start_scn: Scn,
+        table_pair_to_index: &HashMap<(String, String), usize>,
+        schemas: &[Schema],
+        con_id: Option<u32>,
+        output: SyncSender<Result<MappedLogManagerContent, Error>>,
+    ) {
+        let _guard = match start_log_manager(connection, log, start_scn) {
+            Ok(guard) => guard,
+            Err(err) => {
+                let _ = output.send(Err(err));
+                return;
+            }
+        };
+
+        let contents = match listing::LogManagerContent::list(connection, con_id) {
+            Ok(contents) => contents,
+            Err(err) => {
+                let _ = output.send(Err(err));
+                return;
+            }
+        };
+        for content in contents {
+            match parse_and_map(&self.parser, content, table_pair_to_index, schemas) {
+                Ok(Some(mapped)) => {
+                    if output.send(Ok(mapped)).is_err() {
+                        return;
+                    }
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    let _ = output.send(Err(err));
+                    return;
+                }
+            }
+        }
+
+        if let Err(e) = end_log_manager(connection) {
+            let _ = output.send(Err(e));
+        }
+    }
+}
+
+mod listing;
+mod mapping;
+mod parse;
+
+fn start_log_manager<'a>(
+    connection: &'a Connection,
+    log: &ArchivedLog,
+    start_scn: Scn,
+) -> Result<LogManagerGuard<'a>, Error> {
+    let sql =
+        "BEGIN DBMS_LOGMNR.ADD_LOGFILE(LOGFILENAME => :name, OPTIONS => DBMS_LOGMNR.NEW); END;";
+    connection.execute(sql, &[&str_to_sql!(log.name)])?;
+    let sql = "
+    BEGIN
+        DBMS_LOGMNR.START_LOGMNR(
+            STARTSCN => :start_scn,
+            OPTIONS =>
+                DBMS_LOGMNR.DICT_FROM_ONLINE_CATALOG +
+                DBMS_LOGMNR.COMMITTED_DATA_ONLY +
+                DBMS_LOGMNR.PRINT_PRETTY_SQL +
+                DBMS_LOGMNR.NO_ROWID_IN_STMT
+        );
+    END;";
+    connection.execute(sql, &[&start_scn])?;
+    Ok(LogManagerGuard { connection })
+}
+
+fn end_log_manager(connection: &Connection) -> Result<(), Error> {
+    connection.execute("BEGIN DBMS_LOGMNR.END_LOGMNR; END;", &[])?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct LogManagerGuard<'a> {
+    connection: &'a Connection,
+}
+
+impl<'a> Drop for LogManagerGuard<'a> {
+    fn drop(&mut self) {
+        let _ = end_log_manager(self.connection);
+    }
+}
+
+fn parse_and_map(
+    parser: &parse::Parser,
+    content: Result<listing::LogManagerContent, Error>,
+    table_pair_to_index: &HashMap<(String, String), usize>,
+    schemas: &[Schema],
+) -> Result<Option<MappedLogManagerContent>, Error> {
+    let Some(parsed) = parser.parse(content?, table_pair_to_index)? else {
+        return Ok(None);
+    };
+    Ok(Some(match parsed.kind {
+        ParsedLogManagerContentKind::Commit => MappedLogManagerContent::Commit(parsed.scn),
+        ParsedLogManagerContentKind::Op { table_index, op } => {
+            let schema = &schemas[table_index];
+            use dozer_types::types::Operation;
+            use mapping::map_row;
+
+            let op = match op {
+                ParsedOperation::Insert(row) => Operation::Insert {
+                    new: map_row(row, schema)?,
+                },
+                ParsedOperation::Delete(row) => Operation::Delete {
+                    old: map_row(row, schema)?,
+                },
+                ParsedOperation::Update { old, new } => Operation::Update {
+                    old: map_row(old, schema)?,
+                    new: map_row(new, schema)?,
+                },
+            };
+            MappedLogManagerContent::Op { table_index, op }
+        }
+    }))
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/delete.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/delete.rs
@@ -1,0 +1,61 @@
+use dozer_ingestion_connector::dozer_types::log::warn;
+use regex::Regex;
+
+use crate::connector::Error;
+
+use super::{row, ParsedRow};
+
+#[derive(Debug, Clone)]
+pub struct Parser {
+    regex: Regex,
+    row_parser: row::Parser,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        let regex = Regex::new(r#"^delete from "(\w+)"\."(\w+)"\n *where\n(?s)(.+)$"#).unwrap();
+        Self {
+            regex,
+            row_parser: row::Parser::new(" and", ";"),
+        }
+    }
+
+    pub fn parse(&self, sql_redo: &str, table_pair: &(String, String)) -> Result<ParsedRow, Error> {
+        let captures = self
+            .regex
+            .captures(sql_redo)
+            .ok_or_else(|| Error::DeleteFailedToMatch(sql_redo.to_string()))?;
+        let owner = captures.get(1).unwrap().as_str();
+        let table_name = captures.get(2).unwrap().as_str();
+        if owner != table_pair.0 || table_name != table_pair.1 {
+            warn!(
+                "Table name {}.{} doesn't match {}.{} in log content",
+                owner, table_name, table_pair.0, table_pair.1
+            );
+        }
+
+        self.row_parser.parse(captures.get(3).unwrap().as_str())
+    }
+}
+
+#[test]
+fn test_parse() {
+    let parser = Parser::new();
+    let sql_redo = r#"delete from "HR"."EMPLOYEES"
+    where
+       "EMPLOYEE_ID" = 306 and
+       "FIRST_NAME" = 'Nandini' and
+       "LAST_NAME" = 'Shastry' and
+       "EMAIL" = 'NSHASTRY' and
+       "PHONE_NUMBER" = '1234567890' and
+       "JOB_ID" = 'HR_REP' and
+       "SALARY" = 120000 and
+       "COMMISSION_PCT" = .05 and
+       "MANAGER_ID" = 105 and
+       "DEPARTMENT_ID" = 10;
+    "#;
+    let parsed = parser
+        .parse(sql_redo, &("HR".to_string(), "EMPLOYEES".to_string()))
+        .unwrap();
+    assert_eq!(parsed.len(), 10);
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/insert.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/insert.rs
@@ -1,0 +1,62 @@
+use dozer_ingestion_connector::dozer_types::log::warn;
+use regex::Regex;
+
+use crate::connector::Error;
+
+use super::{row, ParsedRow};
+
+#[derive(Debug, Clone)]
+pub struct Parser {
+    regex: Regex,
+    row_parser: row::Parser,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        let regex = Regex::new(r#"^insert into "(\w+)"\."(\w+)"\n *values\n(?s)(.+)$"#).unwrap();
+        Self {
+            regex,
+            row_parser: row::Parser::new(",", ";"),
+        }
+    }
+
+    pub fn parse(&self, sql_redo: &str, table_pair: &(String, String)) -> Result<ParsedRow, Error> {
+        let captures = self
+            .regex
+            .captures(sql_redo)
+            .ok_or_else(|| Error::InsertFailedToMatch(sql_redo.to_string()))?;
+        let owner = captures.get(1).unwrap().as_str();
+        let table_name = captures.get(2).unwrap().as_str();
+        if owner != table_pair.0 || table_name != table_pair.1 {
+            warn!(
+                "Table name {}.{} doesn't match {}.{} in log content",
+                owner, table_name, table_pair.0, table_pair.1
+            );
+        }
+
+        self.row_parser.parse(captures.get(3).unwrap().as_str())
+    }
+}
+
+#[test]
+fn test_parse() {
+    let parser = Parser::new();
+    let sql_redo = r#"insert into "HR"."EMPLOYEES"
+    values
+      "EMPLOYEE_ID" = 306,
+      "FIRST_NAME" = 'Nandini',
+      "LAST_NAME" = 'Shastry',
+      "EMAIL" = 'NSHASTRY',
+      "PHONE_NUMBER" = '1234567890',
+      "JOB_ID" = 'HR_REP',
+      "SALARY" = 120000,
+      "COMMISSION_PCT" = .05,
+      "MANAGER_ID" = 105,
+      "NULL_FIELD" IS NULL,
+      "DEPARTMENT_ID" = 10;
+    "#;
+    let parsed = parser
+        .parse(sql_redo, &("HR".to_string(), "EMPLOYEES".to_string()))
+        .unwrap();
+    assert_eq!(parsed.len(), 11);
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/mod.rs
@@ -1,0 +1,140 @@
+use std::{collections::HashMap, str::FromStr};
+
+use dozer_ingestion_connector::dozer_types::{
+    chrono::{DateTime, Utc},
+    log::{trace, warn},
+    rust_decimal::Decimal,
+};
+
+use crate::connector::{Error, Scn};
+
+use super::listing::LogManagerContent;
+
+#[derive(Debug, Clone)]
+pub struct ParsedLogManagerContent {
+    pub scn: Scn,
+    pub timestamp: DateTime<Utc>,
+    pub kind: ParsedLogManagerContentKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum ParsedLogManagerContentKind {
+    Op {
+        table_index: usize,
+        op: ParsedOperation,
+    },
+    Commit,
+}
+
+type ParsedRow = HashMap<String, ParsedValue>;
+
+#[derive(Debug, Clone)]
+pub enum ParsedOperation {
+    Insert(ParsedRow),
+    Delete(ParsedRow),
+    Update { old: ParsedRow, new: ParsedRow },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedValue {
+    String(String),
+    Number(Decimal),
+    Null,
+}
+
+#[derive(Debug, Clone)]
+pub struct Parser {
+    insert_parser: insert::Parser,
+    delete_parser: delete::Parser,
+    update_parser: update::Parser,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        Self {
+            insert_parser: insert::Parser::new(),
+            delete_parser: delete::Parser::new(),
+            update_parser: update::Parser::new(),
+        }
+    }
+
+    pub fn parse(
+        &self,
+        content: LogManagerContent,
+        table_pair_to_index: &HashMap<(String, String), usize>,
+    ) -> Result<Option<ParsedLogManagerContent>, Error> {
+        if content.operation_code == OP_CODE_COMMIT {
+            return Ok(Some(ParsedLogManagerContent {
+                scn: content.commit_scn,
+                timestamp: content.commit_timestamp,
+                kind: ParsedLogManagerContentKind::Commit,
+            }));
+        }
+
+        let Some(owner) = content.seg_owner else {
+            return Ok(None);
+        };
+        let Some(table_name) = content.table_name else {
+            return Ok(None);
+        };
+        let table_pair = (owner, table_name);
+        let Some(&table_index) = table_pair_to_index.get(&table_pair) else {
+            trace!(
+                "Ignoring operation on table {}.{}",
+                table_pair.0,
+                table_pair.1
+            );
+            return Ok(None);
+        };
+
+        let op = match content.operation_code {
+            OP_CODE_INSERT => {
+                ParsedOperation::Insert(self.insert_parser.parse(&content.sql_redo, &table_pair)?)
+            }
+            OP_CODE_DELETE => {
+                ParsedOperation::Delete(self.delete_parser.parse(&content.sql_redo, &table_pair)?)
+            }
+            OP_CODE_UPDATE => {
+                let (old, new) = self.update_parser.parse(&content.sql_redo, &table_pair)?;
+                ParsedOperation::Update { old, new }
+            }
+            OP_CODE_DDL => {
+                warn!("Ignoring DDL operation: {}", content.sql_redo);
+                return Ok(None);
+            }
+            _ => {
+                trace!("Ignoring operation: {:?}", content.sql_redo);
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(ParsedLogManagerContent {
+            scn: content.commit_scn,
+            timestamp: content.commit_timestamp,
+            kind: ParsedLogManagerContentKind::Op { table_index, op },
+        }))
+    }
+}
+
+impl FromStr for ParsedValue {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('\'') {
+            Ok(ParsedValue::String(s[1..s.len() - 1].to_string()))
+        } else {
+            Ok(ParsedValue::Number(s.parse()?))
+        }
+    }
+}
+
+mod delete;
+mod insert;
+mod row;
+mod update;
+
+const OP_CODE_INSERT: u8 = 1;
+const OP_CODE_DELETE: u8 = 2;
+const OP_CODE_UPDATE: u8 = 3;
+const OP_CODE_DDL: u8 = 5;
+const OP_CODE_COMMIT: u8 = 7;

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/row.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/row.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use regex::Regex;
+
+use crate::connector::Error;
+
+use super::{ParsedRow, ParsedValue};
+
+#[derive(Debug, Clone)]
+pub struct Parser {
+    regex: Regex,
+}
+
+impl Parser {
+    pub fn new(delimiter: &str, end: &str) -> Self {
+        let regex = Regex::new(&format!(
+            "\"(\\w+)\" (= (.+)|IS NULL)({}\\n|{})",
+            delimiter, end
+        ))
+        .unwrap();
+        Self { regex }
+    }
+
+    pub fn parse(&self, values: &str) -> Result<ParsedRow, Error> {
+        let mut result = HashMap::new();
+        for cap in self.regex.captures_iter(values) {
+            let column = cap.get(1).unwrap().as_str();
+            let value = match cap.get(3) {
+                Some(value) => value.as_str().parse()?,
+                None => ParsedValue::Null,
+            };
+            result.insert(column.to_string(), value);
+        }
+        Ok(result)
+    }
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/update.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/parse/update.rs
@@ -1,0 +1,92 @@
+use dozer_ingestion_connector::dozer_types::log::warn;
+use regex::Regex;
+
+use crate::connector::Error;
+
+use super::{row, ParsedRow};
+
+#[derive(Debug, Clone)]
+pub struct Parser {
+    regex: Regex,
+    new_row_parser: row::Parser,
+    old_row_parser: row::Parser,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        let regex =
+            Regex::new(r#"^update "(\w+)"\."(\w+)"\n *set\n(?s)(.+) *where\n(?s)(.+)$"#).unwrap();
+        Self {
+            regex,
+            new_row_parser: row::Parser::new(",", "\n"),
+            old_row_parser: row::Parser::new(" and", ";"),
+        }
+    }
+
+    pub fn parse(
+        &self,
+        sql_redo: &str,
+        table_pair: &(String, String),
+    ) -> Result<(ParsedRow, ParsedRow), Error> {
+        let captures = self
+            .regex
+            .captures(sql_redo)
+            .ok_or_else(|| Error::UpdateFailedToMatch(sql_redo.to_string()))?;
+        let owner = captures.get(1).unwrap().as_str();
+        let table_name = captures.get(2).unwrap().as_str();
+        if owner != table_pair.0 || table_name != table_pair.1 {
+            warn!(
+                "Table name {}.{} doesn't match {}.{} in log content",
+                owner, table_name, table_pair.0, table_pair.1
+            );
+        }
+
+        let mut new_row = self
+            .new_row_parser
+            .parse(captures.get(3).unwrap().as_str())?;
+        let old_row = self
+            .old_row_parser
+            .parse(captures.get(4).unwrap().as_str())?;
+        for (column, old_value) in old_row.iter() {
+            if !new_row.contains_key(column) {
+                new_row.insert(column.clone(), old_value.clone());
+            }
+        }
+        Ok((old_row, new_row))
+    }
+}
+
+#[test]
+fn test_parse() {
+    use super::ParsedValue;
+
+    let parser = Parser::new();
+    let sql_redo = r#"update "OE"."PRODUCT_INFORMATION"
+    set
+      "WARRANTY_PERIOD" = 'TO_YMINTERVAL('+05-00')'
+    where
+      "PRODUCT_ID" = '1799' and
+      "WARRANTY_PERIOD" = 'TO_YMINTERVAL('+01-00')';
+    "#;
+    let (old, new) = parser
+        .parse(sql_redo, &("HR".to_string(), "EMPLOYEES".to_string()))
+        .unwrap();
+    assert_eq!(old.len(), 2);
+    assert_eq!(new.len(), 2);
+    assert_eq!(
+        old.get("PRODUCT_ID").unwrap(),
+        &ParsedValue::String("1799".to_string())
+    );
+    assert_eq!(
+        new.get("PRODUCT_ID").unwrap(),
+        &ParsedValue::String("1799".to_string())
+    );
+    assert_eq!(
+        old.get("WARRANTY_PERIOD").unwrap(),
+        &ParsedValue::String("TO_YMINTERVAL('+01-00')".to_string())
+    );
+    assert_eq!(
+        new.get("WARRANTY_PERIOD").unwrap(),
+        &ParsedValue::String("TO_YMINTERVAL('+05-00')".to_string())
+    );
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/merge.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/merge.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+use oracle::Connection;
+
+use crate::connector::{Error, Scn};
+
+use super::listing::{is_continuous, ArchivedLog, Log, LogFile};
+
+pub fn list_and_join_online_log(
+    connection: &Connection,
+    start_scn: Scn,
+) -> Result<Vec<ArchivedLog>, Error> {
+    let logs = Log::list(connection, start_scn)?;
+    let log_files = LogFile::list(connection)?;
+    let mut log_files = log_files
+        .into_iter()
+        .map(|log_file| (log_file.group, log_file.member))
+        .collect::<HashMap<_, _>>();
+
+    let mut result = vec![];
+    for log in logs {
+        if let Some(name) = log_files.remove(&log.group) {
+            let archived_log = ArchivedLog {
+                name,
+                sequence: log.sequence,
+                first_change: log.first_change,
+                next_change: log.next_change,
+            };
+            result.push(archived_log);
+        } else {
+            // We only want continuous logs
+            break;
+        }
+    }
+
+    Ok(result)
+}
+
+pub fn list_and_merge_archived_log(
+    connection: &Connection,
+    start_scn: Scn,
+    mut online_logs: Vec<ArchivedLog>,
+) -> Result<Vec<ArchivedLog>, Error> {
+    let mut archived_logs = ArchivedLog::list(connection, start_scn)?;
+    let first_continuous_online_log_index = online_logs
+        .iter()
+        .position(|log| is_continuous(archived_logs.last(), log));
+    if let Some(index) = first_continuous_online_log_index {
+        archived_logs.extend(online_logs.drain(index..));
+    }
+    Ok(archived_logs)
+}

--- a/dozer-ingestion/oracle/src/connector/replicate/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/mod.rs
@@ -1,0 +1,13 @@
+use self::listing::ArchivedLog;
+
+use super::Scn;
+
+mod listing;
+pub mod log_miner;
+pub mod merge;
+
+pub fn log_contains_scn(log: Option<&ArchivedLog>, scn: Scn) -> bool {
+    log.map_or(false, |log| {
+        log.first_change <= scn && log.next_change > scn
+    })
+}

--- a/dozer-types/src/models/ingestion_types.rs
+++ b/dozer-types/src/models/ingestion_types.rs
@@ -644,8 +644,8 @@ pub struct OracleConfig {
     pub replicator: OracleReplicator,
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Hash, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Copy, Hash, JsonSchema)]
 pub enum OracleReplicator {
-    LogMiner { poll_interval_in_milliseconds: u32 },
+    LogMiner { poll_interval_in_milliseconds: u64 },
     DozerLogReader,
 }

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -1711,7 +1711,7 @@
               "properties": {
                 "poll_interval_in_milliseconds": {
                   "type": "integer",
-                  "format": "uint32",
+                  "format": "uint64",
                   "minimum": 0.0
                 }
               }


### PR DESCRIPTION
# Setup Oracle Server

https://github.com/oracle/docker-images/blob/main/OracleDatabase/SingleInstance/README.md#running-oracle-database-enterprise-and-standard-edition-2-in-a-container

After building the 19.3.0-ee docker image, run:

```bash
docker run --name oracle -p 1521:1521 -p 5500:5500 -e ORACLE_PWD=123 -e ENABLE_ARCHIVELOG=true -v ./data:/opt/oracle/oradata oracle/database:19.3.0-ee
```

## Populate data

First login as sysdba to the PDB:

```bash
./sqlplus sys/123@//localhost:1521/ORCLPDB1 as sysdba
```

Create a new user named `CHUBEI` (this is hardcoded in the test binary) and insert some data:

```sql
CREATE USER chubei IDENTIFIED BY 123;
GRANT CREATE SESSION TO chubei;
GRANT CREATE TABLE TO chubei;
ALTER USER CHUBEI QUOTA UNLIMITED ON USERS;
CREATE TABLE employees (
  employee_id NUMBER,
  first_name VARCHAR2(50),
  last_name VARCHAR2(50),
  hire_date DATE,
  salary NUMBER
);
INSERT INTO employees (employee_id, first_name, last_name, hire_date, salary)
VALUES (1, 'John', 'Doe', TO_DATE('2022-01-01', 'YYYY-MM-DD'), 50000);

INSERT INTO employees (employee_id, first_name, last_name, hire_date, salary)
VALUES (2, 'Jane', 'Smith', TO_DATE('2022-02-15', 'YYYY-MM-DD'), 60000);
```

## Create the replication user

Login to CDB as sysdba:

```bash
./sqlplus sys/123@//localhost:1521/ORCLCDB as sysdba
```

Enable supplemental logging, create replication user `C##DOZER` (this is hardcoded in test binary) and grant permissions:

```sql
alter database add supplemental log data;
CREATE USER C##DOZER IDENTIFIED BY 123;
ALTER USER C##DOZER SET CONTAINER_DATA=ALL CONTAINER=CURRENT;
GRANT CREATE SESSION TO C##DOZER;
GRANT SELECT ON SYS.V_$LOG TO C##DOZER;
GRANT SELECT ON SYS.V_$LOGFILE TO C##DOZER;
GRANT SELECT ON SYS.V_$ARCHIVED_LOG TO C##DOZER;
GRANT SELECT ON SYS.V_$LOGMNR_CONTENTS TO C##DOZER;
GRANT LOGMINING TO C##DOZER;
GRANT EXECUTE ON DBMS_LOGMNR TO C##DOZER;
```

Login to PDB again and grant more permissions:

```bash
./sqlplus sys/123@//localhost:1521/ORCLPDB1 as sysdba
```

```sql
GRANT CREATE TYPE TO C##DOZER;
GRANT SELECT ON SYS.DBA_TABLES to C##DOZER;
GRANT SELECT ON SYS.DBA_TAB_COLUMNS TO C##DOZER;
GRANT SELECT ON SYS.DBA_CONSTRAINTS TO C##DOZER;
GRANT SELECT ON SYS.DBA_CONS_COLUMNS TO C##DOZER;
GRANT EXECUTE ON SYS.DBMS_FLASHBACK TO C##DOZER;
GRANT SELECT ON CHUBEI.EMPLOYEES TO C##DOZER;
```

# Setup Oracle Client

Download client from https://www.oracle.com/database/technologies/instant-client/downloads.html.

# Run snapshot and replication

```bash
RUST_LOG=info DYLD_LIBRARY_PATH=/Users/chubei/Downloads/instantclient_19_16/ cargo test --target x86_64-apple-darwin -p dozer-ingestion-oracle -- --ignored --nocapture
```

This is what I use on apple silicon, adjust path and target accordingly.

You should see log like:

```text
[dozer-ingestion/oracle/src/connector/mod.rs:459] message = OperationEvent {
    table_index: 1,
    op: BatchInsert {
        new: [
            Record {
                values: [
                    Decimal(
                        101,
                    ),
                    String(
                        "John",
                    ),
                    String(
                        "Doe",
                    ),
                    Date(
                        2022-01-15,
                    ),
                    Decimal(
                        50000,
                    ),
                ],
                lifetime: None,
            },
        ],
    },
    id: None,
}
[2024-02-03T10:16:24Z INFO  dozer_ingestion_oracle::connector] Replicating log /opt/oracle/oradata/ORCLCDB/redo02.log (1532833, 9295429630892703743), starting from 1534673
[2024-02-03T10:16:24Z INFO  dozer_ingestion_oracle::connector] Replicated all logs, retrying after 10s
```

Now login as `CHUBEI` to PDB:

```bash
./sqlplus chubei/123@//localhost:1521/ORCLPDB1
```

And insert some data:

```sql
INSERT INTO CHUBEI.EMPLOYEES (EMPLOYEE_ID, FIRST_NAME, LAST_NAME, HIRE_DATE, SALARY) VALUES (101, 'John', 'Doe', TO_DATE('2022-01-15', 'YYYY-MM-DD'), 50000);
COMMIT;
```

Now the test process should output something like:

```text
[dozer-ingestion/oracle/src/connector/mod.rs:512] message = OperationEvent {
    table_index: 1,
    op: Insert {
        new: Record {
            values: [
                Decimal(
                    101,
                ),
                String(
                    "John",
                ),
                String(
                    "Doe",
                ),
                Date(
                    2022-01-15,
                ),
                Null,
            ],
            lifetime: None,
        },
    },
    id: Some(
        OpIdentifier {
            txid: 1595355,
            seq_in_tx: 0,
        },
    ),
}
```

# Known working types

- NUMBER, converted to Decimal
- VARCHAR2, converted to String
- DATE, converted to Date, in `%d-%b-%y` format, example: 15-JAN-22
- TIMESTAMP(6), converted to Timestamp, in `%d-%b-%y %I.%M.%S%.6f %p` format, example: 04-FEB-24 12.19.18.326567 AM

NULLs are already handled.