### PR TITLE
Reduce disk space usage in CI

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -66,9 +66,6 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         
-      - name: MongoDB in GitHub Actions
-        uses: supercharge/mongodb-github-action@1.8.0
-
       - uses: ./.github/workflows/setup-snowflake-and-kafka
 
       - uses: ./.github/workflows/setup-mysql-and-mariadb
@@ -83,7 +80,7 @@ jobs:
           SN_DRIVER: ${{ secrets.SN_DRIVER }}
         shell: bash
         run: |
-          cargo test test_connector_ --lib --features snowflake,ethereum,kafka,python  --no-fail-fast -- --ignored
+          cargo test -p 'dozer-ingestion-*' --lib --no-fail-fast -- --ignored
 
       - name: Run tests
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ datafusion-physical-plan = { git = "https://github.com/getdozer/arrow-datafusion
 datafusion-sql = { git = "https://github.com/getdozer/arrow-datafusion" }
 datafusion-proto = { git = "https://github.com/getdozer/arrow-datafusion" }
 datafusion-common = { git = "https://github.com/getdozer/arrow-datafusion" }
+
+[profile.dev]
+debug = 0


### PR DESCRIPTION
Disable debuginfo in dev profile and remove MongoDB sidecar container

We can also disable debuginfo with an env var just for CI, but I think the
debuginfo _generally_ does not add too much value for us, and reducing build 
times and target dir size locally is a quite nice side benefit.
The `rust-cache` action already disables incremental compilation on CI, so
no need to also do that manually.
