### PR TITLE
refactor: Guarentee operation order inside a transaction

### DIFF
--- a/dozer-cli/src/pipeline/dummy_sink.rs
+++ b/dozer-cli/src/pipeline/dummy_sink.rs
@@ -12,7 +12,7 @@ use dozer_types::{
     errors::internal::BoxedError,
     log::{info, warn},
     node::OpIdentifier,
-    types::{FieldType, Operation, OperationWithId, Schema},
+    types::{FieldType, Operation, Schema, TableOperation},
 };
 
 #[derive(Debug)]
@@ -63,7 +63,7 @@ struct DummySink {
 }
 
 impl Sink for DummySink {
-    fn process(&mut self, _from_port: PortHandle, op: OperationWithId) -> Result<(), BoxedError> {
+    fn process(&mut self, op: TableOperation) -> Result<(), BoxedError> {
         if self.count % 1000 == 0 {
             if self.count > 0 {
                 info!(

--- a/dozer-cli/src/pipeline/log_sink.rs
+++ b/dozer-cli/src/pipeline/log_sink.rs
@@ -13,7 +13,7 @@ use dozer_core::{
 use dozer_tracing::LabelsAndProgress;
 use dozer_types::types::Schema;
 use dozer_types::{errors::internal::BoxedError, node::OpIdentifier};
-use dozer_types::{indicatif::ProgressBar, types::OperationWithId};
+use dozer_types::{indicatif::ProgressBar, types::TableOperation};
 use tokio::{runtime::Runtime, sync::Mutex};
 
 #[derive(Debug)]
@@ -88,7 +88,7 @@ impl LogSink {
 }
 
 impl Sink for LogSink {
-    fn process(&mut self, _from_port: PortHandle, op: OperationWithId) -> Result<(), BoxedError> {
+    fn process(&mut self, op: TableOperation) -> Result<(), BoxedError> {
         let end = self
             .runtime
             .block_on(self.log.lock())

--- a/dozer-core/src/channels.rs
+++ b/dozer-core/src/channels.rs
@@ -1,10 +1,9 @@
-use crate::node::PortHandle;
-use dozer_types::types::OperationWithId;
+use dozer_types::types::TableOperation;
 
 pub trait ProcessorChannelForwarder {
     /// Sends a operation to downstream nodes. Panics if the operation cannot be sent.
     ///
     /// We must panic instead of returning an error because this method will be called by `Processor::process`,
     /// which only returns recoverable errors.
-    fn send(&mut self, op: OperationWithId, port: PortHandle);
+    fn send(&mut self, op: TableOperation);
 }

--- a/dozer-core/src/executor_operation.rs
+++ b/dozer-core/src/executor_operation.rs
@@ -1,11 +1,11 @@
-use dozer_types::{node::OpIdentifier, types::OperationWithId};
+use dozer_types::{node::OpIdentifier, types::TableOperation};
 
 use crate::epoch::Epoch;
 
 #[derive(Clone, Debug)]
 pub enum ExecutorOperation {
     Op {
-        op: OperationWithId,
+        op: TableOperation,
     },
     Commit {
         epoch: Epoch,

--- a/dozer-core/src/forwarder.rs
+++ b/dozer-core/src/forwarder.rs
@@ -2,7 +2,6 @@ use crate::channels::ProcessorChannelForwarder;
 use crate::epoch::Epoch;
 use crate::error_manager::ErrorManager;
 use crate::errors::ExecutionError;
-use crate::errors::ExecutionError::InvalidPortHandle;
 use crate::executor_operation::ExecutorOperation;
 use crate::node::PortHandle;
 use crate::record_store::RecordWriter;
@@ -10,27 +9,50 @@ use crate::record_store::RecordWriter;
 use crossbeam::channel::Sender;
 use dozer_types::log::debug;
 use dozer_types::node::{NodeHandle, OpIdentifier};
-use dozer_types::types::OperationWithId;
+use dozer_types::types::TableOperation;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
 
 #[derive(Debug)]
+pub struct SenderWithPortMapping {
+    pub sender: Sender<ExecutorOperation>,
+    /// From output port to input port.
+    pub port_mapping: HashMap<PortHandle, Vec<PortHandle>>,
+}
+
+impl SenderWithPortMapping {
+    pub fn send_op(&self, mut op: TableOperation) -> Result<(), ExecutionError> {
+        let Some(ports) = self.port_mapping.get(&op.port) else {
+            // Downstream node is not interested in data from this port.
+            return Ok(());
+        };
+
+        if let Some((last_port, ports)) = ports.split_last() {
+            for port in ports {
+                let mut op = op.clone();
+                op.port = *port;
+                self.sender.send(ExecutorOperation::Op { op })?;
+            }
+            op.port = *last_port;
+            self.sender.send(ExecutorOperation::Op { op })?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
 pub struct ChannelManager {
     owner: NodeHandle,
     record_writers: HashMap<PortHandle, Box<dyn RecordWriter>>,
-    senders: HashMap<PortHandle, Vec<Sender<ExecutorOperation>>>,
+    senders: Vec<SenderWithPortMapping>,
     error_manager: Arc<ErrorManager>,
 }
 
 impl ChannelManager {
     #[inline]
-    pub fn send_op(
-        &mut self,
-        mut op: OperationWithId,
-        port_id: PortHandle,
-    ) -> Result<(), ExecutionError> {
-        if let Some(writer) = self.record_writers.get_mut(&port_id) {
+    pub fn send_op(&mut self, mut op: TableOperation) -> Result<(), ExecutionError> {
+        if let Some(writer) = self.record_writers.get_mut(&op.port) {
             match writer.write(op.op) {
                 Ok(new_op) => op.op = new_op,
                 Err(e) => {
@@ -40,39 +62,35 @@ impl ChannelManager {
             }
         }
 
-        let senders = self
-            .senders
-            .get(&port_id)
-            .ok_or(InvalidPortHandle(port_id))?;
-
-        let exec_op = ExecutorOperation::Op { op };
-
-        if let Some((last_sender, senders)) = senders.split_last() {
+        if let Some((last_sender, senders)) = self.senders.split_last() {
             for sender in senders {
-                sender.send(exec_op.clone())?;
+                sender.send_op(op.clone())?;
             }
-            last_sender.send(exec_op)?;
+            last_sender.send_op(op)?;
         }
 
         Ok(())
     }
 
-    pub fn send_to_all_ports(&self, op: ExecutorOperation) -> Result<(), ExecutionError> {
-        for senders in self.senders.values() {
+    /// Send anything that's not an `ExecutorOperation::Op`.
+    pub fn send_non_op(&self, op: ExecutorOperation) -> Result<(), ExecutionError> {
+        assert!(!matches!(op, ExecutorOperation::Op { .. }));
+        if let Some((last_sender, senders)) = self.senders.split_last() {
             for sender in senders {
-                sender.send(op.clone())?;
+                sender.sender.send(op.clone())?;
             }
+            last_sender.sender.send(op)?;
         }
 
         Ok(())
     }
 
     pub fn send_terminate(&self) -> Result<(), ExecutionError> {
-        self.send_to_all_ports(ExecutorOperation::Terminate)
+        self.send_non_op(ExecutorOperation::Terminate)
     }
 
     pub fn send_snapshotting_started(&self, connection_name: String) -> Result<(), ExecutionError> {
-        self.send_to_all_ports(ExecutorOperation::SnapshottingStarted { connection_name })
+        self.send_non_op(ExecutorOperation::SnapshottingStarted { connection_name })
     }
 
     pub fn send_snapshotting_done(
@@ -80,7 +98,7 @@ impl ChannelManager {
         connection_name: String,
         id: Option<OpIdentifier>,
     ) -> Result<(), ExecutionError> {
-        self.send_to_all_ports(ExecutorOperation::SnapshottingDone {
+        self.send_non_op(ExecutorOperation::SnapshottingDone {
             connection_name,
             id,
         })
@@ -94,7 +112,7 @@ impl ChannelManager {
             epoch.common_info.source_states.deref()
         );
 
-        self.send_to_all_ports(ExecutorOperation::Commit { epoch })
+        self.send_non_op(ExecutorOperation::Commit { epoch })
     }
 
     pub fn owner(&self) -> &NodeHandle {
@@ -104,7 +122,7 @@ impl ChannelManager {
     pub fn new(
         owner: NodeHandle,
         record_writers: HashMap<PortHandle, Box<dyn RecordWriter>>,
-        senders: HashMap<PortHandle, Vec<Sender<ExecutorOperation>>>,
+        senders: Vec<SenderWithPortMapping>,
         error_manager: Arc<ErrorManager>,
     ) -> Self {
         Self {
@@ -117,8 +135,8 @@ impl ChannelManager {
 }
 
 impl ProcessorChannelForwarder for ChannelManager {
-    fn send(&mut self, op: OperationWithId, port: PortHandle) {
-        self.send_op(op, port)
+    fn send(&mut self, op: TableOperation) {
+        self.send_op(op)
             .unwrap_or_else(|e| panic!("Failed to send operation: {e}"))
     }
 }

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -8,11 +8,11 @@ use dozer_types::models::ingestion_types::IngestionMessage;
 use dozer_types::node::OpIdentifier;
 use dozer_types::serde::{Deserialize, Serialize};
 use dozer_types::tonic::async_trait;
-use dozer_types::types::{OperationWithId, Schema};
+use dozer_types::types::{Schema, TableOperation};
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 
-pub type PortHandle = u16;
+pub use dozer_types::types::PortHandle;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(crate = "dozer_types::serde")]
@@ -89,8 +89,7 @@ pub trait Processor: Send + Sync + Debug {
     fn commit(&self, epoch_details: &Epoch) -> Result<(), BoxedError>;
     fn process(
         &mut self,
-        from_port: PortHandle,
-        op: OperationWithId,
+        op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError>;
     fn serialize(&mut self, object: Object) -> Result<(), BoxedError>;
@@ -109,7 +108,7 @@ pub trait SinkFactory: Send + Sync + Debug {
 
 pub trait Sink: Send + Sync + Debug {
     fn commit(&mut self, epoch_details: &Epoch) -> Result<(), BoxedError>;
-    fn process(&mut self, from_port: PortHandle, op: OperationWithId) -> Result<(), BoxedError>;
+    fn process(&mut self, op: TableOperation) -> Result<(), BoxedError>;
     fn persist(&mut self, epoch: &Epoch, queue: &Queue) -> Result<(), BoxedError>;
 
     fn on_source_snapshotting_started(&mut self, connection_name: String)

--- a/dozer-core/src/tests/dag_base_errors.rs
+++ b/dozer-core/src/tests/dag_base_errors.rs
@@ -15,7 +15,7 @@ use dozer_types::models::ingestion_types::{IngestionMessage, TransactionInfo};
 use dozer_types::node::{NodeHandle, OpIdentifier};
 use dozer_types::tonic::async_trait;
 use dozer_types::types::{
-    Field, FieldDefinition, FieldType, Operation, OperationWithId, Record, Schema, SourceDefinition,
+    Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition, TableOperation,
 };
 
 use std::collections::HashMap;
@@ -88,8 +88,7 @@ impl Processor for ErrorProcessor {
 
     fn process(
         &mut self,
-        _from_port: PortHandle,
-        op: OperationWithId,
+        mut op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         self.count += 1;
@@ -101,7 +100,8 @@ impl Processor for ErrorProcessor {
             }
         }
 
-        fw.send(op, DEFAULT_PORT_HANDLE);
+        op.port = DEFAULT_PORT_HANDLE;
+        fw.send(op);
         Ok(())
     }
 
@@ -457,7 +457,7 @@ impl Sink for ErrSink {
         Ok(())
     }
 
-    fn process(&mut self, _from_port: PortHandle, _op: OperationWithId) -> Result<(), BoxedError> {
+    fn process(&mut self, _op: TableOperation) -> Result<(), BoxedError> {
         self.current += 1;
         if self.current == self.err_at {
             if self.panic {

--- a/dozer-core/src/tests/dag_base_run.rs
+++ b/dozer-core/src/tests/dag_base_run.rs
@@ -15,7 +15,7 @@ use dozer_log::tokio::sync::oneshot;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::NodeHandle;
 use dozer_types::tonic::async_trait;
-use dozer_types::types::{OperationWithId, Schema};
+use dozer_types::types::{Schema, TableOperation};
 
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
@@ -74,11 +74,11 @@ impl Processor for NoopProcessor {
 
     fn process(
         &mut self,
-        _from_port: PortHandle,
-        op: OperationWithId,
+        mut op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        fw.send(op, DEFAULT_PORT_HANDLE);
+        op.port = DEFAULT_PORT_HANDLE;
+        fw.send(op);
         Ok(())
     }
 
@@ -227,11 +227,11 @@ impl Processor for NoopJoinProcessor {
 
     fn process(
         &mut self,
-        _from_port: PortHandle,
-        op: OperationWithId,
+        mut op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        fw.send(op, DEFAULT_PORT_HANDLE);
+        op.port = DEFAULT_PORT_HANDLE;
+        fw.send(op);
         Ok(())
     }
 

--- a/dozer-core/src/tests/sinks.rs
+++ b/dozer-core/src/tests/sinks.rs
@@ -4,7 +4,7 @@ use crate::DEFAULT_PORT_HANDLE;
 use dozer_log::storage::Queue;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::node::OpIdentifier;
-use dozer_types::types::{OperationWithId, Schema};
+use dozer_types::types::{Schema, TableOperation};
 
 use dozer_types::log::debug;
 use std::collections::HashMap;
@@ -67,7 +67,7 @@ impl Sink for CountingSink {
         Ok(())
     }
 
-    fn process(&mut self, _from_port: PortHandle, _op: OperationWithId) -> Result<(), BoxedError> {
+    fn process(&mut self, _op: TableOperation) -> Result<(), BoxedError> {
         self.current += 1;
         if self.current == self.expected {
             debug!(

--- a/dozer-sink-clickhouse/src/lib.rs
+++ b/dozer-sink-clickhouse/src/lib.rs
@@ -20,7 +20,7 @@ use dozer_types::node::OpIdentifier;
 use dozer_types::serde::Serialize;
 use dozer_types::tonic::async_trait;
 use dozer_types::types::{
-    DozerDuration, DozerPoint, Field, FieldType, Operation, OperationWithId, Record, Schema,
+    DozerDuration, DozerPoint, Field, FieldType, Operation, Record, Schema, TableOperation,
 };
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -311,7 +311,7 @@ impl Sink for ClickhouseSink {
         self.commit_insert()
     }
 
-    fn process(&mut self, _from_port: PortHandle, op: OperationWithId) -> Result<(), BoxedError> {
+    fn process(&mut self, op: TableOperation) -> Result<(), BoxedError> {
         match op.op {
             Operation::Insert { new } => {
                 let values = self.map_fields(new)?;

--- a/dozer-sink-oracle/src/lib.rs
+++ b/dozer-sink-oracle/src/lib.rs
@@ -285,8 +285,7 @@ impl Sink for OracleSink {
 
     fn process(
         &mut self,
-        _from_port: dozer_core::node::PortHandle,
-        op: dozer_types::types::OperationWithId,
+        op: dozer_types::types::TableOperation,
     ) -> Result<(), dozer_types::errors::internal::BoxedError> {
         match op.op {
             dozer_types::types::Operation::Delete { old } => {

--- a/dozer-sql/src/aggregation/processor.rs
+++ b/dozer-sql/src/aggregation/processor.rs
@@ -6,12 +6,12 @@ use crate::utils::record_hashtable_key::{get_record_hash, RecordKey};
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::checkpoint::serialize::{deserialize_vec_u8, serialize_vec_u8, Cursor};
 use dozer_core::dozer_log::storage::Object;
-use dozer_core::node::{PortHandle, Processor};
+use dozer_core::node::Processor;
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_sql_expression::execution::Expression;
 use dozer_types::bincode;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::{Field, FieldType, Operation, OperationWithId, Record, Schema};
+use dozer_types::types::{Field, FieldType, Operation, Record, Schema, TableOperation};
 use std::collections::HashMap;
 
 use crate::aggregation::aggregator::{
@@ -600,13 +600,12 @@ impl Processor for AggregationProcessor {
 
     fn process(
         &mut self,
-        _from_port: PortHandle,
-        op: OperationWithId,
+        op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         let ops = self.aggregate(op.op)?;
         for output_op in ops {
-            fw.send(OperationWithId::without_id(output_op), DEFAULT_PORT_HANDLE);
+            fw.send(TableOperation::without_id(output_op, DEFAULT_PORT_HANDLE));
         }
         Ok(())
     }

--- a/dozer-sql/src/expression/tests/test_common.rs
+++ b/dozer-sql/src/expression/tests/test_common.rs
@@ -3,16 +3,16 @@ use crate::{projection::factory::ProjectionProcessorFactory, tests::utils::get_s
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::node::ProcessorFactory;
 use dozer_core::DEFAULT_PORT_HANDLE;
-use dozer_types::types::{Field, OperationWithId, Schema};
+use dozer_types::types::{Field, Schema, TableOperation};
 use dozer_types::types::{Operation, Record};
 use std::collections::HashMap;
 
 struct TestChannelForwarder {
-    operations: Vec<OperationWithId>,
+    operations: Vec<TableOperation>,
 }
 
 impl ProcessorChannelForwarder for TestChannelForwarder {
-    fn send(&mut self, op: OperationWithId, _port: dozer_core::node::PortHandle) {
+    fn send(&mut self, op: TableOperation) {
         self.operations.push(op);
     }
 }
@@ -51,11 +51,7 @@ pub(crate) fn run_fct(sql: &str, schema: Schema, input: Vec<Field>) -> Field {
     let op = Operation::Insert { new: rec };
 
     processor
-        .process(
-            DEFAULT_PORT_HANDLE,
-            OperationWithId::without_id(op),
-            &mut fw,
-        )
+        .process(TableOperation::without_id(op, DEFAULT_PORT_HANDLE), &mut fw)
         .unwrap();
 
     match &mut fw.operations[0].op {

--- a/dozer-sql/src/product/set/set_processor.rs
+++ b/dozer-sql/src/product/set/set_processor.rs
@@ -8,10 +8,10 @@ use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::checkpoint::serialize::Cursor;
 use dozer_core::dozer_log::storage::Object;
 use dozer_core::epoch::Epoch;
-use dozer_core::node::{PortHandle, Processor};
+use dozer_core::node::Processor;
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::{Operation, OperationWithId, Record};
+use dozer_types::types::{Operation, Record, TableOperation};
 use std::fmt::{Debug, Formatter};
 
 pub struct SetProcessor {
@@ -95,8 +95,7 @@ impl Processor for SetProcessor {
 
     fn process(
         &mut self,
-        _from_port: PortHandle,
-        op: OperationWithId,
+        op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         match op.op {
@@ -106,16 +105,16 @@ impl Processor for SetProcessor {
                 for (action, record) in records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Insert { new: record }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Insert { new: record },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                         SetAction::Delete => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Delete { old: record }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Delete { old: record },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                     }
                 }
@@ -126,16 +125,16 @@ impl Processor for SetProcessor {
                 for (action, record) in records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Insert { new: record }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Insert { new: record },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                         SetAction::Delete => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Delete { old: record }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Delete { old: record },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                     }
                 }
@@ -147,16 +146,16 @@ impl Processor for SetProcessor {
                 for (action, old) in old_records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Insert { new: old }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Insert { new: old },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                         SetAction::Delete => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Delete { old }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Delete { old },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                     }
                 }
@@ -164,16 +163,16 @@ impl Processor for SetProcessor {
                 for (action, new) in new_records.into_iter() {
                     match action {
                         SetAction::Insert => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Insert { new }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Insert { new },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                         SetAction::Delete => {
-                            fw.send(
-                                OperationWithId::without_id(Operation::Delete { old: new }),
+                            fw.send(TableOperation::without_id(
+                                Operation::Delete { old: new },
                                 DEFAULT_PORT_HANDLE,
-                            );
+                            ));
                         }
                     }
                 }
@@ -181,8 +180,7 @@ impl Processor for SetProcessor {
             Operation::BatchInsert { new } => {
                 for record in new {
                     self.process(
-                        _from_port,
-                        OperationWithId::without_id(Operation::Insert { new: record }),
+                        TableOperation::without_id(Operation::Insert { new: record }, op.port),
                         fw,
                     )?;
                 }

--- a/dozer-sql/src/product/table/processor.rs
+++ b/dozer-sql/src/product/table/processor.rs
@@ -1,10 +1,10 @@
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::dozer_log::storage::Object;
 use dozer_core::epoch::Epoch;
-use dozer_core::node::{PortHandle, Processor};
+use dozer_core::node::Processor;
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::OperationWithId;
+use dozer_types::types::TableOperation;
 
 #[derive(Debug)]
 pub struct TableProcessor {
@@ -24,11 +24,11 @@ impl Processor for TableProcessor {
 
     fn process(
         &mut self,
-        _from_port: PortHandle,
-        op: OperationWithId,
+        mut op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        fw.send(op, DEFAULT_PORT_HANDLE);
+        op.port = DEFAULT_PORT_HANDLE;
+        fw.send(op);
         Ok(())
     }
 

--- a/dozer-sql/src/projection/processor.rs
+++ b/dozer-sql/src/projection/processor.rs
@@ -5,10 +5,10 @@ use dozer_sql_expression::execution::Expression;
 use dozer_core::channels::ProcessorChannelForwarder;
 use dozer_core::dozer_log::storage::Object;
 use dozer_core::epoch::Epoch;
-use dozer_core::node::{PortHandle, Processor};
+use dozer_core::node::Processor;
 use dozer_core::DEFAULT_PORT_HANDLE;
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::types::{Operation, OperationWithId, Record, Schema};
+use dozer_types::types::{Operation, Record, Schema, TableOperation};
 
 #[derive(Debug)]
 pub struct ProjectionProcessor {
@@ -82,8 +82,7 @@ impl ProjectionProcessor {
 impl Processor for ProjectionProcessor {
     fn process(
         &mut self,
-        _from_port: PortHandle,
-        op: OperationWithId,
+        op: TableOperation,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         let output_op = match op.op {
@@ -100,13 +99,11 @@ impl Processor for ProjectionProcessor {
                 Operation::BatchInsert { new: records }
             }
         };
-        fw.send(
-            OperationWithId {
-                id: op.id,
-                op: output_op,
-            },
-            DEFAULT_PORT_HANDLE,
-        );
+        fw.send(TableOperation {
+            id: op.id,
+            op: output_op,
+            port: DEFAULT_PORT_HANDLE,
+        });
         Ok(())
     }
 

--- a/dozer-sql/src/tests/builder_test.rs
+++ b/dozer-sql/src/tests/builder_test.rs
@@ -16,7 +16,7 @@ use dozer_types::node::OpIdentifier;
 use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::tonic::async_trait;
 use dozer_types::types::{
-    Field, FieldDefinition, FieldType, Operation, OperationWithId, Record, Schema, SourceDefinition,
+    Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition, TableOperation,
 };
 use tokio::sync::mpsc::Sender;
 
@@ -177,7 +177,7 @@ impl SinkFactory for TestSinkFactory {
 pub struct TestSink {}
 
 impl Sink for TestSink {
-    fn process(&mut self, _from_port: PortHandle, op: OperationWithId) -> Result<(), BoxedError> {
+    fn process(&mut self, op: TableOperation) -> Result<(), BoxedError> {
         println!("Sink: {:?}", op);
         Ok(())
     }

--- a/dozer-tests/src/sql_tests/helper/pipeline.rs
+++ b/dozer-tests/src/sql_tests/helper/pipeline.rs
@@ -20,7 +20,7 @@ use dozer_sql::builder::statement_to_pipeline;
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::models::ingestion_types::IngestionMessage;
 use dozer_types::node::OpIdentifier;
-use dozer_types::types::{Operation, OperationWithId, Record, Schema, SourceDefinition};
+use dozer_types::types::{Operation, Record, Schema, SourceDefinition, TableOperation};
 use std::collections::HashMap;
 use std::future::pending;
 use tempdir::TempDir;
@@ -249,7 +249,7 @@ impl TestSink {
 }
 
 impl Sink for TestSink {
-    fn process(&mut self, _from_port: PortHandle, op: OperationWithId) -> Result<(), BoxedError> {
+    fn process(&mut self, op: TableOperation) -> Result<(), BoxedError> {
         self.update_result(op.op)
     }
 

--- a/dozer-types/src/types/mod.rs
+++ b/dozer-types/src/types/mod.rs
@@ -295,15 +295,21 @@ pub enum Operation {
     BatchInsert { new: Vec<Record> },
 }
 
+pub type PortHandle = u16;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, bincode::Encode, bincode::Decode)]
-pub struct OperationWithId {
+pub struct TableOperation {
     pub id: Option<OpIdentifier>,
     pub op: Operation,
+    /// For outputting an operation, node should fill the output port.
+    /// For received operation, the port is the input port.
+    /// Port mapping is done in forwarders.
+    pub port: PortHandle,
 }
 
-impl OperationWithId {
-    pub fn without_id(op: Operation) -> Self {
-        Self { id: None, op }
+impl TableOperation {
+    pub fn without_id(op: Operation, port: PortHandle) -> Self {
+        Self { id: None, op, port }
     }
 }
 


### PR DESCRIPTION
Based on https://github.com/getdozer/dozer/discussions/2387. Turns out that the "port concept" is still needed.

This PR changes how threads in the DAG talk to each other.

Previously if there are two edges between a pair of node, two channels are created and operations from the source node are split and sent to different channels, which loses the ordering of the operations.
In this PR we always use a single channel for node-to-node communication. The port information is hence moved into the `ExecutorOperation`.

This opens the possibility for implementing transaction-aware and order-preserving processors and sinks.