### PR TITLE
fix: Oracle redo log can have NULL REDO_SQL

### DIFF
--- a/dozer-ingestion/oracle/src/connector/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/mod.rs
@@ -400,6 +400,9 @@ impl Connector {
                     let content = match content {
                         Ok(content) => content,
                         Err(e) => {
+                            if ingestor.is_closed() {
+                                return Ok(());
+                            }
                             error!("Error during log mining: {}. Retrying.", e);
                             break 'replicate_logs;
                         }

--- a/dozer-ingestion/oracle/src/connector/replicate/log_miner/listing.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log_miner/listing.rs
@@ -10,7 +10,7 @@ pub struct LogManagerContent {
     pub operation_code: u8,
     pub seg_owner: Option<String>,
     pub table_name: Option<String>,
-    pub sql_redo: String,
+    pub sql_redo: Option<String>,
 }
 
 impl LogManagerContent {
@@ -25,7 +25,7 @@ impl LogManagerContent {
             u8,
             Option<String>,
             Option<String>,
-            String,
+            Option<String>,
         );
         let rows = if let Some(con_id) = con_id {
             let sql = "SELECT COMMIT_SCN, COMMIT_TIMESTAMP, OPERATION_CODE, SEG_OWNER, TABLE_NAME, SQL_REDO FROM V$LOGMNR_CONTENTS WHERE COMMIT_SCN >= :start_scn AND SRC_CON_ID = :con_id";


### PR DESCRIPTION
Not able to fix the spurious commit bug yet, but found another bug.