### PR TITLE
Allow renaming of denormalized columns

### DIFF
--- a/dozer-types/src/models/endpoint.rs
+++ b/dozer-types/src/models/endpoint.rs
@@ -114,11 +114,18 @@ pub enum EndpointKind {
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum DenormColumn {
+    Direct(String),
+    Renamed { source: String, destination: String },
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq)]
 pub struct AerospikeDenormalizations {
     pub from_namespace: String,
     pub from_set: String,
     pub key: String,
-    pub columns: Vec<String>,
+    pub columns: Vec<DenormColumn>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -185,7 +185,7 @@
         "columns": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/DenormColumn"
           }
         },
         "from_namespace": {
@@ -871,6 +871,28 @@
           "type": "string"
         }
       }
+    },
+    "DenormColumn": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "required": [
+            "destination",
+            "source"
+          ],
+          "properties": {
+            "destination": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     },
     "DozerTelemetryConfig": {
       "type": "object",


### PR DESCRIPTION
Like before, if the name of a column (bin) is the same in both the
source set and destination set, you can specify it like
```yaml
columns:
  - column_name
```

To rename, you can instead do
```yaml
columns:
  - source: src_col
    destination: dst_col
```
in which case the column will be looked up as `src_col` and written as
`dst_col`
