### PR TITLE
fix: Don't filter oracle V$LOG by rba

### DIFF
--- a/dozer-ingestion/oracle/src/connector/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/mod.rs
@@ -506,10 +506,10 @@ mod tests {
 
         env_logger::init();
 
-        let replicate_user = "DOZER";
-        let data_user = "DOZER";
-        let host = "database-1.cxtwfj9nkwtu.ap-southeast-1.rds.amazonaws.com";
-        let sid = "ORCL";
+        let replicate_user = "C##DOZER";
+        let data_user = "CHUBEI";
+        let host = "localhost";
+        let sid = "ORCLPDB1";
 
         let mut connector = super::Connector::new(
             "oracle".into(),
@@ -535,6 +535,7 @@ mod tests {
         estimate_throughput(iterator);
         let checkpoint = handle.join().unwrap().unwrap();
 
+        let sid = "ORCLCDB";
         let mut connector = super::Connector::new(
             "oracle".into(),
             replicate_user.into(),

--- a/dozer-ingestion/oracle/src/connector/replicate/log/redo/mod.rs
+++ b/dozer-ingestion/oracle/src/connector/replicate/log/redo/mod.rs
@@ -1,6 +1,6 @@
 use oracle::Connection;
 
-use crate::connector::Error;
+use crate::connector::{Error, Scn};
 
 /// Given a log file name, a redo reader emits `LogManagerContent` rows
 pub trait RedoReader {
@@ -8,13 +8,12 @@ pub trait RedoReader {
 
     /// Reads the `LogManagerContent` rows that have:
     ///
-    /// - scn >= start_scn
-    /// - rba > last_rba.0 || (rba == last_rba.0 && rbabyte > last_rba.1)
+    /// - scn > last_scn
     fn read<'a>(
         &self,
         connection: &'a Connection,
         log_file_name: &str,
-        last_rba: Option<(u32, u16)>,
+        last_scn: Option<Scn>,
         con_id: Option<u32>,
     ) -> Result<Self::Iterator<'a>, Error>;
 }


### PR DESCRIPTION
This PR removes the filter on RBA columns, and optionally loads OPERATION_CODE filter from an env var called `DOZER_ORACLE_LOG_MINER_OPERATION_CODE_FILTER`.

Usage is like:

```bash
DOZER_ORACLE_LOG_MINER_OPERATION_CODE_FILTER='OPERATION_CODE in (1, 7)' cargo run
```