### PR TITLE
fix: Oracle source skips uncommitted operations that are before another commit

### DIFF
--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/listing.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/listing.rs
@@ -16,6 +16,7 @@ pub struct LogManagerContent {
 impl LogManagerContent {
     pub fn list(
         connection: &Connection,
+        start_scn: Scn,
         con_id: Option<u32>,
     ) -> Result<impl Iterator<Item = Result<LogManagerContent, Error>> + '_, Error> {
         type Row = (
@@ -27,11 +28,11 @@ impl LogManagerContent {
             String,
         );
         let rows = if let Some(con_id) = con_id {
-            let sql = "SELECT COMMIT_SCN, COMMIT_TIMESTAMP, OPERATION_CODE, SEG_OWNER, TABLE_NAME, SQL_REDO FROM V$LOGMNR_CONTENTS WHERE SRC_CON_ID = :con_id";
-            connection.query_as::<Row>(sql, &[&con_id])
+            let sql = "SELECT COMMIT_SCN, COMMIT_TIMESTAMP, OPERATION_CODE, SEG_OWNER, TABLE_NAME, SQL_REDO FROM V$LOGMNR_CONTENTS WHERE COMMIT_SCN >= :start_scn AND SRC_CON_ID = :con_id";
+            connection.query_as::<Row>(sql, &[&start_scn, &con_id])
         } else {
-            let sql = "SELECT COMMIT_SCN, COMMIT_TIMESTAMP, OPERATION_CODE, SEG_OWNER, TABLE_NAME, SQL_REDO FROM V$LOGMNR_CONTENTS";
-            connection.query_as::<Row>(sql, &[])
+            let sql = "SELECT COMMIT_SCN, COMMIT_TIMESTAMP, OPERATION_CODE, SEG_OWNER, TABLE_NAME, SQL_REDO FROM V$LOGMNR_CONTENTS WHERE COMMIT_SCN >= :start_scn";
+            connection.query_as::<Row>(sql, &[&start_scn])
         }?;
 
         Ok(rows.into_iter().map(|row| {


### PR DESCRIPTION
Turns out we filtered redo records using `SCN`, which is the time that the change was made. We should filter using `COMMIT_SCN` instead.

@MrunmayS can you help validate that this fixes the bug?