### PR TITLE
Aerospike sink: resumability

### DIFF
--- a/dozer-core/src/executor/mod.rs
+++ b/dozer-core/src/executor/mod.rs
@@ -108,7 +108,7 @@ impl DagExecutor {
             let Some(node) = execution_dag.graph()[node_index].kind.as_ref() else {
                 continue;
             };
-            match &node {
+            match node {
                 NodeKind::Source { .. } => unreachable!("We already started the source node"),
                 NodeKind::Processor(_) => {
                     let processor_node = ProcessorNode::new(&mut execution_dag, node_index).await;

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -107,7 +107,7 @@ pub trait SinkFactory: Send + Sync + Debug {
     fn type_name(&self) -> String;
 }
 
-pub trait Sink: Send + Sync + Debug {
+pub trait Sink: Send + Debug {
     fn commit(&mut self, epoch_details: &Epoch) -> Result<(), BoxedError>;
     fn process(&mut self, op: TableOperation) -> Result<(), BoxedError>;
     fn persist(&mut self, epoch: &Epoch, queue: &Queue) -> Result<(), BoxedError>;

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/mod.rs
@@ -13,6 +13,7 @@ use super::listing::ArchivedLog;
 pub enum MappedLogManagerContent {
     Commit(Scn),
     Op {
+        scn: Scn,
         table_index: usize,
         op: dozer_types::types::Operation,
     },
@@ -146,7 +147,11 @@ fn parse_and_map(
                     new: map_row(new, schema)?,
                 },
             };
-            MappedLogManagerContent::Op { table_index, op }
+            MappedLogManagerContent::Op {
+                table_index,
+                op,
+                scn: parsed.scn,
+            }
         }
     }))
 }

--- a/dozer-sink-aerospike/aerospike-client-sys/aerospike_client.h
+++ b/dozer-sink-aerospike/aerospike-client-sys/aerospike_client.h
@@ -12,3 +12,4 @@
 #include <aerospike/as_arraylist.h>
 #include <aerospike/as_map.h>
 #include <aerospike/as_orderedmap.h>
+#include <aerospike/as_exp.h>

--- a/dozer-sink-aerospike/aerospike-client-sys/src/lib.rs
+++ b/dozer-sink-aerospike/aerospike-client-sys/src/lib.rs
@@ -4,3 +4,171 @@
 #![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+#[macro_export]
+macro_rules! as_exp_build {
+    ($func:ident $args:tt ) => {{
+        let mut v = Vec::new();
+        $crate::as_exp_build_inner!(v, $func $args);
+        $crate::as_exp_compile(v.as_mut_ptr(), v.len() as u32)
+    }}
+}
+
+#[macro_export]
+macro_rules! as_exp_build_inner {
+    ($v:expr, as_exp_bin_int($bin_name:expr $(,)?)) => {{
+        let bin_name: *const i8 = $bin_name;
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_BIN,
+            count: 3,
+            sz: 0,
+            prev_va_args: 0,
+            v: std::mem::zeroed(),
+        });
+        $crate::as_exp_build_inner!($v, as_exp_int($crate::as_exp_type_AS_EXP_TYPE_INT as i64));
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_VAL_RAWSTR,
+            v: $crate::as_exp_entry__bindgen_ty_1 { str_val: bin_name },
+            count: 0,
+            sz: 0,
+            prev_va_args: 0,
+        });
+    }};
+    ($v:expr, as_exp_int($val:expr)) => {
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_VAL_INT,
+            v: $crate::as_exp_entry__bindgen_ty_1 { int_val: $val },
+            count: 0,
+            sz: 0,
+            prev_va_args: 0,
+        })
+    };
+    ($v:expr, as_exp_uint($val:expr)) => {
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_VAL_UINT,
+            v: $crate::as_exp_entry__bindgen_ty_1 { uint_val: $val },
+            count: 0,
+            sz: 0,
+            prev_va_args: 0,
+        })
+    };
+    ($v:expr, as_exp_cmp_eq($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_EQ,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_cmp_gt($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_GT,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_cmp_ge($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_GE,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left);
+        $crate::as_exp_build_inner!($v, $right);
+    }};
+    ($v:expr, as_exp_cmp_lt($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_LT,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_cmp_le($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_LE,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_and($($arg_name:ident $arg_args:tt),*)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_AND,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $($crate::as_exp_build_inner!($v, $arg_name $arg_args));*;
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_END_OF_VA_ARGS,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+    }};
+($v:expr, as_exp_or($($arg_name:ident $arg_args:tt),*)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_OR,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $($crate::as_exp_build_inner!($v, $arg_name $arg_args));*;
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_END_OF_VA_ARGS,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+
+    use super::*;
+
+    #[test]
+    fn test_as_exp_build() {
+        // Tested that this results in the same compiled expression as when
+        // using the macros from the C library
+        let bin_name = CString::new("bin_name").unwrap();
+        unsafe {
+            let exp = as_exp_build! {
+                as_exp_and(
+                as_exp_cmp_gt(
+                    as_exp_bin_int(bin_name.as_ptr()),
+                    as_exp_int(3)
+                ),
+                as_exp_cmp_lt(
+                    as_exp_bin_int(bin_name.as_ptr()),
+                    as_exp_int(8)
+                )
+                )
+            };
+            assert!(!exp.is_null());
+            as_exp_destroy(exp);
+        }
+    }
+}

--- a/dozer-sink-aerospike/aerospike-client-sys/src/lib.rs
+++ b/dozer-sink-aerospike/aerospike-client-sys/src/lib.rs
@@ -17,7 +17,7 @@ macro_rules! as_exp_build {
 #[macro_export]
 macro_rules! as_exp_build_inner {
     ($v:expr, as_exp_bin_int($bin_name:expr $(,)?)) => {{
-        let bin_name: *const i8 = $bin_name;
+        let bin_name: *const std::ffi::c_char = $bin_name;
         $v.push($crate::as_exp_entry {
             op: $crate::as_exp_ops__AS_EXP_CODE_BIN,
             count: 3,

--- a/dozer-sink-aerospike/src/lib.rs
+++ b/dozer-sink-aerospike/src/lib.rs
@@ -16,10 +16,7 @@ use std::time::{Duration, Instant};
 use std::{collections::HashMap, fmt::Debug};
 
 use aerospike_client_sys::*;
-use dozer_core::{
-    node::{PortHandle, Sink, SinkFactory},
-    DEFAULT_PORT_HANDLE,
-};
+use dozer_core::node::{PortHandle, Sink, SinkFactory};
 use dozer_types::errors::internal::BoxedError;
 use dozer_types::geo::{Coord, Point};
 use dozer_types::ordered_float::OrderedFloat;
@@ -1429,7 +1426,6 @@ impl Sink for AerospikeSink {
     }
 
     fn process(&mut self, op: TableOperation) -> Result<(), BoxedError> {
-        debug_assert_eq!(op.port, DEFAULT_PORT_HANDLE);
         if let Some(snapshot_sender) = &mut self.snapshot_sender {
             snapshot_sender.send(op)?;
         } else {
@@ -1563,6 +1559,7 @@ impl Sink for AerospikeSink {
 #[cfg(test)]
 mod tests {
 
+    use dozer_core::DEFAULT_PORT_HANDLE;
     use dozer_log::tokio;
     use std::time::Duration;
 

--- a/dozer-types/src/models/sink.rs
+++ b/dozer-types/src/models/sink.rs
@@ -150,6 +150,9 @@ pub struct AerospikeSinkConfig {
     pub n_threads: Option<NonZeroUsize>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tables: Vec<AerospikeSinkTable>,
+    pub metadata_namespace: String,
+    #[serde(default)]
+    pub metadata_set: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -203,11 +203,22 @@
     "AerospikeSinkConfig": {
       "type": "object",
       "required": [
-        "connection"
+        "connection",
+        "metadata_namespace"
       ],
       "properties": {
         "connection": {
           "type": "string"
+        },
+        "metadata_namespace": {
+          "type": "string"
+        },
+        "metadata_set": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "n_threads": {
           "type": [


### PR DESCRIPTION
This implements resuming for the aerospike sink in the following way:

 - Write the OperationId of every op to the affected record
 - On commit, write the OperationId to a separate set asynchronously

When restarting, the commit OperationId is returned as the last operation id.
This might be behind (because aerospike semantics and because we write it asynchronously),
but we catch that by only applying operations if the record they apply to has
an OperationId that is smaller than the applied operation. This means the
commit OperationId is only there to get a reasonably tight lower bound on the
OperationId, as it's not needed for correctness.
