### PR TITLE
Aerospike sink: Add transactionally consistent denormalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,9 +3403,9 @@ name = "dozer-sink-aerospike"
 version = "0.1.0"
 dependencies = [
  "aerospike-client-sys",
- "crossbeam-channel",
  "dozer-core",
  "dozer-types",
+ "itertools 0.12.1",
 ]
 
 [[package]]
@@ -5174,6 +5174,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,6 +3406,7 @@ dependencies = [
  "dozer-core",
  "dozer-types",
  "itertools 0.12.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -9024,9 +9025,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smartstring"

--- a/dozer-core/src/builder_dag.rs
+++ b/dozer-core/src/builder_dag.rs
@@ -160,21 +160,26 @@ impl BuilderDag {
                         .serialize_state()
                         .await
                         .map_err(ExecutionError::Source)?;
+                    let mut checkpoint = None;
                     for sink in source_id_to_sinks.remove(&node.handle).unwrap_or_default() {
                         let sink = &mut graph[sink];
+                        let sink_handle = &sink.handle;
                         let NodeKind::Sink(sink) = &mut sink.kind else {
                             unreachable!()
                         };
                         sink.set_source_state(&state)
                             .map_err(ExecutionError::Sink)?;
+                        if let Some(sink_checkpoint) = source_op_ids.remove(sink_handle) {
+                            checkpoint =
+                                Some(checkpoint.unwrap_or(sink_checkpoint).min(sink_checkpoint));
+                        }
                     }
 
-                    let last_checkpoint = source_op_ids.remove(&node.handle);
                     NodeType {
                         handle: node.handle,
                         kind: NodeKind::Source {
                             source,
-                            last_checkpoint,
+                            last_checkpoint: checkpoint,
                         },
                     }
                 }

--- a/dozer-core/src/executor/mod.rs
+++ b/dozer-core/src/executor/mod.rs
@@ -95,7 +95,7 @@ impl DagExecutor {
             let Some(node) = execution_dag.graph()[node_index].kind.as_ref() else {
                 continue;
             };
-            match &node {
+            match node {
                 NodeKind::Source { .. } => unreachable!("We already started the source node"),
                 NodeKind::Processor(_) => {
                     let processor_node = ProcessorNode::new(&mut execution_dag, node_index).await;

--- a/dozer-core/src/node.rs
+++ b/dozer-core/src/node.rs
@@ -108,7 +108,7 @@ pub trait SinkFactory: Send + Sync + Debug {
     fn type_name(&self) -> String;
 }
 
-pub trait Sink: Send + Sync + Debug {
+pub trait Sink: Send + Debug {
     fn commit(&mut self, epoch_details: &Epoch) -> Result<(), BoxedError>;
     fn process(&mut self, op: TableOperation) -> Result<(), BoxedError>;
 

--- a/dozer-ingestion/oracle/src/connector/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/mod.rs
@@ -375,17 +375,17 @@ impl Connector {
                 }
             };
 
-            for (table_index, op) in transaction.operations {
+            for (seq, (table_index, op)) in transaction.operations.into_iter().enumerate() {
                 if ingestor
                     .blocking_handle_message(IngestionMessage::OperationEvent {
                         table_index,
                         op,
-                        id: None,
+                        id: Some(OpIdentifier::new(transaction.commit_scn, seq as u64)),
                     })
                     .is_err()
                 {
                     return;
-                }
+                };
             }
 
             if ingestor

--- a/dozer-sink-aerospike/Cargo.toml
+++ b/dozer-sink-aerospike/Cargo.toml
@@ -10,3 +10,4 @@ dozer-core = { path = "../dozer-core" }
 dozer-types = { path = "../dozer-types" }
 aerospike-client-sys = { path = "./aerospike-client-sys" }
 itertools = "0.12"
+smallvec = "1.13.1"

--- a/dozer-sink-aerospike/Cargo.toml
+++ b/dozer-sink-aerospike/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 dozer-core = { path = "../dozer-core" }
 dozer-types = { path = "../dozer-types" }
 aerospike-client-sys = { path = "./aerospike-client-sys" }
-crossbeam-channel = "0.5.11"
+itertools = "0.12"

--- a/dozer-sink-aerospike/aerospike-client-sys/aerospike_client.h
+++ b/dozer-sink-aerospike/aerospike-client-sys/aerospike_client.h
@@ -13,3 +13,4 @@
 #include <aerospike/as_arraylist.h>
 #include <aerospike/as_map.h>
 #include <aerospike/as_orderedmap.h>
+#include <aerospike/as_exp.h>

--- a/dozer-sink-aerospike/aerospike-client-sys/src/lib.rs
+++ b/dozer-sink-aerospike/aerospike-client-sys/src/lib.rs
@@ -4,3 +4,171 @@
 #![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+#[macro_export]
+macro_rules! as_exp_build {
+    ($func:ident $args:tt ) => {{
+        let mut v = Vec::new();
+        $crate::as_exp_build_inner!(v, $func $args);
+        $crate::as_exp_compile(v.as_mut_ptr(), v.len() as u32)
+    }}
+}
+
+#[macro_export]
+macro_rules! as_exp_build_inner {
+    ($v:expr, as_exp_bin_int($bin_name:expr $(,)?)) => {{
+        let bin_name: *const i8 = $bin_name;
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_BIN,
+            count: 3,
+            sz: 0,
+            prev_va_args: 0,
+            v: std::mem::zeroed(),
+        });
+        $crate::as_exp_build_inner!($v, as_exp_int($crate::as_exp_type_AS_EXP_TYPE_INT as i64));
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_VAL_RAWSTR,
+            v: $crate::as_exp_entry__bindgen_ty_1 { str_val: bin_name },
+            count: 0,
+            sz: 0,
+            prev_va_args: 0,
+        });
+    }};
+    ($v:expr, as_exp_int($val:expr)) => {
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_VAL_INT,
+            v: $crate::as_exp_entry__bindgen_ty_1 { int_val: $val },
+            count: 0,
+            sz: 0,
+            prev_va_args: 0,
+        })
+    };
+    ($v:expr, as_exp_uint($val:expr)) => {
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_VAL_UINT,
+            v: $crate::as_exp_entry__bindgen_ty_1 { uint_val: $val },
+            count: 0,
+            sz: 0,
+            prev_va_args: 0,
+        })
+    };
+    ($v:expr, as_exp_cmp_eq($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_EQ,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_cmp_gt($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_GT,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_cmp_ge($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_GE,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left);
+        $crate::as_exp_build_inner!($v, $right);
+    }};
+    ($v:expr, as_exp_cmp_lt($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_LT,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_cmp_le($left_name:ident $left_args:tt, $right_name:ident $right_args:tt $(,)?)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_CMP_LE,
+            count: 3,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $crate::as_exp_build_inner!($v, $left_name $left_args);
+        $crate::as_exp_build_inner!($v, $right_name $right_args);
+    }};
+    ($v:expr, as_exp_and($($arg_name:ident $arg_args:tt),*)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_AND,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $($crate::as_exp_build_inner!($v, $arg_name $arg_args));*;
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_END_OF_VA_ARGS,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+    }};
+($v:expr, as_exp_or($($arg_name:ident $arg_args:tt),*)) => {{
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_OR,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+        $($crate::as_exp_build_inner!($v, $arg_name $arg_args));*;
+        $v.push($crate::as_exp_entry {
+            op: $crate::as_exp_ops__AS_EXP_CODE_END_OF_VA_ARGS,
+            count: 0,
+            v: std::mem::zeroed(),
+            sz: 0,
+            prev_va_args: 0,
+        });
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+
+    use super::*;
+
+    #[test]
+    fn test_as_exp_build() {
+        // Tested that this results in the same compiled expression as when
+        // using the macros from the C library
+        let bin_name = CString::new("bin_name").unwrap();
+        unsafe {
+            let exp = as_exp_build! {
+                as_exp_and(
+                as_exp_cmp_gt(
+                    as_exp_bin_int(bin_name.as_ptr()),
+                    as_exp_int(3)
+                ),
+                as_exp_cmp_lt(
+                    as_exp_bin_int(bin_name.as_ptr()),
+                    as_exp_int(8)
+                )
+                )
+            };
+            assert!(!exp.is_null());
+            as_exp_destroy(exp);
+        }
+    }
+}

--- a/dozer-sink-aerospike/src/aerospike.rs
+++ b/dozer-sink-aerospike/src/aerospike.rs
@@ -48,7 +48,7 @@ impl BinNames {
             .collect()
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn _len(&self) -> usize {
         self.storage.len()
     }
 
@@ -819,7 +819,6 @@ pub(crate) fn parse_record(
             }
         };
         if !field.nullable && v == Field::Null {
-            &field.name;
             return Err(Error::NotNullNotFound);
         }
         values.push(v);

--- a/dozer-sink-aerospike/src/aerospike.rs
+++ b/dozer-sink-aerospike/src/aerospike.rs
@@ -1,0 +1,920 @@
+use std::{
+    alloc::{handle_alloc_error, Layout},
+    ffi::{c_char, c_void, CStr, CString, NulError},
+    mem::MaybeUninit,
+    ptr::{addr_of, NonNull},
+    slice,
+};
+
+use itertools::Itertools;
+
+use aerospike_client_sys::*;
+use dozer_types::{
+    chrono::{DateTime, NaiveDate},
+    geo::{Coord, Point},
+    json_types::{DestructuredJsonRef, JsonValue},
+    ordered_float::OrderedFloat,
+    rust_decimal::prelude::*,
+    thiserror,
+    types::{DozerDuration, DozerPoint, Field, Record, Schema},
+};
+
+use crate::{denorm_dag::Error, AerospikeSinkError};
+
+#[derive(Debug)]
+pub struct BinNames {
+    storage: Vec<CString>,
+    _ptrs: Vec<*mut i8>,
+}
+
+unsafe impl Send for BinNames {}
+
+impl Clone for BinNames {
+    fn clone(&self) -> Self {
+        let storage = self.storage.clone();
+        let ptrs = Self::make_ptrs(&storage);
+        Self {
+            storage,
+            _ptrs: ptrs,
+        }
+    }
+}
+
+impl BinNames {
+    fn make_ptrs(storage: &[CString]) -> Vec<*mut i8> {
+        storage
+            .iter()
+            .map(|name| name.as_ptr() as *mut i8)
+            .collect()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub(crate) unsafe fn _ptrs(&mut self) -> *mut *mut i8 {
+        self._ptrs.as_mut_ptr()
+    }
+
+    pub(crate) fn names(&self) -> &[CString] {
+        &self.storage
+    }
+
+    pub(crate) fn new<I: IntoIterator<Item = impl AsRef<str>>>(names: I) -> Result<Self, NulError> {
+        let storage: Vec<CString> = names
+            .into_iter()
+            .map(|name| CString::new(name.as_ref()))
+            .collect::<Result<_, _>>()?;
+        let ptrs = Self::make_ptrs(&storage);
+        Ok(Self {
+            storage,
+            _ptrs: ptrs,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub struct AerospikeError {
+    pub(crate) code: i32,
+    pub(crate) message: String,
+}
+
+impl AerospikeError {
+    pub(crate) fn from_code(value: as_status) -> Self {
+        let message = unsafe { as_error_string(value) };
+
+        let message = unsafe { CStr::from_ptr(message) };
+        // The message is ASCII (I think?), so this should not fail
+        Self {
+            code: value,
+            message: message.to_str().unwrap().to_owned(),
+        }
+    }
+}
+
+impl From<as_error> for AerospikeError {
+    fn from(value: as_error) -> Self {
+        let code = value.code;
+        let message = unsafe {
+            let message = CStr::from_ptr(value.message.as_ptr());
+            // The message is ASCII (I think?), so this should not fail
+            message.to_str().unwrap()
+        };
+        Self {
+            code,
+            message: message.to_owned(),
+        }
+    }
+}
+
+impl std::fmt::Display for AerospikeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} - {}", self.code, self.message)
+    }
+}
+
+// Client should never be `Clone`, because of the custom Drop impl
+#[derive(Debug)]
+pub struct Client {
+    inner: NonNull<aerospike>,
+}
+
+// The aerospike client API is thread-safe.
+unsafe impl Send for Client {}
+unsafe impl Sync for Client {}
+
+#[inline(always)]
+pub(crate) unsafe fn check_alloc<T>(ptr: *mut T) -> *mut T {
+    if ptr.is_null() {
+        handle_alloc_error(Layout::new::<T>())
+    }
+    ptr
+}
+#[inline(always)]
+unsafe fn as_try(f: impl FnOnce(*mut as_error) -> as_status) -> Result<(), AerospikeError> {
+    let mut err = MaybeUninit::uninit();
+    if f(err.as_mut_ptr()) == as_status_e_AEROSPIKE_OK {
+        Ok(())
+    } else {
+        Err(AerospikeError::from(err.assume_init()))
+    }
+}
+
+impl Client {
+    pub fn new(hosts: &CStr) -> Result<Self, AerospikeError> {
+        let mut config = unsafe {
+            let mut config = MaybeUninit::uninit();
+            as_config_init(config.as_mut_ptr());
+            config.assume_init()
+        };
+        config.policies.batch.base.total_timeout = 10000;
+        unsafe {
+            // The hosts string will be copied, so pass it as `as_ptr` so the original
+            // gets deallocated at the end of this block
+            as_config_add_hosts(&mut config as *mut as_config, hosts.as_ptr(), 3000);
+        }
+        // Allocate a new client instance. Our `Drop` implementation will make
+        // sure it is destroyed
+        let this = unsafe {
+            let inner = aerospike_new(&mut config as *mut as_config);
+            if inner.is_null() {
+                handle_alloc_error(Layout::new::<aerospike>())
+            }
+            let this = Self {
+                inner: NonNull::new_unchecked(inner),
+            };
+            this.connect()?;
+            this
+        };
+        Ok(this)
+    }
+
+    fn connect(&self) -> Result<(), AerospikeError> {
+        unsafe { as_try(|err| aerospike_connect(self.inner.as_ptr(), err)) }
+    }
+
+    unsafe fn put(
+        &self,
+        key: *const as_key,
+        record: *mut as_record,
+        mut policy: as_policy_write,
+        filter: Option<NonNull<as_exp>>,
+    ) -> Result<(), AerospikeError> {
+        if let Some(filter) = filter {
+            policy.base.filter_exp = filter.as_ptr();
+        }
+        as_try(|err| {
+            aerospike_key_put(
+                self.inner.as_ptr(),
+                err,
+                &policy as *const as_policy_write,
+                key,
+                record,
+            )
+        })
+    }
+
+    pub(crate) unsafe fn _insert(
+        &self,
+        key: *const as_key,
+        new: *mut as_record,
+        filter: Option<NonNull<as_exp>>,
+    ) -> Result<(), AerospikeError> {
+        let mut policy = self.inner.as_ref().config.policies.write;
+        policy.exists = as_policy_exists_e_AS_POLICY_EXISTS_CREATE;
+        self.put(key, new, policy, filter)
+    }
+
+    pub(crate) unsafe fn _update(
+        &self,
+        key: *const as_key,
+        new: *mut as_record,
+        filter: Option<NonNull<as_exp>>,
+    ) -> Result<(), AerospikeError> {
+        let mut policy = self.inner.as_ref().config.policies.write;
+        policy.exists = as_policy_exists_e_AS_POLICY_EXISTS_UPDATE;
+        self.put(key, new, policy, filter)
+    }
+
+    pub(crate) unsafe fn upsert(
+        &self,
+        key: *const as_key,
+        new: *mut as_record,
+        filter: Option<NonNull<as_exp>>,
+    ) -> Result<(), AerospikeError> {
+        let mut policy = self.inner.as_ref().config.policies.write;
+        policy.exists = as_policy_exists_e_AS_POLICY_EXISTS_CREATE_OR_REPLACE;
+        self.put(key, new, policy, filter)
+    }
+
+    pub(crate) unsafe fn _delete(
+        &self,
+        key: *const as_key,
+        filter: Option<NonNull<as_exp>>,
+    ) -> Result<(), AerospikeError> {
+        let mut policy = self.inner.as_ref().config.policies.remove;
+        if let Some(filter) = filter {
+            policy.base.filter_exp = filter.as_ptr();
+        }
+        as_try(|err| {
+            aerospike_key_remove(
+                self.inner.as_ptr(),
+                err,
+                &policy as *const as_policy_remove,
+                key,
+            )
+        })
+    }
+
+    pub(crate) unsafe fn write_batch(
+        &self,
+        batch: *mut as_batch_records,
+    ) -> Result<(), AerospikeError> {
+        as_try(|err| aerospike_batch_write(self.inner.as_ptr(), err, std::ptr::null(), batch))
+    }
+
+    pub(crate) unsafe fn _select(
+        &self,
+        key: *const as_key,
+        bins: &[*const c_char],
+        record: &mut *mut as_record,
+    ) -> Result<(), AerospikeError> {
+        as_try(|err| {
+            aerospike_key_select(
+                self.inner.as_ptr(),
+                err,
+                std::ptr::null(),
+                key,
+                // This won't write to the mut ptr
+                bins.as_ptr() as *mut *const c_char,
+                record as *mut *mut as_record,
+            )
+        })
+    }
+    pub(crate) unsafe fn get(
+        &self,
+        key: *const as_key,
+        record: &mut *mut as_record,
+    ) -> Result<(), AerospikeError> {
+        as_try(|err| {
+            aerospike_key_get(
+                self.inner.as_ptr(),
+                err,
+                std::ptr::null(),
+                key,
+                record as *mut *mut as_record,
+            )
+        })
+    }
+
+    pub(crate) unsafe fn batch_get(
+        &self,
+        batch: *mut as_batch_records,
+    ) -> Result<(), AerospikeError> {
+        as_try(|err| aerospike_batch_read(self.inner.as_ptr(), err, std::ptr::null(), batch))
+    }
+
+    /// # Safety
+    /// The caller is responsible for cleaning up the response
+    ///
+    /// This function sends a raw info request to the aerospike server
+    pub unsafe fn info(
+        &self,
+        request: &CStr,
+        response: &mut *mut i8,
+    ) -> Result<(), AerospikeError> {
+        as_try(|err| {
+            aerospike_info_any(
+                self.inner.as_ptr(),
+                err,
+                std::ptr::null(),
+                request.as_ptr(),
+                response as *mut *mut i8,
+            )
+        })
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        unsafe {
+            aerospike_destroy(self.inner.as_ptr());
+        }
+    }
+}
+
+pub(crate) fn convert_json(value: &JsonValue) -> Result<*mut as_bin_value, AerospikeSinkError> {
+    unsafe {
+        Ok(match value.destructure_ref() {
+            // as_nil is a static, so we can't directly create a mutable pointer to it. We cast
+            // through a const pointer instead. This location will never be written to,
+            // because `free = false`
+            DestructuredJsonRef::Null => addr_of!(as_nil) as *mut as_val as *mut as_bin_value,
+            DestructuredJsonRef::Bool(value) => {
+                check_alloc(as_boolean_new(value)) as *mut as_bin_value
+            }
+            DestructuredJsonRef::Number(value) => {
+                if let Some(float) = value.to_f64() {
+                    check_alloc(as_double_new(float)) as *mut as_bin_value
+                } else if let Some(integer) = value.to_i64() {
+                    check_alloc(as_integer_new(integer)) as *mut as_bin_value
+                } else {
+                    // If we can't represent as i64, we have a u64 that's larger than i64::MAX
+                    return Err(AerospikeSinkError::IntegerOutOfRange(
+                        value.to_u64().unwrap(),
+                    ));
+                }
+            }
+            DestructuredJsonRef::String(value) => {
+                let bytes = check_alloc(as_bytes_new(value.len() as u32));
+                as_bytes_set(bytes, 0, value.as_ptr(), value.len() as u32);
+                (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
+                bytes as *mut as_bin_value
+            }
+            DestructuredJsonRef::Array(value) => {
+                let list = check_alloc(as_arraylist_new(value.len() as u32, value.len() as u32));
+                for v in value.iter() {
+                    let as_value = convert_json(v)?;
+                    if as_arraylist_append(list, as_value as *mut as_val)
+                        != as_status_e_AEROSPIKE_OK
+                    {
+                        as_arraylist_destroy(list);
+                        return Err(AerospikeSinkError::CreateRecordError);
+                    }
+                }
+                list as *mut as_bin_value
+            }
+            DestructuredJsonRef::Object(value) => {
+                let map = check_alloc(as_orderedmap_new(value.len() as u32));
+                struct Map(*mut as_orderedmap);
+                impl Drop for Map {
+                    fn drop(&mut self) {
+                        unsafe {
+                            as_orderedmap_destroy(self.0);
+                        }
+                    }
+                }
+                // Make sure the map is deallocated if we encounter any error...
+                let _map_guard = Map(map);
+                for (k, v) in value.iter() {
+                    let as_value = convert_json(v)?;
+                    let key = {
+                        let bytes = check_alloc(as_bytes_new(k.len() as u32));
+                        debug_assert!(as_bytes_set(bytes, 0, k.as_ptr(), k.len() as u32));
+                        (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
+                        bytes as *mut as_val
+                    };
+                    if as_orderedmap_set(map, key, as_value as *mut as_val) != 0 {
+                        return Err(AerospikeSinkError::CreateRecordError);
+                    };
+                }
+                // ...but don't deallocate if we succeed
+                std::mem::forget(_map_guard);
+                map as *mut as_bin_value
+            }
+        })
+    }
+}
+
+#[inline]
+fn set_str_key(
+    key: *mut as_key,
+    namespace: &CStr,
+    set: &CStr,
+    mut string: String,
+    allocated_strings: &mut Vec<String>,
+) {
+    unsafe {
+        let bytes = as_bytes_new_wrap(string.as_mut_ptr(), string.len() as u32, false);
+        (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
+        allocated_strings.push(string);
+        as_key_init_value(
+            key,
+            namespace.as_ptr(),
+            set.as_ptr(),
+            bytes as *const _ as *const as_key_value,
+        );
+    }
+}
+
+pub(crate) unsafe fn init_key(
+    key: *mut as_key,
+    namespace: &CStr,
+    set: &CStr,
+    key_fields: &[Field],
+    allocated_strings: &mut Vec<String>,
+) -> Result<(), AerospikeSinkError> {
+    assert!(!key_fields.is_empty());
+    // Fast option
+    if key_fields.len() == 1 {
+        return init_key_single(key, namespace, set, &key_fields[0], allocated_strings);
+    }
+
+    let key_string = key_fields.iter().join("_");
+    set_str_key(key, namespace, set, key_string, allocated_strings);
+
+    Ok(())
+}
+
+unsafe fn init_key_single(
+    key: *mut as_key,
+    namespace: &CStr,
+    set: &CStr,
+    key_field: &Field,
+    allocated_strings: &mut Vec<String>,
+) -> Result<(), AerospikeSinkError> {
+    unsafe {
+        match key_field {
+            Field::UInt(v) => {
+                as_key_init_int64(key, namespace.as_ptr(), set.as_ptr(), *v as i64);
+            }
+            Field::Int(v) => {
+                as_key_init_int64(key, namespace.as_ptr(), set.as_ptr(), *v);
+            }
+            Field::U128(v) => set_str_key(key, namespace, set, v.to_string(), allocated_strings),
+            Field::I128(v) => set_str_key(key, namespace, set, v.to_string(), allocated_strings),
+            Field::Decimal(v) => set_str_key(key, namespace, set, v.to_string(), allocated_strings),
+            // For keys, we need to allocate a new CString, because there is no
+            // API to set a key to a string that's not null-terminated. For bin
+            // values, we can. XXX: possible point for optimization
+            Field::Text(string) | Field::String(string) => {
+                // Casting to mut is safe. The pointer only needs to be mut so it
+                // can be deallocated if the `free` parameter is true
+                let bytes =
+                    as_bytes_new_wrap(string.as_ptr() as *mut u8, string.len() as u32, false);
+                (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
+                as_key_init_value(
+                    key,
+                    namespace.as_ptr(),
+                    set.as_ptr(),
+                    bytes as *const _ as *const as_key_value,
+                );
+            }
+            Field::Binary(v) => {
+                as_key_init_rawp(
+                    key,
+                    namespace.as_ptr(),
+                    set.as_ptr(),
+                    v.as_ptr(),
+                    v.len() as u32,
+                    false,
+                );
+            }
+
+            Field::Timestamp(v) => {
+                set_str_key(key, namespace, set, v.to_rfc3339(), allocated_strings)
+            }
+            // Date's display implementation is RFC3339 compatible
+            Field::Date(v) => set_str_key(key, namespace, set, v.to_string(), allocated_strings),
+            // We can ignore the time unit, as we always output a
+            // full-resolution duration
+            Field::Duration(DozerDuration(duration, _)) => set_str_key(
+                key,
+                namespace,
+                set,
+                format!("PT{},{:09}S", duration.as_secs(), duration.subsec_nanos()),
+                allocated_strings,
+            ),
+            Field::Null => unreachable!("Primary key cannot be null"),
+            Field::Boolean(_) | Field::Json(_) | Field::Point(_) | Field::Float(_) => {
+                unreachable!("Unsupported primary key type. If this is reached, it means this record does not conform to the schema.")
+            }
+        };
+    }
+    Ok(())
+}
+
+unsafe fn rec_set_str(
+    record: *mut as_record,
+    name: *const c_char,
+    string: String,
+    allocated_strings: &mut Vec<String>,
+) {
+    rec_set_bytes(
+        record,
+        name,
+        string.as_bytes(),
+        as_bytes_type_e_AS_BYTES_STRING,
+    );
+    allocated_strings.push(string);
+}
+
+unsafe fn rec_set_bytes(
+    record: *mut as_record,
+    name: *const c_char,
+    bytes: &[u8],
+    type_: as_bytes_type,
+) {
+    let ptr = bytes.as_ptr();
+    let len = bytes.len();
+    as_record_set_raw_typep(record, name, ptr, len as u32, type_, false);
+}
+
+#[allow(unused)]
+pub(crate) unsafe fn init_record(
+    record: *mut as_record,
+    dozer_record: &Record,
+    bin_names: &[CString],
+    n_extra_cols: u16,
+    allocated_strings: &mut Vec<String>,
+) -> Result<(), AerospikeSinkError> {
+    as_record_init(
+        record,
+        dozer_record.values.len() as u16 + n_extra_cols /* denorm */ + 2, /* tx_id and seq */
+    );
+    for (def, field) in bin_names.iter().zip(&dozer_record.values) {
+        let name = def.as_ptr();
+        match field {
+            Field::UInt(v) => {
+                as_record_set_int64(record, name, *v as i64);
+            }
+            Field::U128(v) => {
+                rec_set_str(record, name, v.to_string(), allocated_strings);
+            }
+            Field::Int(v) => {
+                as_record_set_int64(record, name, *v);
+            }
+            Field::I128(v) => {
+                rec_set_str(record, name, v.to_string(), allocated_strings);
+            }
+            Field::Float(OrderedFloat(v)) => {
+                as_record_set_double(record, name, *v);
+            }
+            Field::Boolean(v) => {
+                as_record_set_bool(record, name, *v);
+            }
+            Field::String(v) | Field::Text(v) => {
+                as_record_set_raw_typep(
+                    record,
+                    name,
+                    v.as_ptr(),
+                    v.len() as u32,
+                    as_bytes_type_e_AS_BYTES_STRING,
+                    false,
+                );
+            }
+            Field::Binary(v) => {
+                as_record_set_rawp(record, name, v.as_ptr(), v.len() as u32, false);
+            }
+            Field::Decimal(v) => {
+                rec_set_str(record, name, v.to_string(), allocated_strings);
+            }
+            Field::Timestamp(v) => {
+                rec_set_str(record, name, v.to_rfc3339(), allocated_strings);
+            }
+            // Date's display implementation is RFC3339 compatible
+            Field::Date(v) => {
+                rec_set_str(record, name, v.to_string(), allocated_strings);
+            }
+            Field::Duration(DozerDuration(duration, _)) => {
+                rec_set_str(
+                    record,
+                    name,
+                    format!("PT{},{:09}S", duration.as_secs(), duration.subsec_nanos()),
+                    allocated_strings,
+                );
+            }
+            Field::Null => {
+                as_record_set_nil(record, name);
+            }
+            // XXX: Geojson points have to have coordinates <90. Dozer points can
+            // be arbitrary locations.
+            Field::Point(DozerPoint(Point(Coord { x, y }))) => {
+                // Using our string-as-bytes trick does not work, as BYTES_GEOJSON is not
+                // a plain string format. Instead, we just make sure we include a nul-byte
+                // in our regular string, as that is easiest to integration with the other
+                // string allocations.
+                let string = format!(
+                    r#"{{"type": "Point", "coordinates": [{}, {}]}}{}"#,
+                    x.0, y.0, '\0'
+                );
+                as_record_set_geojson_strp(record, name, string.as_ptr().cast(), false);
+                allocated_strings.push(string);
+            }
+            Field::Json(v) => {
+                let value = convert_json(v)?;
+                as_record_set(record, name, value);
+            }
+        }
+    }
+    Ok(())
+}
+
+unsafe fn set_operation_str(
+    ops: *mut as_operations,
+    name: *const c_char,
+    mut string: String,
+    allocated_strings: &mut Vec<String>,
+) {
+    let ptr = string.as_mut_ptr();
+    let len = string.len();
+    allocated_strings.push(string);
+    // Unfortunately we need to do an allocation here for the bytes container.
+    // This is because as_operations does not allow setting a bytes type in
+    // its operations api. TODO: Add a raw_typep api like `as_record_set_raw_typep`
+    // for as_operations
+    let bytes = as_bytes_new_wrap(ptr, len as u32, false);
+    (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
+    as_operations_add_write(ops, name, bytes as *mut as_bin_value);
+}
+
+pub(crate) unsafe fn init_batch_write_operations(
+    ops: *mut as_operations,
+    dozer_record: &[Field],
+    bin_names: &[CString],
+    allocated_strings: &mut Vec<String>,
+) -> Result<(), AerospikeSinkError> {
+    for (def, field) in bin_names.iter().zip(dozer_record) {
+        let name = def.as_ptr();
+        // This is almost the same as the implementation for keys,
+        // the key difference being that we don't have to allocate a new
+        // string, because we can use `as_record_set_raw_typep` to set
+        // rust strings directly without intermediate allocations
+        // TODO: Unify the implementations
+        match field {
+            Field::UInt(v) => {
+                as_operations_add_write_int64(ops, name, *v as i64);
+            }
+            Field::U128(v) => {
+                set_operation_str(ops, name, v.to_string(), allocated_strings);
+            }
+            Field::Int(v) => {
+                as_operations_add_write_int64(ops, name, *v);
+            }
+            Field::I128(v) => {
+                set_operation_str(ops, name, v.to_string(), allocated_strings);
+            }
+            Field::Float(v) => {
+                as_operations_add_write_double(ops, name, v.0);
+            }
+            Field::Boolean(v) => {
+                as_operations_add_write_bool(ops, name, *v);
+            }
+            Field::String(string) | Field::Text(string) => {
+                set_operation_str(ops, name, string.to_owned(), allocated_strings);
+            }
+            Field::Binary(v) => {
+                as_operations_add_write_rawp(ops, name, v.as_ptr(), v.len() as u32, false);
+            }
+            Field::Decimal(v) => {
+                set_operation_str(ops, name, v.to_string(), allocated_strings);
+            }
+            Field::Timestamp(v) => {
+                set_operation_str(ops, name, v.to_rfc3339(), allocated_strings);
+            }
+            // Date's display implementation is RFC3339 compatible
+            Field::Date(v) => {
+                set_operation_str(ops, name, v.to_string(), allocated_strings);
+            }
+            Field::Duration(DozerDuration(duration, _)) => {
+                set_operation_str(
+                    ops,
+                    name,
+                    format!("PT{},{:09}S", duration.as_secs(), duration.subsec_nanos()),
+                    allocated_strings,
+                );
+            }
+            Field::Null => {
+                // as_bin_value is a union, with nil being an as_val. It is therefore
+                // valid to just cast a pointer to the as_nil constant (of type as_val),
+                // as its location is static
+                as_operations_add_write(ops, name, addr_of!(as_nil) as *mut as_bin_value);
+            }
+            Field::Point(DozerPoint(Point(Coord { x, y }))) => {
+                // Using our string-as-bytes trick does not work, as BYTES_GEOJSON is not
+                // a plain string format. Instead, we just make sure we include a nul-byte
+                // in our regular string, as that is easiest to integration with the other
+                // string allocations being `String` and not `CString`. We know we whttps://docs.oracle.com/en/database/oracle/oracle-database/19/ladbi/running-oracle-universal-installer-to-install-oracle-database.html#GUID-DD4800E9-C651-4B08-A6AC-E5ECCC6512B9on't
+                // have any intermediate nul-bytes, as we control the string
+                let string = format!(
+                    r#"{{"type": "Point", "coordinates": [{}, {}]}}{}"#,
+                    x.0, y.0, '\0'
+                );
+                as_operations_add_write_geojson_strp(ops, name, string.as_ptr().cast(), false);
+                allocated_strings.push(string);
+            }
+            Field::Json(v) => {
+                as_operations_add_write(ops, name, convert_json(v)?);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[inline(always)]
+fn map<T>(val: *mut as_val, typ: as_val_type_e, f: impl FnOnce(&T) -> Option<Field>) -> Field {
+    as_util_fromval(val, typ)
+        .map(|val| unsafe { val.as_ref() })
+        .and_then(f)
+        .unwrap_or(Field::Null)
+}
+
+pub(crate) fn parse_record(
+    record: &as_record,
+    schema: &Schema,
+    bin_names: &BinNames,
+) -> Result<Vec<Field>, Error> {
+    let record = record as *const as_record;
+    let mut values = Vec::with_capacity(schema.fields.len());
+    for (field, name) in schema.fields.iter().zip(bin_names.names()) {
+        let val = unsafe { as_record_get(record, name.as_ptr()) as *mut as_val };
+        let v = if val.is_null() {
+            Field::Null
+        } else {
+            match field.typ {
+                dozer_types::types::FieldType::UInt => {
+                    map(val, as_val_type_e_AS_INTEGER, |v: &as_integer| {
+                        Some(Field::UInt(v.value.to_u64()?))
+                    })
+                }
+                dozer_types::types::FieldType::U128 => {
+                    map(val, as_val_type_e_AS_STRING, |v: &as_string| {
+                        Some(Field::U128(unsafe {
+                            CStr::from_ptr(v.value).to_str().ok()?.parse().ok()?
+                        }))
+                    })
+                }
+                dozer_types::types::FieldType::Int => {
+                    map(val, as_val_type_e_AS_INTEGER, |v: &as_integer| {
+                        Some(Field::Int(v.value))
+                    })
+                }
+                dozer_types::types::FieldType::I128 => {
+                    map(val, as_val_type_e_AS_STRING, |v: &as_string| {
+                        Some(Field::I128(unsafe {
+                            CStr::from_ptr(v.value).to_str().ok()?.parse().ok()?
+                        }))
+                    })
+                }
+                dozer_types::types::FieldType::Float => {
+                    map(val, as_val_type_e_AS_DOUBLE, |v: &as_double| {
+                        Some(Field::Float(OrderedFloat(v.value)))
+                    })
+                }
+                dozer_types::types::FieldType::Boolean => {
+                    map(val, as_val_type_e_AS_BOOLEAN, |v: &as_boolean| {
+                        Some(Field::Boolean(v.value))
+                    })
+                }
+                dozer_types::types::FieldType::String => {
+                    map(val, as_val_type_e_AS_STRING, |v: &as_string| {
+                        Some(Field::String(
+                            unsafe { CStr::from_ptr(v.value) }.to_str().ok()?.to_owned(),
+                        ))
+                    })
+                }
+                dozer_types::types::FieldType::Text => {
+                    map(val, as_val_type_e_AS_STRING, |v: &as_string| {
+                        Some(Field::Text(
+                            unsafe { CStr::from_ptr(v.value) }.to_str().ok()?.to_owned(),
+                        ))
+                    })
+                }
+                dozer_types::types::FieldType::Binary => {
+                    map(val, as_val_type_e_AS_BYTES, |v: &as_bytes| {
+                        Some(Field::Binary(unsafe {
+                            slice::from_raw_parts(v.value, v.size as usize).to_vec()
+                        }))
+                    })
+                }
+                dozer_types::types::FieldType::Decimal => {
+                    map(val, as_val_type_e_AS_STRING, |v: &as_string| {
+                        Some(Field::Decimal(unsafe {
+                            CStr::from_ptr(v.value).to_str().ok()?.parse().ok()?
+                        }))
+                    })
+                }
+                dozer_types::types::FieldType::Timestamp => {
+                    map(val, as_val_type_e_AS_STRING, |v: &as_string| {
+                        Some(Field::Timestamp(unsafe {
+                            DateTime::parse_from_rfc3339(CStr::from_ptr(v.value).to_str().ok()?)
+                                .ok()?
+                        }))
+                    })
+                }
+
+                dozer_types::types::FieldType::Date => {
+                    map(val, as_val_type_e_AS_STRING, |v: &as_string| {
+                        Some(Field::Date(unsafe {
+                            NaiveDate::from_str(CStr::from_ptr(v.value).to_str().ok()?).ok()?
+                        }))
+                    })
+                }
+                dozer_types::types::FieldType::Point => unimplemented!(),
+                dozer_types::types::FieldType::Duration => unimplemented!(),
+                dozer_types::types::FieldType::Json => unimplemented!(),
+            }
+        };
+        if !field.nullable && v == Field::Null {
+            dbg!(&field.name);
+            return Err(Error::NotNullNotFound);
+        }
+        values.push(v);
+    }
+    Ok(values)
+}
+
+#[inline(always)]
+fn as_util_fromval<T>(v: *mut as_val, typ: as_val_type_e) -> Option<NonNull<T>> {
+    unsafe {
+        let v = NonNull::new(v)?;
+        if v.as_ref().type_ != typ as u8 {
+            return None;
+        }
+        Some(v.cast())
+    }
+}
+
+#[inline(always)]
+unsafe fn as_vector_reserve(vector: *mut as_vector) -> *mut c_void {
+    if (*vector).size >= (*vector).capacity {
+        as_vector_increase_capacity(vector);
+    }
+    let item = (*vector)
+        .list
+        .byte_add((*vector).size as usize * (*vector).item_size as usize);
+    (item as *mut u8).write_bytes(0, (*vector).item_size as usize);
+    (*vector).size += 1;
+    item
+}
+
+#[inline(always)]
+pub(crate) unsafe fn as_vector_get(vector: *const as_vector, index: usize) -> *const c_void {
+    debug_assert!(index < (*vector).size as usize);
+    (*vector)
+        .list
+        .byte_add((*vector).item_size as usize * index)
+}
+
+#[inline(always)]
+pub(crate) unsafe fn as_batch_write_reserve(
+    records: *mut as_batch_records,
+) -> *mut as_batch_write_record {
+    let r = as_vector_reserve(&mut (*records).list as *mut as_vector) as *mut as_batch_write_record;
+    (*r).type_ = AS_BATCH_WRITE as u8;
+    (*r).has_write = true;
+    r
+}
+
+#[inline(always)]
+pub(crate) unsafe fn as_batch_remove_reserve(
+    records: *mut as_batch_records,
+) -> *mut as_batch_remove_record {
+    let r =
+        as_vector_reserve(&mut (*records).list as *mut as_vector) as *mut as_batch_remove_record;
+    (*r).type_ = AS_BATCH_REMOVE as u8;
+    (*r).has_write = true;
+    r
+}
+
+#[inline(always)]
+pub(crate) unsafe fn as_batch_read_reserve(
+    records: *mut as_batch_records,
+) -> *mut as_batch_read_record {
+    let r = as_vector_reserve(&mut (*records).list as *mut as_vector) as *mut as_batch_read_record;
+    (*r).type_ = AS_BATCH_READ as u8;
+    r
+}
+
+#[inline(always)]
+pub(crate) unsafe fn as_batch_records_create(capacity: u32) -> *mut as_batch_records {
+    as_vector_create(std::mem::size_of::<as_batch_record>() as u32, capacity)
+        as *mut as_batch_records
+}
+
+pub(crate) struct AsOperations(*mut as_operations);
+impl AsOperations {
+    pub(crate) fn new(capacity: u16) -> Self {
+        unsafe { Self(check_alloc(as_operations_new(capacity))) }
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut as_operations {
+        self.0
+    }
+}
+
+impl Drop for AsOperations {
+    fn drop(&mut self) {
+        unsafe { as_operations_destroy(self.0) }
+    }
+}

--- a/dozer-sink-aerospike/src/denorm_dag.rs
+++ b/dozer-sink-aerospike/src/denorm_dag.rs
@@ -1,0 +1,867 @@
+use std::collections::HashMap;
+use std::ffi::{CStr, CString, NulError};
+use std::ops::Deref;
+use std::ptr::{addr_of_mut, NonNull};
+
+use aerospike_client_sys::*;
+use dozer_core::daggy::petgraph::Direction;
+use dozer_core::daggy::{self, EdgeIndex, NodeIndex};
+use dozer_core::petgraph::visit::{
+    EdgeRef, IntoEdgesDirected, IntoNeighborsDirected, IntoNodeReferences,
+};
+use dozer_types::indexmap::IndexMap;
+use dozer_types::models::sink::{AerospikeSet, AerospikeSinkTable};
+use dozer_types::thiserror;
+use dozer_types::types::{Field, Record, Schema, TableOperation};
+use itertools::Itertools;
+
+use crate::aerospike::{
+    as_batch_read_reserve, as_batch_records_create, as_batch_remove_reserve,
+    as_batch_write_reserve, as_vector_get, check_alloc, init_batch_write_operations, init_key,
+    parse_record, AerospikeError, AsOperations, BinNames, Client,
+};
+use crate::AerospikeSinkError;
+
+#[derive(Debug, Clone)]
+struct CachedRecord {
+    dirty: bool,
+    record: Option<Vec<Field>>,
+}
+
+impl Deref for CachedRecord {
+    type Target = Option<Vec<Field>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.record
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Node {
+    namespace: CString,
+    set: CString,
+    schema: Schema,
+    batch: IndexMap<Vec<Field>, CachedRecord>,
+    bins: BinNames,
+    denormalize_to: Option<(CString, CString)>,
+}
+
+impl Node {
+    fn insert(&mut self, key: Vec<Field>, value: Option<Vec<Field>>) -> usize {
+        self.batch
+            .insert_full(
+                key,
+                CachedRecord {
+                    dirty: true,
+                    record: value,
+                },
+            )
+            .0
+    }
+
+    fn get_index_or_insert(&mut self, key: Vec<Field>, value: Option<Vec<Field>>) -> usize {
+        let entry = self.batch.entry(key);
+        let index = entry.index();
+        entry.or_insert(CachedRecord {
+            dirty: true,
+            record: value,
+        });
+        index
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Edge {
+    bins: BinNames,
+    key_fields: Vec<usize>,
+    keys: HashMap<usize, Vec<Field>>,
+    field_indices: Vec<usize>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Duplicate sink set definition: {namespace}.{set}")]
+    DuplicateSinkTable { namespace: String, set: String },
+    #[error("Set referenced in denormalization not found: {namespace}.{set}")]
+    SetNotFound { namespace: String, set: String },
+    #[error("Adding denormalizing lookup on set {namespace}.{set} from set {from_namespace}.{from_set} would create a cycle")]
+    Cycle {
+        namespace: String,
+        set: String,
+        from_namespace: String,
+        from_set: String,
+    },
+    #[error("Field not found")]
+    FieldNotFound(String),
+    #[error("Invalid name")]
+    InvalidName(#[from] NulError),
+    #[error("Non-nullible lookup value not found")]
+    NotNullNotFound,
+}
+
+#[derive(Debug)]
+pub(crate) struct DenormalizationState {
+    layers: Vec<Vec<NodeIndex>>,
+    dag: DenormDag,
+    current_transaction: Option<u64>,
+    base_tables: Vec<(NodeIndex, Vec<CString>)>,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct DenormalizedTable {
+    pub(crate) bin_names: Vec<CString>,
+    pub(crate) namespace: CString,
+    pub(crate) set: CString,
+    pub(crate) records: Vec<(Vec<Field>, Vec<Field>)>,
+}
+type DenormDag = daggy::Dag<Node, Edge>;
+
+fn bin_names_recursive(dag: &DenormDag, nid: NodeIndex, bins: &mut Vec<CString>) {
+    let mut neighbors = dag.neighbors_directed(nid, Direction::Outgoing).detach();
+    while let Some((edge, node)) = neighbors.next(dag.graph()) {
+        let edge = dag.edge_weight(edge).unwrap();
+        bins.extend_from_slice(edge.bins.names());
+        bin_names_recursive(dag, node, bins);
+    }
+}
+
+impl DenormalizationState {
+    pub(crate) fn new(tables: &[(AerospikeSinkTable, Schema)]) -> Result<Self, Error> {
+        assert!(!tables.is_empty());
+        let dag = Self::build_dag(tables)?;
+        let layers = Self::build_layers(dag.clone())?;
+        let base_tables: Vec<_> = dag
+            .node_references()
+            // Filter out non-base-tables
+            .filter_map(|(i, node)| node.denormalize_to.is_some().then_some(i))
+            // Find all added bin names using a depth-first search
+            .map(|id| {
+                let mut bin_names = dag.node_weight(id).unwrap().bins.names().to_vec();
+                bin_names_recursive(&dag, id, &mut bin_names);
+                (id, bin_names)
+            })
+            .collect();
+        Ok(Self {
+            layers,
+            dag,
+            current_transaction: None,
+            base_tables,
+        })
+    }
+
+    fn build_dag(tables: &[(AerospikeSinkTable, Schema)]) -> Result<DenormDag, Error> {
+        let mut dag: daggy::Dag<Node, Edge> = daggy::Dag::new();
+        let mut node_by_name = HashMap::new();
+        for (table, schema) in tables.iter() {
+            let bin_names = BinNames::new(schema.fields.iter().map(|field| &field.name))?;
+            let denormalize_to = table
+                .write_denormalized_to
+                .as_ref()
+                .map(|to| -> Result<_, Error> {
+                    let AerospikeSet { namespace, set } = to;
+                    Ok((
+                        CString::new(namespace.as_str())?,
+                        CString::new(set.as_str())?,
+                    ))
+                })
+                .transpose()?;
+            let idx = dag.add_node(Node {
+                namespace: CString::new(table.namespace.as_str())?,
+                set: CString::new(table.set_name.as_str())?,
+                schema: schema.clone(),
+                batch: IndexMap::new(),
+                bins: bin_names,
+                denormalize_to,
+            });
+
+            if node_by_name
+                .insert((table.namespace.clone(), table.set_name.clone()), idx)
+                .is_some()
+            {
+                return Err(Error::DuplicateSinkTable {
+                    namespace: table.namespace.clone(),
+                    set: table.set_name.clone(),
+                });
+            }
+        }
+        for (table, schema) in tables {
+            let to_idx = node_by_name[&(table.namespace.clone(), table.set_name.clone())];
+            for denorm in &table.denormalize {
+                let from_idx = node_by_name
+                    .get(&(denorm.from_namespace.clone(), denorm.from_set.clone()))
+                    .copied()
+                    .ok_or_else(|| Error::SetNotFound {
+                        namespace: denorm.from_namespace.clone(),
+                        set: denorm.from_set.clone(),
+                    })?;
+
+                let from_schema = &dag.node_weight(from_idx).unwrap().schema;
+                let key_idx = match &denorm.key {
+                    dozer_types::models::sink::DenormKey::Simple(name) => {
+                        vec![
+                            schema
+                                .get_field_index(name)
+                                .map_err(|_| Error::FieldNotFound(name.to_owned()))?
+                                .0,
+                        ]
+                    }
+                    dozer_types::models::sink::DenormKey::Composite(names) => names
+                        .iter()
+                        .map(|name| {
+                            schema
+                                .get_field_index(name)
+                                .map(|(i, _)| i)
+                                .map_err(|_| Error::FieldNotFound(name.to_owned()))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                };
+
+                let bin_names = BinNames::new(denorm.columns.iter().map(|col| {
+                    let (_, dst) = col.to_src_dst();
+                    dst
+                }))?;
+
+                let bin_indices: Vec<_> = denorm
+                    .columns
+                    .iter()
+                    .map(|col| -> Result<_, Error> {
+                        let (src, _) = col.to_src_dst();
+                        let (id, _) = from_schema
+                            .get_field_index(src)
+                            .map_err(|_| Error::FieldNotFound(src.to_owned()))?;
+                        Ok(id)
+                    })
+                    .try_collect()?;
+
+                dag.add_edge(
+                    to_idx,
+                    from_idx,
+                    Edge {
+                        key_fields: key_idx,
+                        bins: bin_names,
+                        keys: HashMap::new(),
+                        field_indices: bin_indices,
+                    },
+                )
+                .map_err(|_| Error::Cycle {
+                    namespace: table.namespace.clone(),
+                    set: table.set_name.clone(),
+                    from_namespace: denorm.from_namespace.clone(),
+                    from_set: denorm.from_set.clone(),
+                })?;
+            }
+        }
+
+        Ok(dag)
+    }
+
+    fn build_layers(mut dag: DenormDag) -> Result<Vec<Vec<NodeIndex>>, Error> {
+        let mut layers = Vec::new();
+
+        while dag.node_count() > 0 {
+            // Find all the nodes without incoming edges
+            let roots: Vec<_> = dag
+                .graph()
+                .node_indices()
+                .filter(|index| {
+                    dag.edges_directed(*index, Direction::Incoming)
+                        .next()
+                        .is_none()
+                })
+                .collect();
+            for root in &roots {
+                dag.remove_node(*root);
+            }
+            layers.push(roots);
+        }
+
+        Ok(layers)
+    }
+}
+
+pub(crate) struct RecordBatch {
+    inner: NonNull<as_batch_records>,
+    allocated_strings: Vec<String>,
+    operations: Vec<AsOperations>,
+}
+
+impl RecordBatch {
+    pub(crate) fn new(capacity: u32, n_strings_estimate: u32) -> Self {
+        let ptr = unsafe { NonNull::new(as_batch_records_create(capacity)).unwrap() };
+        Self {
+            inner: ptr,
+            allocated_strings: Vec::with_capacity(n_strings_estimate as usize),
+            operations: Vec::with_capacity(capacity as usize),
+        }
+    }
+
+    pub(crate) unsafe fn as_mut_ptr(&mut self) -> *mut as_batch_records {
+        self.inner.as_ptr()
+    }
+
+    pub(crate) unsafe fn inner(&self) -> &as_batch_records {
+        self.inner.as_ref()
+    }
+
+    pub(crate) fn reserve_read(&mut self) -> *mut as_batch_read_record {
+        unsafe { check_alloc(as_batch_read_reserve(self.as_mut_ptr())) }
+    }
+
+    pub(crate) fn reserve_write(&mut self) -> *mut as_batch_write_record {
+        unsafe { check_alloc(as_batch_write_reserve(self.as_mut_ptr())) }
+    }
+
+    pub(crate) fn reserve_remove(&mut self) -> *mut as_batch_remove_record {
+        unsafe { check_alloc(as_batch_remove_reserve(self.as_mut_ptr())) }
+    }
+
+    pub(crate) fn add_write(
+        &mut self,
+        namespace: &CStr,
+        set: &CStr,
+        bin_names: &[CString],
+        key: &[Field],
+        values: &[Field],
+    ) -> Result<(), AerospikeSinkError> {
+        let write_rec = self.reserve_write();
+        unsafe {
+            init_key(
+                addr_of_mut!((*write_rec).key),
+                namespace,
+                set,
+                key,
+                &mut self.allocated_strings,
+            )?;
+            let mut ops = AsOperations::new(values.len().try_into().unwrap());
+            init_batch_write_operations(
+                ops.as_mut_ptr(),
+                values,
+                bin_names,
+                &mut self.allocated_strings,
+            )?;
+            (*write_rec).ops = ops.as_mut_ptr();
+            self.operations.push(ops);
+        }
+        Ok(())
+    }
+
+    fn add_remove(
+        &mut self,
+        namespace: &CStr,
+        set: &CStr,
+        key: &[Field],
+    ) -> Result<(), AerospikeSinkError> {
+        let remove_rec = self.reserve_remove();
+        unsafe {
+            init_key(
+                addr_of_mut!((*remove_rec).key),
+                namespace,
+                set,
+                key,
+                &mut self.allocated_strings,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn add_read_all(
+        &mut self,
+        namespace: &CStr,
+        set: &CStr,
+        key: &[Field],
+    ) -> Result<(), AerospikeSinkError> {
+        let remove_rec = self.reserve_read();
+        unsafe {
+            init_key(
+                addr_of_mut!((*remove_rec).key),
+                namespace,
+                set,
+                key,
+                &mut self.allocated_strings,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RecordBatch {
+    fn drop(&mut self) {
+        unsafe { as_batch_records_destroy(self.inner.as_ptr()) }
+    }
+}
+
+impl DenormalizationState {
+    fn do_insert(&mut self, node_id: NodeIndex, new: Record) {
+        let node = self.dag.node_weight_mut(node_id).unwrap();
+        let idx = new.get_key_fields(&node.schema);
+
+        let batch_idx = node.insert(idx, Some(new.values.clone()));
+        // Queue a lookup for all the outgoing edges
+        let mut edges = self
+            .dag
+            .neighbors_directed(node_id, Direction::Outgoing)
+            .detach();
+        while let Some(edge) = edges.next_edge(self.dag.graph()) {
+            let edge_weight = self.dag.edge_weight_mut(edge).unwrap();
+            let key = edge_weight
+                .key_fields
+                .iter()
+                .map(|i| new.values[*i].clone())
+                .collect();
+            edge_weight.keys.insert(batch_idx, key);
+        }
+    }
+
+    pub(crate) fn process(&mut self, op: TableOperation) -> Result<(), AerospikeSinkError> {
+        self.current_transaction = op.id.map(|id| id.txid);
+        let node_id: NodeIndex = (op.port as u32).into();
+        match op.op {
+            dozer_types::types::Operation::Delete { old } => {
+                let node = self.dag.node_weight_mut(node_id).unwrap();
+                let schema = &node.schema;
+                let idx = old.get_key_fields(schema);
+                node.insert(idx, None);
+            }
+            dozer_types::types::Operation::Insert { new } => {
+                self.do_insert(node_id, new);
+            }
+            dozer_types::types::Operation::Update { old, new } => {
+                let node = self.dag.node_weight_mut(node_id).unwrap();
+                let schema = &node.schema;
+                let old_pk = old.get_key_fields(schema);
+                let new_pk = new.get_key_fields(schema);
+                if old_pk != new_pk {
+                    return Err(AerospikeSinkError::PrimaryKeyChanged {
+                        old: old_pk.clone(),
+                        new: new_pk.clone(),
+                    });
+                }
+                node.insert(new_pk, Some(new.values));
+            }
+            dozer_types::types::Operation::BatchInsert { new } => {
+                for value in new {
+                    self.do_insert(node_id, value);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn build_read_batch(&self, layer: &[NodeIndex]) -> Result<RecordBatch, AerospikeSinkError> {
+        let batch_size: u32 = layer
+            .iter()
+            .flat_map(|node| self.dag.edges_directed(*node, Direction::Incoming))
+            .map(|edge| edge.weight().keys.len())
+            .sum::<usize>()
+            .try_into()
+            .unwrap();
+        let mut batch = RecordBatch::new(batch_size, batch_size);
+
+        for node_id in layer {
+            let node = self.dag.node_weight(*node_id).unwrap();
+            for input in self.dag.edges_directed(*node_id, Direction::Incoming) {
+                let edge = self.dag.edge_weight(input.id()).unwrap();
+                for key in edge.keys.values() {
+                    batch.add_read_all(&node.namespace, &node.set, key)?;
+                }
+            }
+        }
+        Ok(batch)
+    }
+
+    pub(crate) fn persist(&mut self, client: &Client) -> Result<(), AerospikeSinkError> {
+        let batch_size_upper_bound: usize = self
+            .dag
+            .node_references()
+            .map(|(_, node)| node.batch.len())
+            .sum();
+
+        let batch_size: u32 = batch_size_upper_bound.try_into().unwrap();
+        let mut write_batch = RecordBatch::new(batch_size, batch_size);
+
+        for node in self.dag.node_weights_mut() {
+            for (key, dirty_record) in node
+                .batch
+                .drain(..)
+                .filter_map(|(i, rec)| rec.dirty.then_some((i, rec.record)))
+            {
+                if let Some(dirty_record) = dirty_record {
+                    write_batch.add_write(
+                        &node.namespace,
+                        &node.set,
+                        node.bins.names(),
+                        &key,
+                        &dirty_record,
+                    )?;
+                } else {
+                    write_batch.add_remove(&node.namespace, &node.set, &key)?;
+                }
+            }
+        }
+        for edge in self.dag.edge_weights_mut() {
+            edge.keys.clear();
+        }
+        unsafe {
+            client.write_batch(write_batch.as_mut_ptr())?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn perform_denorm(
+        &mut self,
+        client: &Client,
+    ) -> Result<Vec<DenormalizedTable>, AerospikeSinkError> {
+        for layer in &self.layers {
+            let mut batch = self.build_read_batch(layer)?;
+            unsafe {
+                client.batch_get(batch.as_mut_ptr())?;
+            }
+            let mut idx = 0;
+            // Do the get and update the cache
+            let record_list = unsafe { &batch.inner().list };
+            for node_id in layer {
+                let mut edges = self
+                    .dag
+                    .neighbors_directed(*node_id, Direction::Incoming)
+                    .detach();
+                while let Some(input) = edges.next_edge(self.dag.graph()) {
+                    let keys = &self.dag.edge_weight(input).unwrap().keys;
+                    let mut vals = Vec::with_capacity(keys.len());
+                    for key in keys.values() {
+                        unsafe {
+                            debug_assert!(idx < record_list.size as usize);
+                            let record = as_vector_get(record_list as *const as_vector, idx)
+                                as *const as_batch_read_record;
+                            let result = (*record).result;
+                            let node = self.dag.node_weight(*node_id).unwrap();
+                            if result == as_status_e_AEROSPIKE_ERR_RECORD_NOT_FOUND {
+                                vals.push((key.clone(), None));
+                            } else if result == as_status_e_AEROSPIKE_OK {
+                                vals.push((
+                                    key.clone(),
+                                    Some(parse_record(
+                                        &(*record).record,
+                                        &node.schema,
+                                        &node.bins,
+                                    )?),
+                                ));
+                            } else {
+                                return Err(AerospikeError::from_code(result).into());
+                            }
+                            idx += 1;
+                        }
+                    }
+                    for (key, val) in vals {
+                        self.dag
+                            .node_weight_mut(*node_id)
+                            .unwrap()
+                            .get_index_or_insert(key, val);
+                    }
+                }
+                // Update the outgoing edges with the keys from this layer
+                let mut edges = self
+                    .dag
+                    .neighbors_directed(*node_id, Direction::Outgoing)
+                    .detach();
+                while let Some(edge_id) = edges.next_edge(self.dag.graph()) {
+                    let node = self.dag.node_weight(*node_id).unwrap();
+                    let edge = self.dag.edge_weight(edge_id).unwrap();
+                    let mut keys_to_add = Vec::with_capacity(node.batch.len());
+                    for (i, v) in node.batch.values().enumerate() {
+                        if let Some(v) = &v.record {
+                            let key_values =
+                                edge.key_fields.iter().map(|i| v[*i].clone()).collect();
+                            keys_to_add.push((i, key_values))
+                        }
+                    }
+                    self.dag
+                        .edge_weight_mut(edge_id)
+                        .unwrap()
+                        .keys
+                        .extend(keys_to_add);
+                }
+            }
+        }
+
+        let mut ret = Vec::new();
+        // Run through the graph again, now that all the data is in the caches
+        for (nid, bin_names) in self.base_tables.iter().cloned() {
+            let mut node_batch = self.dag.node_weight(nid).unwrap().batch.clone();
+            for (primary_table_index, primary_table_fields) in node_batch
+                .values_mut()
+                .flat_map(|v| &mut v.record)
+                .enumerate()
+            {
+                for edge in self.dag.edges_directed(nid, Direction::Outgoing) {
+                    self.recurse_dag_lookup(
+                        primary_table_fields,
+                        edge.id(),
+                        primary_table_index,
+                        false,
+                    );
+                }
+            }
+            let node = self.dag.node_weight(nid).unwrap();
+            let (namespace, set) = node.denormalize_to.clone().unwrap();
+            let table = DenormalizedTable {
+                namespace,
+                set,
+                bin_names,
+                records: node_batch
+                    .into_iter()
+                    .filter_map(|(key, rec)| rec.dirty.then_some((key, rec.record?)))
+                    .collect(),
+            };
+            ret.push(table);
+        }
+
+        Ok(ret)
+    }
+
+    fn recurse_dag_lookup(
+        &self,
+        primary_table_fields: &mut Vec<Field>,
+        edge_id: EdgeIndex,
+        base_id: usize,
+        mut fill_null: bool,
+    ) {
+        let edge = self.dag.edge_weight(edge_id).unwrap();
+        let tgt_id = self.dag.edge_endpoints(edge_id).unwrap().1;
+        let tgt = self.dag.node_weight(tgt_id).unwrap();
+        let key = &edge.keys[&base_id];
+        let (tgt_table_index, _tgt_key, tgt_values) = tgt.batch.get_full(key).unwrap();
+        if let (Some(lookup_fields), false) = (tgt_values.deref(), fill_null) {
+            primary_table_fields
+                .extend(edge.field_indices.iter().map(|i| lookup_fields[*i].clone()))
+        } else {
+            fill_null = true;
+            primary_table_fields.extend(std::iter::repeat(Field::Null).take(edge.bins.len()));
+        }
+
+        for new_edge in self.dag.edges_directed(tgt_id, Direction::Outgoing) {
+            self.recurse_dag_lookup(
+                primary_table_fields,
+                new_edge.id(),
+                tgt_table_index,
+                fill_null,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+
+    use dozer_types::{
+        models::sink::{
+            AerospikeDenormalizations, AerospikeSet, AerospikeSinkTable, DenormColumn, DenormKey,
+        },
+        rust_decimal::Decimal,
+        types::{
+            Field, FieldDefinition, FieldType, Operation, Record, Schema, SourceDefinition,
+            TableOperation,
+        },
+    };
+
+    use crate::{aerospike::Client, denorm_dag::DenormalizedTable};
+
+    use super::DenormalizationState;
+
+    #[test]
+    fn test_name() {
+        let mut customer_schema = Schema::new();
+        customer_schema
+            .field(
+                FieldDefinition::new(
+                    "id".into(),
+                    FieldType::String,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                true,
+            )
+            .field(
+                FieldDefinition::new(
+                    "phone_number".into(),
+                    FieldType::String,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            );
+
+        let mut account_schema = Schema::new();
+        account_schema
+            .field(
+                FieldDefinition::new(
+                    "id".into(),
+                    FieldType::UInt,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                true,
+            )
+            .field(
+                FieldDefinition::new(
+                    "customer_id".into(),
+                    FieldType::String,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .field(
+                FieldDefinition::new(
+                    "transaction_limit".into(),
+                    FieldType::UInt,
+                    true,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            );
+        let mut transaction_schema = Schema::new();
+        transaction_schema
+            .field(
+                FieldDefinition::new(
+                    "id".into(),
+                    FieldType::UInt,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                true,
+            )
+            .field(
+                FieldDefinition::new(
+                    "account_id".into(),
+                    FieldType::UInt,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            )
+            .field(
+                FieldDefinition::new(
+                    "amount".into(),
+                    FieldType::Decimal,
+                    false,
+                    SourceDefinition::Dynamic,
+                ),
+                false,
+            );
+
+        let tables = vec![
+            (
+                AerospikeSinkTable {
+                    source_table_name: "".into(),
+                    namespace: "test".into(),
+                    set_name: "customers".into(),
+                    denormalize: vec![],
+                    write_denormalized_to: None,
+                },
+                customer_schema,
+            ),
+            (
+                AerospikeSinkTable {
+                    source_table_name: "".into(),
+                    namespace: "test".into(),
+                    set_name: "accounts".into(),
+                    denormalize: vec![AerospikeDenormalizations {
+                        from_namespace: "test".into(),
+                        from_set: "customers".into(),
+                        key: DenormKey::Simple("customer_id".into()),
+                        columns: vec![DenormColumn::Direct("phone_number".into())],
+                    }],
+                    write_denormalized_to: None,
+                },
+                account_schema,
+            ),
+            (
+                AerospikeSinkTable {
+                    source_table_name: "".into(),
+                    namespace: "test".into(),
+                    set_name: "transactions".into(),
+                    denormalize: vec![AerospikeDenormalizations {
+                        from_namespace: "test".into(),
+                        from_set: "accounts".into(),
+                        key: DenormKey::Simple("account_id".into()),
+                        columns: vec![DenormColumn::Direct("transaction_limit".into())],
+                    }],
+                    write_denormalized_to: Some(AerospikeSet {
+                        namespace: "test".into(),
+                        set: "transactions_denorm".into(),
+                    }),
+                },
+                transaction_schema,
+            ),
+        ];
+        let mut state = DenormalizationState::new(&tables).unwrap();
+        // Customers
+        state
+            .process(TableOperation {
+                id: None,
+                op: Operation::Insert {
+                    new: dozer_types::types::Record::new(vec![
+                        Field::String("1001".into()),
+                        Field::String("+1234567".into()),
+                    ]),
+                },
+                port: 0,
+            })
+            .unwrap();
+        // Accounts
+        state
+            .process(TableOperation {
+                id: None,
+                op: Operation::Insert {
+                    new: dozer_types::types::Record::new(vec![
+                        Field::UInt(101),
+                        Field::String("1001".into()),
+                        Field::Null,
+                    ]),
+                },
+                port: 1,
+            })
+            .unwrap();
+        // Transactions
+        state
+            .process(TableOperation {
+                id: None,
+                op: Operation::Insert {
+                    new: Record::new(vec![
+                        Field::UInt(1),
+                        Field::UInt(101),
+                        Field::Decimal(Decimal::new(123, 2)),
+                    ]),
+                },
+                port: 2,
+            })
+            .unwrap();
+        let client = Client::new(&CString::new("localhost:3000").unwrap()).unwrap();
+        let res = state.perform_denorm(&client).unwrap();
+        assert_eq!(
+            res,
+            vec![DenormalizedTable {
+                bin_names: vec![
+                    CString::new("id").unwrap(),
+                    CString::new("account_id").unwrap(),
+                    CString::new("amount").unwrap(),
+                    CString::new("transaction_limit").unwrap(),
+                    CString::new("phone_number").unwrap(),
+                ],
+                records: vec![(
+                    vec![Field::UInt(1)],
+                    vec![
+                        Field::UInt(1),
+                        Field::UInt(101),
+                        Field::Decimal(Decimal::new(123, 2)),
+                        Field::Null,
+                        Field::String("+1234567".into())
+                    ]
+                )],
+                namespace: CString::new("test").unwrap(),
+                set: CString::new("transactions_denorm").unwrap()
+            }]
+        );
+    }
+}

--- a/dozer-sink-aerospike/src/lib.rs
+++ b/dozer-sink-aerospike/src/lib.rs
@@ -294,6 +294,10 @@ impl AerospikeMetadata {
                 }) => (None, None),
                 Err(e) => return Err(e),
             };
+            // Not found, so allocate a new record
+            if record.is_null() {
+                record = as_record_new(2);
+            }
             Ok(Self {
                 client,
                 key,

--- a/dozer-sink-aerospike/src/lib.rs
+++ b/dozer-sink-aerospike/src/lib.rs
@@ -1,63 +1,57 @@
-use crossbeam_channel::{bounded, Receiver, Sender};
-use dozer_core::event::EventHub;
-use dozer_types::json_types::{DestructuredJsonRef, JsonValue};
-use dozer_types::models::connection::AerospikeConnection;
-use dozer_types::models::sink::DenormColumn;
-use dozer_types::node::OpIdentifier;
-use std::alloc::{handle_alloc_error, Layout};
-use std::ffi::{c_char, c_void, CStr, CString, NulError};
-use std::fmt::Display;
-use std::mem::{self, MaybeUninit};
-use std::num::NonZeroUsize;
-use std::ptr::{addr_of, null, NonNull};
-use std::sync::Arc;
-use std::thread::available_parallelism;
-use std::time::{Duration, Instant};
-use std::{collections::HashMap, fmt::Debug};
+pub use crate::aerospike::Client;
 
-use aerospike_client_sys::{
-    aerospike, aerospike_batch_write, aerospike_connect, aerospike_destroy, aerospike_info_any,
-    aerospike_key_put, aerospike_key_remove, aerospike_key_select, aerospike_new,
-    as_arraylist_append, as_arraylist_destroy, as_arraylist_new, as_batch_record, as_batch_records,
-    as_batch_records_destroy, as_batch_write_record, as_bin_value, as_boolean_new, as_bytes_new,
-    as_bytes_new_wrap, as_bytes_set, as_bytes_type, as_bytes_type_e_AS_BYTES_STRING, as_config,
-    as_config_add_hosts, as_config_init, as_double_new, as_error, as_integer_new, as_key,
-    as_key_destroy, as_key_init_int64, as_key_init_rawp, as_key_init_value, as_key_value, as_nil,
-    as_operations, as_operations_add_write, as_operations_add_write_bool,
-    as_operations_add_write_double, as_operations_add_write_geojson_strp,
-    as_operations_add_write_int64, as_operations_add_write_rawp, as_operations_destroy,
-    as_operations_init, as_orderedmap, as_orderedmap_destroy, as_orderedmap_new, as_orderedmap_set,
-    as_policy_batch, as_policy_exists_e_AS_POLICY_EXISTS_CREATE,
-    as_policy_exists_e_AS_POLICY_EXISTS_UPDATE, as_policy_remove, as_policy_write, as_record,
-    as_record_destroy, as_record_get, as_record_init, as_record_set, as_record_set_bool,
-    as_record_set_double, as_record_set_geojson_strp, as_record_set_int64, as_record_set_nil,
-    as_record_set_raw_typep, as_record_set_rawp, as_status,
-    as_status_e_AEROSPIKE_ERR_RECORD_NOT_FOUND, as_status_e_AEROSPIKE_OK, as_val,
-    as_val_val_reserve, as_vector, as_vector_increase_capacity, as_vector_init, AS_BATCH_WRITE,
-    AS_BIN_NAME_MAX_LEN,
-};
+use aerospike_client_sys::*;
+use denorm_dag::DenormalizationState;
+use dozer_core::event::EventHub;
+use dozer_types::log::error;
+use dozer_types::models::connection::AerospikeConnection;
+use dozer_types::node::OpIdentifier;
+use dozer_types::thiserror;
+
+use std::collections::HashMap;
+use std::ffi::{CStr, CString, NulError};
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use crate::aerospike::AerospikeError;
+use crate::denorm_dag::RecordBatch;
+
+mod aerospike;
+mod denorm_dag;
 
 use dozer_core::node::{PortHandle, Sink, SinkFactory};
+
 use dozer_types::errors::internal::BoxedError;
-use dozer_types::geo::{Coord, Point};
-use dozer_types::ordered_float::OrderedFloat;
 use dozer_types::tonic::async_trait;
 use dozer_types::{
     errors::types::TypeError,
-    log::{error, info, warn},
+    log::warn,
     models::sink::AerospikeSinkConfig,
-    thiserror::{self, Error},
-    types::{
-        DozerDuration, DozerPoint, Field, FieldType, Operation, Record, Schema, TableOperation,
-    },
+    types::{Field, FieldType, Schema, TableOperation},
 };
 
-#[derive(Error, Debug)]
+mod constants {
+    use std::ffi::CStr;
+
+    // TODO: Replace with cstring literals when they're stablized,
+    // currently planned for Rust 1.77
+    const fn cstr(value: &'static [u8]) -> &'static CStr {
+        // Check that the supplied value is valid (ends with nul byte)
+        assert!(CStr::from_bytes_with_nul(value).is_ok());
+        // Do the conversion again
+        unsafe { CStr::from_bytes_with_nul_unchecked(value) }
+    }
+
+    pub(super) const META_KEY: &CStr = cstr(b"metadata\0");
+    pub(super) const META_BASE_TXN_ID_BIN: &CStr = cstr(b"txn_id\0");
+    pub(super) const META_LOOKUP_TXN_ID_BIN: &CStr = cstr(b"txn_id\0");
+}
+
+#[derive(thiserror::Error, Debug)]
 enum AerospikeSinkError {
-    #[error("Aerospike client error: {} - {}", .0.code, .0.message)]
+    #[error("Aerospike client error: {0}")]
     Aerospike(#[from] AerospikeError),
-    #[error("Aerospike does not support composite primary keys")]
-    CompositePrimaryKey,
     #[error("No primary key found. Aerospike requires records to have a primary key")]
     NoPrimaryKey,
     #[error("Unsupported type for primary key: {0}")]
@@ -72,194 +66,10 @@ enum AerospikeSinkError {
     BinNameTooLong(String),
     #[error("Integer out of range. The supplied usigned integer was larger than the maximum representable value for an aerospike integer")]
     IntegerOutOfRange(u64),
-}
-
-#[derive(Debug, Error)]
-pub struct AerospikeError {
-    code: i32,
-    message: String,
-}
-
-impl From<as_error> for AerospikeError {
-    fn from(value: as_error) -> Self {
-        let code = value.code;
-        let message = unsafe {
-            let message = CStr::from_ptr(value.message.as_ptr());
-            // The message is ASCII (I think?), so this should not fail
-            message.to_str().unwrap()
-        };
-        Self {
-            code,
-            message: message.to_owned(),
-        }
-    }
-}
-
-impl Display for AerospikeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} - {}", self.code, self.message)
-    }
-}
-
-// Client should never be `Clone`, because of the custom Drop impl
-#[derive(Debug)]
-pub struct Client {
-    inner: NonNull<aerospike>,
-}
-
-// The aerospike client API is thread-safe.
-unsafe impl Send for Client {}
-unsafe impl Sync for Client {}
-
-#[inline(always)]
-unsafe fn check_alloc<T>(ptr: *mut T) -> *mut T {
-    if ptr.is_null() {
-        handle_alloc_error(Layout::new::<T>())
-    }
-    ptr
-}
-#[inline(always)]
-unsafe fn as_try(mut f: impl FnMut(*mut as_error) -> as_status) -> Result<(), AerospikeError> {
-    let mut err = MaybeUninit::uninit();
-    if f(err.as_mut_ptr()) == as_status_e_AEROSPIKE_OK {
-        Ok(())
-    } else {
-        Err(AerospikeError::from(err.assume_init()))
-    }
-}
-
-impl Client {
-    pub fn new(hosts: &CStr) -> Result<Self, AerospikeError> {
-        let mut config = unsafe {
-            let mut config = MaybeUninit::uninit();
-            as_config_init(config.as_mut_ptr());
-            config.assume_init()
-        };
-        config.policies.batch.base.total_timeout = 10000;
-        unsafe {
-            // The hosts string will be copied, so pass it as `as_ptr` so the original
-            // gets deallocated at the end of this block
-            as_config_add_hosts(&mut config as *mut as_config, hosts.as_ptr(), 3000);
-        }
-        // Allocate a new client instance. Our `Drop` implementation will make
-        // sure it is destroyed
-        let this = unsafe {
-            let inner = aerospike_new(&mut config as *mut as_config);
-            if inner.is_null() {
-                handle_alloc_error(Layout::new::<aerospike>())
-            } else {
-                let this = Self {
-                    inner: NonNull::new_unchecked(inner),
-                };
-                this.connect()?;
-                this
-            }
-        };
-        Ok(this)
-    }
-
-    fn connect(&self) -> Result<(), AerospikeError> {
-        unsafe { as_try(|err| aerospike_connect(self.inner.as_ptr(), err)) }
-    }
-
-    unsafe fn put(
-        &self,
-        key: *const as_key,
-        record: *mut as_record,
-        policy: as_policy_write,
-    ) -> Result<(), AerospikeError> {
-        as_try(|err| {
-            aerospike_key_put(
-                self.inner.as_ptr(),
-                err,
-                &policy as *const as_policy_write,
-                key,
-                record,
-            )
-        })
-    }
-
-    unsafe fn insert(&self, key: *const as_key, new: *mut as_record) -> Result<(), AerospikeError> {
-        let mut policy = self.inner.as_ref().config.policies.write;
-        policy.exists = as_policy_exists_e_AS_POLICY_EXISTS_CREATE;
-        self.put(key, new, policy)
-    }
-
-    unsafe fn update(&self, key: *const as_key, new: *mut as_record) -> Result<(), AerospikeError> {
-        let mut policy = self.inner.as_ref().config.policies.write;
-        policy.exists = as_policy_exists_e_AS_POLICY_EXISTS_UPDATE;
-        self.put(key, new, policy)
-    }
-
-    unsafe fn delete(&self, key: *const as_key) -> Result<(), AerospikeError> {
-        let policy = self.inner.as_ref().config.policies.remove;
-        as_try(|err| {
-            aerospike_key_remove(
-                self.inner.as_ptr(),
-                err,
-                &policy as *const as_policy_remove,
-                key,
-            )
-        })
-    }
-
-    unsafe fn write_batch(&self, batch: *mut as_batch_records) -> Result<(), AerospikeError> {
-        let policy = self.inner.as_ref().config.policies.batch;
-        as_try(|err| {
-            aerospike_batch_write(
-                self.inner.as_ptr(),
-                err,
-                &policy as *const as_policy_batch,
-                batch,
-            )
-        })
-    }
-
-    unsafe fn select(
-        &self,
-        key: *const as_key,
-        bins: &[*const c_char],
-        record: &mut *mut as_record,
-    ) -> Result<(), AerospikeError> {
-        as_try(|err| {
-            aerospike_key_select(
-                self.inner.as_ptr(),
-                err,
-                null(),
-                key,
-                // This won't write to the mut ptr
-                bins.as_ptr() as *mut *const c_char,
-                record as *mut *mut as_record,
-            )
-        })
-    }
-
-    /// # Safety
-    ///
-    /// This function sends a raw info request to the aerospike server
-    pub unsafe fn info(
-        &self,
-        request: &CStr,
-        response: &mut *mut i8,
-    ) -> Result<(), AerospikeError> {
-        as_try(|err| {
-            aerospike_info_any(
-                self.inner.as_ptr(),
-                err,
-                null(),
-                request.as_ptr(),
-                response as *mut *mut i8,
-            )
-        })
-    }
-}
-
-impl Drop for Client {
-    fn drop(&mut self) {
-        unsafe {
-            aerospike_destroy(self.inner.as_ptr());
-        }
-    }
+    #[error("Changing the value of a primary key is not supported for Aerospike sink. Old: {old:?}, new: {new:?}")]
+    PrimaryKeyChanged { old: Vec<Field>, new: Vec<Field> },
+    #[error("Denormalization error: {0}")]
+    DenormError(#[from] denorm_dag::Error),
 }
 
 #[derive(Debug)]
@@ -299,24 +109,22 @@ impl SinkFactory for AerospikeSinkFactory {
     ) -> Result<Box<dyn dozer_core::node::Sink>, BoxedError> {
         let hosts = CString::new(self.connection_config.hosts.as_str())?;
         let client = Client::new(&hosts).map_err(AerospikeSinkError::from)?;
-        let n_threads = self
-            .config
-            .n_threads
-            .or_else(|| available_parallelism().ok())
-            .unwrap_or_else(|| {
-                warn!("Unable to automatically determine the correct amount of threads to use for Aerospike sink, so defaulting to 1.\nTo override, set `n_threads` in your Aerospike sink config");
-                NonZeroUsize::new(1).unwrap()
-            });
 
-        let mut tables = vec![];
-        for (port, table) in self.config.tables.iter().enumerate() {
-            let schema = input_schemas.remove(&(port as PortHandle)).unwrap();
-            let primary_index = match schema.primary_index.len() {
-                1 => schema.primary_index[0],
-                0 => return Err(AerospikeSinkError::NoPrimaryKey.into()),
-                _ => return Err(AerospikeSinkError::CompositePrimaryKey.into()),
+        let tables: Vec<_> = self
+            .config
+            .tables
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, table)| (table, input_schemas.remove(&(i as PortHandle)).unwrap()))
+            .collect();
+        // Validate schemas
+        for (_, schema) in tables.iter() {
+            if schema.primary_index.is_empty() {
+                return Err(AerospikeSinkError::NoPrimaryKey.into());
             };
-            match schema.fields[primary_index].typ {
+            for idx in schema.primary_index.iter() {
+                match schema.fields[*idx].typ  {
                 // These are definitely OK as the primary key
                 dozer_types::types::FieldType::UInt
                 | dozer_types::types::FieldType::U128
@@ -331,7 +139,7 @@ impl SinkFactory for AerospikeSinkFactory {
                 // them to make sure the user is aware
                 typ @ (dozer_types::types::FieldType::Decimal |
                 dozer_types::types::FieldType::Timestamp |
-                dozer_types::types::FieldType::Date) => warn!("Using a {typ} column as a primary key for Aerospike sink. This is only allowed because this type is converted to a String. Cast to another type explicitly to silence this warning."),
+                dozer_types::types::FieldType::Date) => warn!("Using a {typ} column as a primary key for Aerospike sink. This is only allowed because this type is converted to a String. Cast to a type supported by aerospike to silence this warning."),
 
                 // These are not OK as keys, so error out
                 typ @ (dozer_types::types::FieldType::Float|
@@ -341,66 +149,30 @@ impl SinkFactory for AerospikeSinkFactory {
                         return Err(Box::new(AerospikeSinkError::UnsupportedPrimaryKeyType(typ)));
                     }
             }
-            for field in &schema.fields {
-                if field.name.len() > AS_BIN_NAME_MAX_LEN as usize {
-                    return Err(AerospikeSinkError::BinNameTooLong(field.name.to_owned()).into());
+                for field in &schema.fields {
+                    if field.name.len() > AS_BIN_NAME_MAX_LEN as usize {
+                        return Err(
+                            AerospikeSinkError::BinNameTooLong(field.name.to_owned()).into()
+                        );
+                    }
                 }
             }
-            let bin_names = schema
-                .fields
-                .iter()
-                .map(|field| {
-                    if field.name.len() <= AS_BIN_NAME_MAX_LEN as usize {
-                        CString::new(field.name.clone()).map_err(AerospikeSinkError::NulError)
-                    } else {
-                        Err(AerospikeSinkError::BinNameTooLong(field.name.to_owned()))
-                    }
-                })
-                .collect::<Result<_, _>>()?;
-
-            let denormalizations = table
-                .denormalize
-                .iter()
-                .map(|denorm| {
-                    let columns: Vec<_> = denorm
-                        .columns
-                        .iter()
-                        .cloned()
-                        .map(|col| match col {
-                            DenormColumn::Direct(name) => (name.clone(), name),
-                            DenormColumn::Renamed {
-                                source,
-                                destination,
-                            } => (source, destination),
-                        })
-                        .collect();
-                    Denormalization::new(
-                        &denorm.from_namespace,
-                        &denorm.from_set,
-                        schema.get_field_index(&denorm.key)?.0,
-                        &columns,
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let n_denormalization_cols = denormalizations
-                .iter()
-                .map(|denorm| denorm.columns.len() as u16)
-                .sum();
-
-            tables.push(AerospikeTable {
-                namespace: CString::new(table.namespace.clone())?,
-                set_name: CString::new(table.set_name.clone())?,
-                primary_index,
-                bin_names,
-                denormalizations,
-                n_denormalization_cols,
-            });
         }
+        let denorm_state = DenormalizationState::new(&tables)?;
+
+        let metadata_namespace = CString::new(self.config.metadata_namespace.clone())?;
+        let metadata_set = CString::new(
+            self.config
+                .metadata_set
+                .to_owned()
+                .unwrap_or("__replication_metadata".to_owned()),
+        )?;
         Ok(Box::new(AerospikeSink::new(
             self.config.clone(),
             client,
-            tables,
-            n_threads.into(),
+            denorm_state,
+            metadata_namespace,
+            metadata_set,
         )))
     }
 
@@ -433,8 +205,8 @@ impl Drop for Key<'_> {
 struct AsRecord<'a>(&'a mut as_record);
 
 impl AsRecord<'_> {
-    fn as_mut_ptr(&mut self) -> *mut as_record {
-        self.0 as *mut as_record
+    fn as_ptr(&self) -> *const as_record {
+        &*self.0 as *const as_record
     }
 }
 
@@ -447,806 +219,181 @@ impl Drop for AsRecord<'_> {
 
 #[derive(Debug)]
 struct AerospikeSink {
-    sender: Sender<TableOperation>,
-    snapshotting_started_instant: HashMap<String, Instant>,
     config: AerospikeSinkConfig,
+    replication_worker: AerospikeSinkWorker,
+    current_transaction: Option<u64>,
+    metadata_namespace: CString,
+    metadata_set: CString,
+    client: Arc<Client>,
 }
+
+type TxnId = u64;
 
 #[derive(Debug)]
-struct Denormalization {
-    namespace: CString,
-    set: CString,
-    key_field: usize,
-    columns: Vec<(CString, CString)>,
-    source_column_ptrs: Vec<*const c_char>,
+struct MetadataWriter {
+    client: Arc<Client>,
+    key: NonNull<as_key>,
+    record: NonNull<as_record>,
 }
 
-// column ptrs
-unsafe impl Send for Denormalization {}
+// NonNull doesn't impl Send
+unsafe impl Send for MetadataWriter {}
 
-impl Denormalization {
-    fn new(
-        namespace: &str,
-        set: &str,
-        key_field: usize,
-        columns: &[(String, String)],
-    ) -> Result<Self, AerospikeSinkError> {
-        let namespace = CString::new(namespace)?;
-        let set = CString::new(set)?;
-
-        let columns = columns
-            .iter()
-            .map(|(src, dst)| Ok((CString::new(src.as_str())?, CString::new(dst.as_str())?)))
-            .collect::<Result<Vec<_>, NulError>>()?;
-        let mut source_column_ptrs: Vec<_> =
-            columns.iter().map(|(src, _dst)| src.as_ptr()).collect();
-        source_column_ptrs.push(null());
-        Ok(Self {
-            namespace,
-            set,
-            key_field,
-            columns,
-            source_column_ptrs,
-        })
-    }
-}
-
-impl Clone for Denormalization {
-    fn clone(&self) -> Self {
-        let columns = self.columns.clone();
-        let mut source_column_ptrs: Vec<_> =
-            columns.iter().map(|(src, _dst)| src.as_ptr()).collect();
-        source_column_ptrs.push(null());
-        Self {
-            namespace: self.namespace.clone(),
-            set: self.set.clone(),
-            key_field: self.key_field,
-            columns,
-            source_column_ptrs,
+impl MetadataWriter {
+    fn new(client: Arc<Client>, namespace: CString, set: CString) -> Self {
+        unsafe {
+            let key = NonNull::new(as_key_new(
+                namespace.as_ptr(),
+                set.as_ptr(),
+                constants::META_KEY.as_ptr(),
+            ))
+            .unwrap();
+            let record = NonNull::new(as_record_new(1)).unwrap();
+            Self {
+                client,
+                key,
+                record,
+            }
         }
     }
+
+    fn write(&mut self, txid: TxnId, bin: &CStr) -> Result<(), AerospikeSinkError> {
+        unsafe {
+            as_record_set_int64(self.record.as_ptr(), bin.as_ptr(), txid as i64);
+            self.client
+                .upsert(self.key.as_ptr(), self.record.as_ptr(), None)?;
+        }
+        Ok(())
+    }
+    fn write_base(&mut self, txid: TxnId) -> Result<(), AerospikeSinkError> {
+        self.write(txid, constants::META_BASE_TXN_ID_BIN)?;
+        Ok(())
+    }
+    fn write_lookup(&mut self, txid: TxnId) -> Result<(), AerospikeSinkError> {
+        self.write(txid, constants::META_LOOKUP_TXN_ID_BIN)?;
+        Ok(())
+    }
 }
 
-#[derive(Debug, Clone)]
-struct AerospikeTable {
-    namespace: CString,
-    set_name: CString,
-    primary_index: usize,
-    bin_names: Vec<CString>,
-    denormalizations: Vec<Denormalization>,
-    n_denormalization_cols: u16,
+impl Drop for MetadataWriter {
+    fn drop(&mut self) {
+        unsafe {
+            as_record_destroy(self.record.as_ptr());
+            as_key_destroy(self.key.as_ptr());
+        }
+    }
 }
 
 impl AerospikeSink {
     fn new(
         config: AerospikeSinkConfig,
         client: Client,
-        tables: Vec<AerospikeTable>,
-        n_threads: usize,
+        state: DenormalizationState,
+        metadata_namespace: CString,
+        metadata_set: CString,
     ) -> Self {
         let client = Arc::new(client);
-        let mut workers = Vec::with_capacity(n_threads);
-        let (sender, receiver) = bounded(n_threads);
-        for _ in 0..n_threads {
-            workers.push(AerospikeSinkWorker {
-                client: client.clone(),
-                receiver: receiver.clone(),
-                tables: tables.clone(),
-            });
-        }
-        for mut worker in workers {
-            std::thread::spawn(move || worker.run());
-        }
+
+        let metadata_writer = MetadataWriter::new(
+            client.clone(),
+            metadata_namespace.clone(),
+            metadata_set.clone(),
+        );
+
+        let worker_instance = AerospikeSinkWorker {
+            client: client.clone(),
+            state,
+            metadata_writer,
+        };
 
         Self {
             config,
-            sender,
-            snapshotting_started_instant: Default::default(),
+            replication_worker: worker_instance,
+            current_transaction: None,
+            metadata_namespace,
+            metadata_set,
+            client,
         }
     }
 }
 
-fn convert_json(value: &JsonValue) -> Result<*mut as_bin_value, AerospikeSinkError> {
-    unsafe {
-        Ok(match value.destructure_ref() {
-            DestructuredJsonRef::Null => addr_of!(as_nil) as *mut as_val as *mut as_bin_value,
-            DestructuredJsonRef::Bool(value) => {
-                check_alloc(as_boolean_new(value)) as *mut as_bin_value
-            }
-            DestructuredJsonRef::Number(value) => {
-                if let Some(float) = value.to_f64() {
-                    check_alloc(as_double_new(float)) as *mut as_bin_value
-                } else if let Some(integer) = value.to_i64() {
-                    check_alloc(as_integer_new(integer)) as *mut as_bin_value
-                } else {
-                    // If we can't represent as i64, we have a u64 that's larger than i64::MAX
-                    return Err(AerospikeSinkError::IntegerOutOfRange(
-                        value.to_u64().unwrap(),
-                    ));
-                }
-            }
-            DestructuredJsonRef::String(value) => {
-                let bytes = check_alloc(as_bytes_new(value.len() as u32));
-                as_bytes_set(bytes, 0, value.as_ptr(), value.len() as u32);
-                (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
-                bytes as *mut as_bin_value
-            }
-            DestructuredJsonRef::Array(value) => {
-                let list = check_alloc(as_arraylist_new(value.len() as u32, value.len() as u32));
-                for v in value.iter() {
-                    let as_value = convert_json(v)?;
-                    if as_arraylist_append(list, as_value as *mut as_val)
-                        != as_status_e_AEROSPIKE_OK
-                    {
-                        as_arraylist_destroy(list);
-                        return Err(AerospikeSinkError::CreateRecordError);
-                    }
-                }
-                list as *mut as_bin_value
-            }
-            DestructuredJsonRef::Object(value) => {
-                let map = check_alloc(as_orderedmap_new(value.len() as u32));
-                struct Map(*mut as_orderedmap);
-                impl Drop for Map {
-                    fn drop(&mut self) {
-                        unsafe {
-                            as_orderedmap_destroy(self.0);
-                        }
-                    }
-                }
-                // Make sure the map is deallocated if we encounter any error...
-                let _map_guard = Map(map);
-                for (k, v) in value.iter() {
-                    let as_value = convert_json(v)?;
-                    let key = {
-                        let bytes = check_alloc(as_bytes_new(k.len() as u32));
-                        debug_assert!(as_bytes_set(bytes, 0, k.as_ptr(), k.len() as u32));
-                        (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
-                        bytes as *mut as_val
-                    };
-                    if as_orderedmap_set(map, key, as_value as *mut as_val) != 0 {
-                        return Err(AerospikeSinkError::CreateRecordError);
-                    };
-                }
-                // ...but don't deallocate if we succeed
-                mem::forget(_map_guard);
-                map as *mut as_bin_value
-            }
-        })
-    }
-}
-
+#[derive(Debug)]
 struct AerospikeSinkWorker {
     client: Arc<Client>,
-    receiver: Receiver<TableOperation>,
-    tables: Vec<AerospikeTable>,
+    state: DenormalizationState,
+    metadata_writer: MetadataWriter,
 }
 
 impl AerospikeSinkWorker {
-    fn run(&mut self) {
-        while let Ok(op) = self.receiver.recv() {
-            if let Err(e) = self.process_impl(op) {
-                error!("Error processing operation: {}", e);
-            }
-        }
-    }
-
-    #[inline]
-    fn set_str_key(
-        &self,
-        key: *mut as_key,
-        namespace: &CStr,
-        set: &CStr,
-        mut string: String,
-        allocated_strings: &mut Vec<String>,
-    ) {
-        unsafe {
-            let bytes = as_bytes_new_wrap(string.as_mut_ptr(), string.len() as u32, false);
-            (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
-            allocated_strings.push(string);
-            as_key_init_value(
-                key,
-                namespace.as_ptr(),
-                set.as_ptr(),
-                bytes as *const _ as *const as_key_value,
-            );
-        }
-    }
-
-    unsafe fn init_key(
-        &self,
-        key: *mut as_key,
-        namespace: &CStr,
-        set: &CStr,
-        key_field: &Field,
-        allocated_strings: &mut Vec<String>,
-    ) -> Result<(), AerospikeSinkError> {
-        unsafe {
-            match key_field {
-                Field::UInt(v) => {
-                    as_key_init_int64(key, namespace.as_ptr(), set.as_ptr(), *v as i64);
-                }
-                Field::Int(v) => {
-                    as_key_init_int64(key, namespace.as_ptr(), set.as_ptr(), *v);
-                }
-                Field::U128(v) => {
-                    self.set_str_key(key, namespace, set, v.to_string(), allocated_strings)
-                }
-                Field::I128(v) => {
-                    self.set_str_key(key, namespace, set, v.to_string(), allocated_strings)
-                }
-                Field::Decimal(v) => {
-                    self.set_str_key(key, namespace, set, v.to_string(), allocated_strings)
-                }
-                // For keys, we need to allocate a new CString, because there is no
-                // API to set a key to a string that's not null-terminated. For bin
-                // values, we can. XXX: possible point for optimization
-                Field::Text(string) | Field::String(string) => {
-                    // Casting to mut is safe. The pointer only needs to be mut so it
-                    // can be deallocated if the `free` parameter is true
-                    let bytes =
-                        as_bytes_new_wrap(string.as_ptr() as *mut u8, string.len() as u32, false);
-                    (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
-                    as_key_init_value(
-                        key,
-                        namespace.as_ptr(),
-                        set.as_ptr(),
-                        bytes as *const _ as *const as_key_value,
-                    );
-                }
-                Field::Binary(v) => {
-                    as_key_init_rawp(
-                        key,
-                        namespace.as_ptr(),
-                        set.as_ptr(),
-                        v.as_ptr(),
-                        v.len() as u32,
-                        false,
-                    );
-                }
-
-                Field::Timestamp(v) => self.set_str_key(
-                    key,
-                    namespace,
-                    set,
-                    // Use a delayed formatting to RFC3339 so we don't have to allocate an
-                    // intermediate rust String
-                    v.to_rfc3339(),
-                    allocated_strings,
-                ),
-                // Date's display implementation is RFC3339 compatible
-                Field::Date(v) => {
-                    self.set_str_key(key, namespace, set, v.to_string(), allocated_strings)
-                }
-                // We can ignore the time unit, as we always output a
-                // full-resolution duration
-                Field::Duration(DozerDuration(duration, _)) => self.set_str_key(
-                    key,
-                    namespace,
-                    set,
-                    format!("PT{},{:09}S", duration.as_secs(), duration.subsec_nanos()),
-                    allocated_strings,
-                ),
-                Field::Null => unreachable!("Primary key cannot be null"),
-                Field::Boolean(_) | Field::Json(_) | Field::Point(_) | Field::Float(_) => {
-                    unreachable!("Unsupported primary key type. If this is reached, it means this record does not conform to the schema.")
-                }
-            };
-        }
+    fn process(&mut self, op: TableOperation) -> Result<(), AerospikeSinkError> {
+        self.state.process(op)?;
         Ok(())
     }
 
-    unsafe fn rec_set_str(
-        record: *mut as_record,
-        name: *const c_char,
-        string: String,
-        allocated_strings: &mut Vec<String>,
-    ) {
-        Self::rec_set_bytes(
-            record,
-            name,
-            string.as_bytes(),
-            as_bytes_type_e_AS_BYTES_STRING,
-        );
-        allocated_strings.push(string);
-    }
-
-    unsafe fn rec_set_bytes(
-        record: *mut as_record,
-        name: *const c_char,
-        bytes: &[u8],
-        type_: as_bytes_type,
-    ) {
-        let ptr = bytes.as_ptr();
-        let len = bytes.len();
-        as_record_set_raw_typep(record, name, ptr, len as u32, type_, false);
-    }
-
-    unsafe fn init_record(
-        &self,
-        record: *mut as_record,
-        dozer_record: &Record,
-        bin_names: &[CString],
-        n_extra_cols: u16,
-        allocated_strings: &mut Vec<String>,
-    ) -> Result<(), AerospikeSinkError> {
-        as_record_init(record, dozer_record.values.len() as u16 + n_extra_cols);
-        for (def, field) in bin_names.iter().zip(&dozer_record.values) {
-            let name = def.as_ptr();
-            match field {
-                Field::UInt(v) => {
-                    as_record_set_int64(record, name, *v as i64);
-                }
-                Field::U128(v) => {
-                    Self::rec_set_str(record, name, v.to_string(), allocated_strings);
-                }
-                Field::Int(v) => {
-                    as_record_set_int64(record, name, *v);
-                }
-                Field::I128(v) => {
-                    Self::rec_set_str(record, name, v.to_string(), allocated_strings);
-                }
-                Field::Float(OrderedFloat(v)) => {
-                    as_record_set_double(record, name, *v);
-                }
-                Field::Boolean(v) => {
-                    as_record_set_bool(record, name, *v);
-                }
-                Field::String(v) | Field::Text(v) => {
-                    as_record_set_raw_typep(
-                        record,
-                        name,
-                        v.as_ptr(),
-                        v.len() as u32,
-                        as_bytes_type_e_AS_BYTES_STRING,
-                        false,
-                    );
-                }
-                Field::Binary(v) => {
-                    as_record_set_rawp(record, name, v.as_ptr(), v.len() as u32, false);
-                }
-                Field::Decimal(v) => {
-                    Self::rec_set_str(record, name, v.to_string(), allocated_strings);
-                }
-                Field::Timestamp(v) => {
-                    Self::rec_set_str(record, name, v.to_rfc3339(), allocated_strings);
-                }
-                // Date's display implementation is RFC3339 compatible
-                Field::Date(v) => {
-                    Self::rec_set_str(record, name, v.to_string(), allocated_strings);
-                }
-                Field::Duration(DozerDuration(duration, _)) => {
-                    Self::rec_set_str(
-                        record,
-                        name,
-                        format!("PT{},{:09}S", duration.as_secs(), duration.subsec_nanos()),
-                        allocated_strings,
-                    );
-                }
-                Field::Null => {
-                    as_record_set_nil(record, name);
-                }
-                // XXX: Geojson points have to have coordinates <90. Dozer points can
-                // be arbitrary locations.
-                Field::Point(DozerPoint(Point(Coord { x, y }))) => {
-                    // Using our string-as-bytes trick does not work, as BYTES_GEOJSON is not
-                    // a plain string format. Instead, we just make sure we include a nul-byte
-                    // in our regular string, as that is easiest to integration with the other
-                    // string allocations.
-                    let string = format!(
-                        r#"{{"type": "Point", "coordinates": [{}, {}]}}{}"#,
-                        x.0, y.0, '\0'
-                    );
-                    as_record_set_geojson_strp(record, name, string.as_ptr().cast(), false);
-                    allocated_strings.push(string);
-                }
-                Field::Json(v) => {
-                    let value = convert_json(v)?;
-                    as_record_set(record, name, value);
-                }
+    fn commit(&mut self, txid: Option<u64>) -> Result<(), AerospikeSinkError> {
+        let denormalized_tables = self.state.perform_denorm(&self.client)?;
+        let batch_size_est: usize = denormalized_tables
+            .iter()
+            .map(|table| table.records.len())
+            .sum();
+        // Write denormed tables
+        let mut batch = RecordBatch::new(batch_size_est as u32, batch_size_est as u32);
+        for table in denormalized_tables {
+            for (key, record) in table.records {
+                batch.add_write(
+                    &table.namespace,
+                    &table.set,
+                    &table.bin_names,
+                    &key,
+                    &record,
+                )?;
             }
+        }
+
+        unsafe { self.client.write_batch(batch.as_mut_ptr())? };
+
+        // Write denormed txid
+        if let Some(txid) = txid {
+            self.metadata_writer.write_base(txid)?;
+        }
+
+        self.state.persist(&self.client)?;
+
+        if let Some(txid) = txid {
+            self.metadata_writer.write_lookup(txid)?;
         }
         Ok(())
     }
-
-    unsafe fn set_operation_str(
-        ops: *mut as_operations,
-        name: *const c_char,
-        mut string: String,
-        allocated_strings: &mut Vec<String>,
-    ) {
-        let ptr = string.as_mut_ptr();
-        let len = string.len();
-        allocated_strings.push(string);
-        // Unfortunately we need to do an allocation here for the bytes container.
-        // This is because as_operations does not allow setting a bytes type in
-        // its operations api. TODO: Add a raw_typep api like `as_record_set_raw_typep`
-        // for as_operations
-        let bytes = as_bytes_new_wrap(ptr, len as u32, false);
-        (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
-        as_operations_add_write(ops, name, bytes as *mut as_bin_value);
-    }
-
-    unsafe fn init_ops(
-        &self,
-        ops: *mut as_operations,
-        dozer_record: &Record,
-        bin_names: &[CString],
-        allocated_strings: &mut Vec<String>,
-    ) -> Result<(), AerospikeSinkError> {
-        for (def, field) in bin_names.iter().zip(&dozer_record.values) {
-            let name = def.as_ptr();
-            // This is almost the same as the implementation for keys,
-            // the key difference being that we don't have to allocate a new
-            // string, because we can use `as_record_set_raw_typep` to set
-            // rust strings directly without intermediate allocations
-            // TODO: Unify the implementations
-            match field {
-                Field::UInt(v) => {
-                    as_operations_add_write_int64(ops, name, *v as i64);
-                }
-                Field::U128(v) => {
-                    Self::set_operation_str(ops, name, v.to_string(), allocated_strings);
-                }
-                Field::Int(v) => {
-                    as_operations_add_write_int64(ops, name, *v);
-                }
-                Field::I128(v) => {
-                    Self::set_operation_str(ops, name, v.to_string(), allocated_strings);
-                }
-                Field::Float(v) => {
-                    as_operations_add_write_double(ops, name, v.0);
-                }
-                Field::Boolean(v) => {
-                    as_operations_add_write_bool(ops, name, *v);
-                }
-                Field::String(string) | Field::Text(string) => {
-                    let ptr = string.as_ptr();
-                    let len = string.len();
-                    // Casting to *mut is safe because aerospike won't write
-                    // to it if `free` is false
-                    let bytes = as_bytes_new_wrap(ptr as *mut u8, len as u32, false);
-                    (*bytes).type_ = as_bytes_type_e_AS_BYTES_STRING;
-                    as_operations_add_write(ops, name, bytes as *mut as_bin_value);
-                }
-                Field::Binary(v) => {
-                    as_operations_add_write_rawp(ops, name, v.as_ptr(), v.len() as u32, false);
-                }
-                Field::Decimal(v) => {
-                    Self::set_operation_str(ops, name, v.to_string(), allocated_strings);
-                }
-                Field::Timestamp(v) => {
-                    Self::set_operation_str(ops, name, v.to_rfc3339(), allocated_strings);
-                }
-                // Date's display implementation is RFC3339 compatible
-                Field::Date(v) => {
-                    Self::set_operation_str(ops, name, v.to_string(), allocated_strings);
-                }
-                Field::Duration(DozerDuration(duration, _)) => {
-                    Self::set_operation_str(
-                        ops,
-                        name,
-                        format!("PT{},{:09}S", duration.as_secs(), duration.subsec_nanos()),
-                        allocated_strings,
-                    );
-                }
-                Field::Null => {
-                    // as_bin_value is a union, with nil being an as_val. It is therefore
-                    // valid to just cast a pointer to the as_nil constant (of type as_val),
-                    // as its location is static
-                    as_operations_add_write(ops, name, addr_of!(as_nil) as *mut as_bin_value);
-                }
-                Field::Point(DozerPoint(Point(Coord { x, y }))) => {
-                    // Using our string-as-bytes trick does not work, as BYTES_GEOJSON is not
-                    // a plain string format. Instead, we just make sure we include a nul-byte
-                    // in our regular string, as that is easiest to integration with the other
-                    // string allocations being `String` and not `CString`. We know we won't
-                    // have any intermediate nul-bytes, as we control the string
-                    let string = format!(
-                        r#"{{"type": "Point", "coordinates": [{}, {}]}}{}"#,
-                        x.0, y.0, '\0'
-                    );
-                    as_operations_add_write_geojson_strp(ops, name, string.as_ptr().cast(), false);
-                    allocated_strings.push(string);
-                }
-                Field::Json(v) => {
-                    as_operations_add_write(ops, name, convert_json(v)?);
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn process_impl(&mut self, op: TableOperation) -> Result<(), AerospikeSinkError> {
-        let table = &self.tables[op.port as usize];
-
-        if !table.denormalizations.is_empty() {
-            if let Operation::BatchInsert { new } = op.op {
-                for rec in new.into_iter() {
-                    self.process_impl(TableOperation {
-                        op: Operation::Insert { new: rec },
-                        id: op.id,
-                        port: op.port,
-                    })?;
-                }
-                return Ok(());
-            }
-        }
-        // XXX: We know from the schema how many strings we have to allocate,
-        // so we could optimize this to allocate the correct amount ahead
-        // of time. Furthermore, we also know (an upper bound of) the total size of the strings we
-        // have to allocate, so we could just allocate one large Vec<u8>, and
-        // use that for all string allocations, like an arena
-        let mut allocated_strings = Vec::new();
-        match op.op {
-            Operation::Insert { new } => {
-                // We create the key and record on the stack, because we can
-                // and it saves an allocation. These structs are self-referential
-                // on the C side (for value-types), so make sure not to move them.
-                // This prevents us from creating a wrapper type responsible for cleaning
-                // up, as that would move. We could probably make some kind of smart wrapper
-                // using PhantomPinned and `pin!()`
-                let mut key = MaybeUninit::uninit();
-                let mut _record = MaybeUninit::uninit();
-
-                unsafe {
-                    self.init_key(
-                        key.as_mut_ptr(),
-                        &table.namespace,
-                        &table.set_name,
-                        &new.values[table.primary_index],
-                        &mut allocated_strings,
-                    )?;
-                    let k = Key(key.assume_init_mut());
-                    self.init_record(
-                        _record.as_mut_ptr(),
-                        &new,
-                        &table.bin_names,
-                        table.n_denormalization_cols,
-                        &mut allocated_strings,
-                    )?;
-                    let mut record = AsRecord(_record.assume_init_mut());
-                    for Denormalization {
-                        key_field,
-                        source_column_ptrs,
-                        namespace,
-                        set,
-                        columns,
-                    } in &table.denormalizations
-                    {
-                        let mut _key = MaybeUninit::uninit();
-                        self.init_key(
-                            _key.as_mut_ptr(),
-                            namespace,
-                            set,
-                            &new.values[*key_field],
-                            &mut allocated_strings,
-                        )?;
-                        let key = Key(_key.assume_init_mut());
-                        let mut _rec = MaybeUninit::uninit();
-                        as_record_init(_rec.as_mut_ptr(), columns.len() as u16);
-                        let mut denorm_rec = AsRecord(_rec.assume_init_mut());
-                        loop {
-                            #[allow(non_upper_case_globals)]
-                            match self.client.select(
-                                key.as_ptr(),
-                                source_column_ptrs,
-                                &mut denorm_rec.as_mut_ptr(),
-                            ) {
-                                Ok(()) => break,
-                                // If the record is not found, wait and try again,
-                                // we are probably behind the task responsible for writing it
-                                Err(AerospikeError {
-                                    code: as_status_e_AEROSPIKE_ERR_RECORD_NOT_FOUND,
-                                    message: _,
-                                }) => std::thread::sleep(Duration::from_millis(100)),
-                                Err(e) => return Err(e.into()),
-                            }
-                        }
-                        // The column_ptrs array needs to end with a null ptr, so use
-                        // `columns` for the bound instead
-                        for (src, dst) in columns {
-                            let val = as_record_get(denorm_rec.as_mut_ptr(), src.as_ptr());
-
-                            // Increment ref count, so we can destroy the denorm record
-                            // without dropping the bin values
-                            as_val_val_reserve(val as *mut as_val);
-                            as_record_set(record.as_mut_ptr(), dst.as_ptr(), val);
-                        }
-                        as_record_destroy(denorm_rec.as_mut_ptr());
-                    }
-                    self.client.insert(k.as_ptr(), record.as_mut_ptr())?;
-                }
-            }
-            Operation::Delete { old } => {
-                let mut key = MaybeUninit::uninit();
-                unsafe {
-                    self.init_key(
-                        key.as_mut_ptr(),
-                        &table.namespace,
-                        &table.set_name,
-                        &old.values[table.primary_index],
-                        &mut allocated_strings,
-                    )?;
-                    let k = Key(key.assume_init_mut());
-                    self.client.delete(k.as_ptr())?;
-                }
-            }
-            Operation::Update { old, new } => {
-                let mut key = MaybeUninit::uninit();
-                let mut record = MaybeUninit::uninit();
-                unsafe {
-                    self.init_key(
-                        key.as_mut_ptr(),
-                        &table.namespace,
-                        &table.set_name,
-                        &old.values[table.primary_index],
-                        &mut allocated_strings,
-                    )?;
-                    let k = Key(key.assume_init_mut());
-                    self.init_record(
-                        record.as_mut_ptr(),
-                        &new,
-                        &table.bin_names,
-                        0,
-                        &mut allocated_strings,
-                    )?;
-                    let mut r = AsRecord(record.assume_init_mut());
-                    self.client.update(k.as_ptr(), r.as_mut_ptr())?;
-                }
-            }
-            Operation::BatchInsert { new } => {
-                // Create an as_batch_write_record for each key
-                // Create an as_operations for each bin and assign them to the
-                // as_batch_write_record
-                let mut batch = unsafe {
-                    let mut batch = MaybeUninit::uninit();
-                    as_batch_records_init(batch.as_mut_ptr(), new.len() as u32);
-                    Batch(batch.assume_init())
-                };
-                // Wrapper type here, so `as_operations_destroy` is called, even
-                // when an error occurs
-                let mut operations = Operations::new(new.len());
-                for dozer_record in new.iter() {
-                    unsafe {
-                        let record = as_batch_write_reserve(batch.as_ptr());
-                        let ops = operations.next(dozer_record.values.len());
-                        if ops.is_null() {
-                            return Err(AerospikeSinkError::CreateRecordError);
-                        }
-                        self.init_ops(ops, dozer_record, &table.bin_names, &mut allocated_strings)?;
-                        (*record).ops = ops;
-                        self.init_key(
-                            &mut (*record).key as *mut as_key,
-                            &table.namespace,
-                            &table.set_name,
-                            &dozer_record.values[table.primary_index],
-                            &mut allocated_strings,
-                        )?;
-                    }
-                }
-                unsafe {
-                    self.client.write_batch(batch.as_ptr())?;
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-struct Operations(Vec<MaybeUninit<as_operations>>);
-impl Operations {
-    fn new(size: usize) -> Self {
-        Self(Vec::with_capacity(size))
-    }
-
-    /// SAFETY:
-    /// May only be called at most `size` times. If called more often, the previously
-    /// returned pointers are invalidated
-    unsafe fn next(&mut self, n_bins: usize) -> *mut as_operations {
-        debug_assert!(self.0.len() < self.0.capacity()); // Check that we don't reallocate
-        self.0.push(MaybeUninit::uninit());
-        let ptr = self.0.last_mut().unwrap().as_mut_ptr();
-        let init = unsafe { as_operations_init(ptr, n_bins.try_into().unwrap()) };
-        if init.is_null() {
-            self.0.pop();
-        }
-        init
-    }
-}
-
-impl Drop for Operations {
-    fn drop(&mut self) {
-        unsafe {
-            for ops in self.0.iter_mut() {
-                as_operations_destroy(ops.as_mut_ptr());
-            }
-        }
-    }
-}
-
-#[repr(transparent)]
-struct Batch(as_batch_records);
-impl Batch {
-    fn as_ptr(&mut self) -> *mut as_batch_records {
-        &mut self.0 as *mut _
-    }
-}
-
-impl Drop for Batch {
-    fn drop(&mut self) {
-        unsafe {
-            as_batch_records_destroy(&mut self.0 as *mut as_batch_records);
-        }
-    }
-}
-
-#[inline(always)]
-unsafe fn as_vector_reserve(vector: *mut as_vector) -> *mut c_void {
-    if (*vector).size >= (*vector).capacity {
-        as_vector_increase_capacity(vector);
-    }
-    let item = (*vector)
-        .list
-        .byte_add((*vector).size as usize * (*vector).item_size as usize);
-    (item as *mut u8).write_bytes(0, (*vector).item_size as usize);
-    (*vector).size += 1;
-    item
-}
-
-#[inline(always)]
-unsafe fn as_batch_write_reserve(records: *mut as_batch_records) -> *mut as_batch_write_record {
-    let r = as_vector_reserve(&mut (*records).list as *mut as_vector) as *mut as_batch_write_record;
-    (*r).type_ = AS_BATCH_WRITE as u8;
-    (*r).has_write = true;
-    r
-}
-
-#[inline(always)]
-unsafe fn as_batch_records_init(records: *mut as_batch_records, capacity: u32) {
-    as_vector_init(
-        &mut (*records).list as *mut as_vector,
-        mem::size_of::<as_batch_record>() as u32,
-        capacity,
-    );
 }
 
 impl Sink for AerospikeSink {
     fn commit(&mut self, _epoch_details: &dozer_core::epoch::Epoch) -> Result<(), BoxedError> {
+        self.replication_worker
+            .commit(self.current_transaction.take())?;
         Ok(())
     }
 
     fn process(&mut self, op: TableOperation) -> Result<(), BoxedError> {
-        self.sender.send(op)?;
+        // Set current transaction before any error can be thrown, so we don't
+        // get stuck in an error loop if this error gets ignored by the caller
+        self.current_transaction = op.id.map(|id| id.txid);
+
+        self.replication_worker.process(op)?;
         Ok(())
     }
 
     fn on_source_snapshotting_started(
         &mut self,
-        connection_name: String,
+        _connection_name: String,
     ) -> Result<(), BoxedError> {
-        self.snapshotting_started_instant
-            .insert(connection_name, Instant::now());
         Ok(())
     }
 
     fn on_source_snapshotting_done(
         &mut self,
-        connection_name: String,
+        _connection_name: String,
         _id: Option<OpIdentifier>,
     ) -> Result<(), BoxedError> {
-        if let Some(started_instant) = self.snapshotting_started_instant.remove(&connection_name) {
-            info!(
-                "Snapshotting for connection {} took {:?}",
-                connection_name,
-                started_instant.elapsed()
-            );
-        } else {
-            warn!(
-                "Snapshotting for connection {} took unknown time",
-                connection_name
-            );
-        }
         Ok(())
     }
 
@@ -1259,7 +406,41 @@ impl Sink for AerospikeSink {
     }
 
     fn get_latest_op_id(&mut self) -> Result<Option<OpIdentifier>, BoxedError> {
-        Ok(None)
+        let mut _k = MaybeUninit::uninit();
+        let mut _r = std::ptr::null_mut();
+        unsafe {
+            as_key_init_strp(
+                _k.as_mut_ptr(),
+                self.metadata_namespace.as_ptr(),
+                self.metadata_set.as_ptr(),
+                constants::META_KEY.as_ptr(),
+                false,
+            );
+            let key = Key(_k.assume_init_mut());
+            #[allow(non_upper_case_globals)]
+            match self.client.get(key.as_ptr(), &mut _r) {
+                Ok(_) => {}
+                Err(AerospikeError {
+                    code: as_status_e_AEROSPIKE_ERR_RECORD_NOT_FOUND,
+                    message: _,
+                }) => return Ok(None),
+                Err(e) => return Err(e.into()),
+            }
+            let record = AsRecord(_r.as_mut().unwrap());
+            let txid = as_record_get_int64(
+                record.as_ptr(),
+                constants::META_LOOKUP_TXN_ID_BIN.as_ptr(),
+                -1,
+            );
+            if txid > 0 {
+                Ok(Some(OpIdentifier {
+                    txid: txid as u64,
+                    seq_in_tx: 0,
+                }))
+            } else {
+                Ok(None)
+            }
+        }
     }
 
     fn max_batch_duration_ms(&self) -> Option<u64> {
@@ -1279,10 +460,11 @@ mod tests {
 
     use dozer_types::{
         chrono::{DateTime, NaiveDate},
+        geo::Point,
         models::sink::AerospikeSinkTable,
         ordered_float::OrderedFloat,
         rust_decimal::Decimal,
-        types::FieldDefinition,
+        types::{DozerDuration, DozerPoint, FieldDefinition, Operation, Record},
     };
 
     use super::*;
@@ -1379,9 +561,12 @@ mod tests {
                     namespace: "test".into(),
                     set_name: set.to_owned(),
                     denormalize: vec![],
+                    write_denormalized_to: None,
                 }],
                 max_batch_duration_ms: None,
                 preferred_batch_size: None,
+                metadata_namespace: "test".into(),
+                metadata_set: None,
             },
         );
         factory

--- a/dozer-types/src/models/sink.rs
+++ b/dozer-types/src/models/sink.rs
@@ -167,6 +167,8 @@ pub struct AerospikeSinkTable {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub denormalize: Vec<AerospikeDenormalizations>,
     pub write_denormalized_to: Option<AerospikeSet>,
+    #[serde(default)]
+    pub primary_key: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]

--- a/dozer-types/src/models/sink.rs
+++ b/dozer-types/src/models/sink.rs
@@ -124,13 +124,38 @@ pub enum DenormColumn {
     Renamed { source: String, destination: String },
 }
 
+impl DenormColumn {
+    pub fn to_src_dst(&self) -> (&str, &str) {
+        match self {
+            DenormColumn::Direct(name) => (name, name),
+            DenormColumn::Renamed {
+                source,
+                destination,
+            } => (source, destination),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum DenormKey {
+    Simple(String),
+    Composite(Vec<String>),
+}
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct AerospikeDenormalizations {
     pub from_namespace: String,
     pub from_set: String,
-    pub key: String,
+    pub key: DenormKey,
     pub columns: Vec<DenormColumn>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq)]
+pub struct AerospikeSet {
+    pub namespace: String,
+    pub set: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq)]
@@ -141,6 +166,7 @@ pub struct AerospikeSinkTable {
     pub set_name: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub denormalize: Vec<AerospikeDenormalizations>,
+    pub write_denormalized_to: Option<AerospikeSet>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]
@@ -152,6 +178,9 @@ pub struct AerospikeSinkConfig {
     pub tables: Vec<AerospikeSinkTable>,
     pub max_batch_duration_ms: Option<u64>,
     pub preferred_batch_size: Option<u64>,
+    pub metadata_namespace: String,
+    #[serde(default)]
+    pub metadata_set: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]

--- a/dozer-types/src/types/field.rs
+++ b/dozer-types/src/types/field.rs
@@ -819,7 +819,7 @@ impl Display for Field {
                 let (x, y) = p.0.x_y();
                 write!(f, "POINT({}, {})", x.0, y.0)
             }
-            Field::Duration(d) => write!(f, "{:?}", d.0),
+            Field::Duration(d) => write!(f, "PT{},{:09}S", d.0.as_secs(), d.0.subsec_nanos()),
             Field::Null => write!(f, ""),
         }
     }

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -180,15 +180,31 @@
           "type": "string"
         },
         "key": {
-          "type": "string"
+          "$ref": "#/definitions/DenormKey"
         }
       },
       "additionalProperties": false
     },
+    "AerospikeSet": {
+      "type": "object",
+      "required": [
+        "namespace",
+        "set"
+      ],
+      "properties": {
+        "namespace": {
+          "type": "string"
+        },
+        "set": {
+          "type": "string"
+        }
+      }
+    },
     "AerospikeSinkConfig": {
       "type": "object",
       "required": [
-        "connection"
+        "connection",
+        "metadata_namespace"
       ],
       "properties": {
         "connection": {
@@ -201,6 +217,16 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        },
+        "metadata_namespace": {
+          "type": "string"
+        },
+        "metadata_set": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "n_threads": {
           "type": [
@@ -249,6 +275,16 @@
         },
         "source_table_name": {
           "type": "string"
+        },
+        "write_denormalized_to": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AerospikeSet"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -828,6 +864,19 @@
             "source": {
               "type": "string"
             }
+          }
+        }
+      ]
+    },
+    "DenormKey": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       ]

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -270,6 +270,13 @@
         "namespace": {
           "type": "string"
         },
+        "primary_key": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "set_name": {
           "type": "string"
         },


### PR DESCRIPTION
This is based on the aerospike resumability branch.

I added a configuration to the aerospike sink table config, which specifies
where to write the denormalized version of that table to, called `write_denormalized_to`.
All tables will also be written in their raw form.

Resumability is implemented using a two-phase approach:
First, write the denormalized tables, then write a txid for the denorm tables
Second, write the lookup tables, then write a txid for the lookup tables

If we go down between writing the denorm txid and the lookup txid, we skip denorm until we reach the lookup txid. 
