### PR TITLE
fix: Use user provided type in Oracle source

### DIFF
--- a/dozer-ingestion/oracle/src/connector/listing.rs
+++ b/dozer-ingestion/oracle/src/connector/listing.rs
@@ -15,14 +15,18 @@ pub struct TableColumn {
 }
 
 impl TableColumn {
-    pub fn list(connection: &Connection, schemas: &[String]) -> Result<Vec<TableColumn>, Error> {
+    pub fn list(
+        connection: &Connection,
+        string_collection_type_name: &str,
+        schemas: &[String],
+    ) -> Result<Vec<TableColumn>, Error> {
         assert!(!schemas.is_empty());
         let sql = "
         SELECT OWNER, TABLE_NAME, COLUMN_NAME, DATA_TYPE, NULLABLE, DATA_PRECISION, DATA_SCALE
         FROM ALL_TAB_COLUMNS
         WHERE OWNER IN (SELECT COLUMN_VALUE FROM TABLE(:2))
         ";
-        let schemas = super::string_collection(connection, schemas)?;
+        let schemas = super::string_collection(connection, string_collection_type_name, schemas)?;
         debug!("{}, {}", sql, schemas);
         let rows = connection.query_as::<(
             String,
@@ -63,6 +67,7 @@ pub struct ConstraintColumn {
 impl ConstraintColumn {
     pub fn list(
         connection: &Connection,
+        string_collection_type_name: &str,
         schemas: &[String],
     ) -> Result<Vec<ConstraintColumn>, Error> {
         assert!(!schemas.is_empty());
@@ -75,7 +80,7 @@ impl ConstraintColumn {
         FROM ALL_CONS_COLUMNS
         WHERE OWNER IN (SELECT COLUMN_VALUE FROM TABLE(:2))
         ";
-        let schemas = super::string_collection(connection, schemas)?;
+        let schemas = super::string_collection(connection, string_collection_type_name, schemas)?;
         debug!("{}, {}", sql, schemas);
         let rows =
             connection.query_as::<(String, String, String, Option<String>)>(sql, &[&schemas])?;
@@ -102,7 +107,11 @@ pub struct Constraint {
 }
 
 impl Constraint {
-    pub fn list(connection: &Connection, schemas: &[String]) -> Result<Vec<Constraint>, Error> {
+    pub fn list(
+        connection: &Connection,
+        string_collection_type_name: &str,
+        schemas: &[String],
+    ) -> Result<Vec<Constraint>, Error> {
         assert!(!schemas.is_empty());
         let sql = "
         SELECT
@@ -114,7 +123,7 @@ impl Constraint {
             AND
             CONSTRAINT_TYPE = 'P'
         ";
-        let schemas = super::string_collection(connection, schemas)?;
+        let schemas = super::string_collection(connection, string_collection_type_name, schemas)?;
         debug!("{}, {}", sql, schemas);
         let rows = connection.query_as::<(Option<String>, Option<String>)>(sql, &[&schemas])?;
 

--- a/dozer-ingestion/oracle/src/lib.rs
+++ b/dozer-ingestion/oracle/src/lib.rs
@@ -53,6 +53,7 @@ impl OracleConnector {
                         config.user.clone(),
                         &config.password,
                         &root_connect_string,
+                        config.string_collection_type_name.clone(),
                         batch_size,
                         config.replicator,
                     )?;
@@ -61,9 +62,10 @@ impl OracleConnector {
                         let pdb_connect_string = format!("{}:{}/{}", config.host, config.port, pdb);
                         let pdb_connector = connector::Connector::new(
                             connection_name,
-                            config.user.clone(),
+                            config.user,
                             &config.password,
                             &pdb_connect_string,
+                            config.string_collection_type_name,
                             batch_size,
                             config.replicator,
                         )?;

--- a/dozer-sink-oracle/src/lib.rs
+++ b/dozer-sink-oracle/src/lib.rs
@@ -920,6 +920,7 @@ mod tests {
                 sid: "ORCLCDB".into(),
                 pdb: Some("ORCLPDB1".into()),
                 schemas: vec![],
+                string_collection_type_name: "DOZER_VAARY_OF_VARCHAR2".to_string(),
                 batch_size: None,
                 replicator: dozer_types::models::ingestion_types::OracleReplicator::LogMiner {
                     poll_interval_in_milliseconds: 0,

--- a/dozer-types/src/models/ingestion_types.rs
+++ b/dozer-types/src/models/ingestion_types.rs
@@ -656,6 +656,8 @@ pub struct OracleConfig {
     /// The schemas to consider when listing tables. If empty, will list all schemas, which can be slow.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub schemas: Vec<String>,
+    /// A `VARRAY OF VARCHAR2` type that can be used by dozer.
+    pub string_collection_type_name: String,
     /// Batch size during snapshotting
     pub batch_size: Option<usize>,
     pub replicator: OracleReplicator,

--- a/json_schemas/dozer.json
+++ b/json_schemas/dozer.json
@@ -1379,6 +1379,7 @@
         "port",
         "replicator",
         "sid",
+        "string_collection_type_name",
         "user"
       ],
       "properties": {
@@ -1420,6 +1421,10 @@
           }
         },
         "sid": {
+          "type": "string"
+        },
+        "string_collection_type_name": {
+          "description": "A `VARRAY OF VARCHAR2` type that can be used by dozer.",
           "type": "string"
         },
         "user": {


### PR DESCRIPTION
We don't want to require `CREATE TYPE` permission.

To make this work, we need to first create a type. Say the type name is `DOZER_VARRAY_OF_VARCHAR2 `.

```sql
CREATE TYPE DOZER_VARRAY_OF_VARCHAR2 AS VARRAY(20) OF VARCHAR2(100);
```

Then grant permission on that type to the replicate user. Say the replicate user is `DOZER`:

```sql
GRANT EXECUTE ON DOZER_VARRAY_OF_VARCHAR2 TO DOZER;
```

Then in the configuration, add a new field `string_collection_type_name`, whose value should be the FULL NAME of the type. Say the user that owns the type is `SYS`.

```yaml
string_collection_type_name: SYS.DOZER_VARRAY_OF_VARCHAR2
```